### PR TITLE
Use version number from Cargo.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,14 @@ use application::Application;
 use git_interactive::GitInteractive;
 use window::Window;
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 fn main() {
 	let filepath = match env::args().nth(1) {
 		Some(arg) => {
 			match arg.as_ref() {
 				"--version" | "-v" => {
-					println!("v0.5.0");
+					println!("v{}", VERSION);
 					process::exit(0);
 				},
 				_ => arg


### PR DESCRIPTION
The hard coded version number was easy to forget to update, so use the value from the Cargo.toml file.