### PR TITLE
Update asset for .deb generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/git-interactive-tool", "usr/bin/interactive-rebase-tool", "755"],
+    ["target/release/git-interactive-rebase-tool", "usr/bin/interactive-rebase-tool", "755"],
     ["README.md", "usr/share/doc/cargo-deb/README", "644"],
 ]


### PR DESCRIPTION
Pretty self-explanatory. As discussed yesterday evening, the asset file path in Cargo.toml that `cargo deb` uses is incorrect - it was missing `rebase` in the name. This causes the deb generation to fail.