### PR TITLE
Add support for core.commentChar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,12 +127,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "git-interactive-rebase-tool"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.191 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git2"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -145,6 +182,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -183,6 +259,22 @@ dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -427,6 +519,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,19 +571,27 @@ dependencies = [
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum clippy 0.0.191 (registry+https://github.com/rust-lang/crates.io-index)" = "9e9e82aa6f8e55fc7110bda2c333c671c31b36da976237ecbde9958dea89e08b"
 "checksum clippy_lints 0.0.191 (registry+https://github.com/rust-lang/crates.io-index)" = "7fd834b607d54d7eb70df08115d6c434a775fe5a12f3cc59d2ac331f09f04c15"
+"checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
+"checksum curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71c63a540a9ee4e15e56c3ed9b11a2f121239b9f6d7b7fe30f616e048148df9a"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
+"checksum git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "910a2df52d2354e4eb27aa12f3803ea86bf461a93e17028908ec0e356572aa7b"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libgit2-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7adce4cc6db027611f537837a7c404319b6314dae49c5db80ad5332229894751"
+"checksum libssh2-sys 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5afcb36f9a2012ab8d3a9ba5186ee2d1c4587acf199cb47879a73c5fe1b731a4"
+"checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum ncurses 5.91.0 (registry+https://github.com/rust-lang/crates.io-index)" = "431cc11a5225e21cb85ea479858ac2e0b3c7a67c9506016cd8818de15dcdc8f1"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
 "checksum pad 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9b8de33465981073e32e1d75bb89ade49062bb853e7c97ec2c13439095563a"
 "checksum pancurses 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e8b44c647ccce6cf8afb048389565ccb7c9a1532d77e085a81fafacddace922"
 "checksum pdcurses-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90e12bfe55b7080fdfa0742f7a22ce7d5d1da250ca064ae6b81c843a2084fa2a"
@@ -519,6 +624,7 @@ dependencies = [
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-interactive-rebase-tool"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Tim Oram <me@mitmaro.ca>"]
 license = "ISC"
 description = "Full feature terminal based sequence editor for git interactive rebase. Written in Rust using ncurses."
@@ -24,6 +24,7 @@ clippy = {version = "0.0.191", optional = true}
 pancurses = "0.15.0"
 pad = "0.1.5"
 clap = "2.31.2"
+git2 = "0.7.2"
 
 [features]
 default = []

--- a/src/application.rs
+++ b/src/application.rs
@@ -171,7 +171,7 @@ mod tests {
 	
 	#[test]
 	fn application_read_all_actions() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let app = Application::new(gi, window);
 		assert_eq!(app.git_interactive.get_lines().len(), 12);
@@ -179,7 +179,7 @@ mod tests {
 	
 	#[test]
 	fn application_show_help() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('?');
@@ -190,7 +190,7 @@ mod tests {
 	#[test]
 	fn application_show_commit() {
 		// first commit in
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-show-commit.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-show-commit.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('c');
@@ -200,7 +200,7 @@ mod tests {
 	
 	#[test]
 	fn application_scroll_basic() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-long.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-long.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::KeyDown;
@@ -216,10 +216,10 @@ mod tests {
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_selected_line_index(), 1);
 	}
-	
+
 	#[test]
 	fn application_scroll_limits() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-short.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-short.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::KeyUp;
@@ -241,7 +241,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_pick() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		// first item is already pick
@@ -254,7 +254,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_reword() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('r');
@@ -264,7 +264,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_edit() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('e');
@@ -274,7 +274,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_squash() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('s');
@@ -284,7 +284,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_drop() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('d');
@@ -294,7 +294,7 @@ mod tests {
 	
 	#[test]
 	fn application_swap_down() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('j');
@@ -306,7 +306,7 @@ mod tests {
 	
 	#[test]
 	fn application_swap_up() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::KeyDown;
@@ -320,7 +320,7 @@ mod tests {
 	
 	#[test]
 	fn application_quit() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('Q');
@@ -331,7 +331,18 @@ mod tests {
 	
 	#[test]
 	fn application_finish() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in").unwrap();
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
+		let window = Window::new();
+		let mut app = Application::new(gi, window);
+		app.window.window.next_char = Input::Character('W');
+		app.process_input();
+		assert_eq!(app.exit_code.unwrap(), 0);
+		assert!(!app.git_interactive.get_lines().is_empty());
+	}
+
+	#[test]
+	fn application_alternative_comment_character() {
+		let gi = GitInteractive::new_from_filepath("test/git-rebase-alternative-comment-character.in", "%").unwrap();
 		let window = Window::new();
 		let mut app = Application::new(gi, window);
 		app.window.window.next_char = Input::Character('W');

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -1,0 +1,44 @@
+use git2::ConfigLevel;
+use git2::Config;
+use std::env;
+use std::path::Path;
+
+pub struct GitConfig {
+	pub comment_char: String,
+}
+
+impl GitConfig {
+	pub fn new() -> Result<Self, String> {
+		let cfg = Config::open_default();
+
+		match cfg {
+			Ok(mut config) => {
+				match env::var_os("GIT_DIR") {
+					Some(val) => match val.into_string() {
+						Ok(s) => {
+							let mut p = s.to_owned();
+							p.push_str("/config");
+							match config.add_file(Path::new(&p), ConfigLevel::Local, false) {
+								Ok(_v) => {}, Err(_e) => {}
+							}
+						},
+						Err(_e) => {}
+					},
+					None => {}
+				}
+
+				Ok(GitConfig {
+					comment_char: match config.get_string("core.commentChar") {
+						Ok(comment_char_value) => comment_char_value,
+						Err(_msg) => String::from("#")
+					}
+				})
+			},
+			Err(msg) => {
+				Err(format!(
+					"Error reading git config, Reason {}\n", msg
+				))
+			}
+		}
+	}
+}

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -16,7 +16,7 @@ pub struct GitInteractive {
 }
 
 impl GitInteractive {
-	pub fn new_from_filepath(filepath: &str) -> Result<Self, String> {
+	pub fn new_from_filepath(filepath: &str, comment_char: &str) -> Result<Self, String> {
 		let path = PathBuf::from(filepath);
 
 		let mut file = match File::open(&path) {
@@ -48,7 +48,7 @@ impl GitInteractive {
 			Some("noop") => Ok(Vec::new()),
 			_ => {
 				s.lines()
-					.filter(|l| !l.starts_with('#') && !l.is_empty())
+					.filter(|l| !l.starts_with(comment_char) && !l.is_empty())
 					.map(|l| Line::new(l))
 					.collect()
 			}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate clap;
+extern crate git2;
 extern crate pad;
 extern crate pancurses;
 
@@ -9,6 +10,7 @@ mod action;
 mod application;
 mod cli;
 mod commit;
+mod git_config;
 mod git_interactive;
 mod line;
 mod window;
@@ -16,6 +18,7 @@ mod window;
 mod mocks;
 
 use application::Application;
+use git_config::GitConfig;
 use git_interactive::GitInteractive;
 use std::process;
 use window::Window;
@@ -24,8 +27,16 @@ fn main() {
 	let matches = cli::build_cli().get_matches();
 
 	let filepath = matches.value_of("rebase-todo-filepath").unwrap();
-	
-	let git_interactive = match GitInteractive::new_from_filepath(filepath) {
+
+	let git_config = match GitConfig::new() {
+		Ok(gc) => gc,
+		Err(msg) => {
+			eprintln!("{}", msg);
+			process::exit(1)
+		}
+	};
+
+	let git_interactive = match GitInteractive::new_from_filepath(filepath, &git_config.comment_char) {
 		Ok(gi) => gi,
 		Err(msg) => {
 			eprintln!("{}", msg);

--- a/test/git-rebase-alternative-comment-character.in
+++ b/test/git-rebase-alternative-comment-character.in
@@ -1,0 +1,4 @@
+pick aaa Added tests
+fixup bbb Added tests
+pick ccc #Added tests
+% foo bar comment


### PR DESCRIPTION
Having the configuration option `core.commentChar` set to anything other than `#` would result in the tool being unable to read the rebase tool. This change reads the configuration value and uses it over the hard-coded value.