### PR TITLE
Fix #77 by using color pair 0 for the default fg

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,11 +1,11 @@
 #[derive(Debug, Copy, Clone)]
 pub enum Color {
+	White,
 	Black,
 	Blue,
 	Cyan,
 	Green,
 	Magenta,
 	Red,
-	White,
 	Yellow,
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -26,13 +26,13 @@ use config::Config;
 use input::Input;
 
 const COLOR_TABLE: [i16; 8] = [
+	pancurses::COLOR_WHITE,
 	pancurses::COLOR_BLACK,
 	pancurses::COLOR_BLUE,
 	pancurses::COLOR_CYAN,
 	pancurses::COLOR_GREEN,
 	pancurses::COLOR_MAGENTA,
 	pancurses::COLOR_RED,
-	pancurses::COLOR_WHITE,
 	pancurses::COLOR_YELLOW,
 ];
 
@@ -263,13 +263,13 @@ impl Window {
 
 	fn set_color(&self, color: Color) {
 		match color {
-			Color::Black => self.window.attrset(pancurses::COLOR_PAIR(0)),
-			Color::Blue => self.window.attrset(pancurses::COLOR_PAIR(1)),
-			Color::Cyan => self.window.attrset(pancurses::COLOR_PAIR(2)),
-			Color::Green => self.window.attrset(pancurses::COLOR_PAIR(3)),
-			Color::Magenta => self.window.attrset(pancurses::COLOR_PAIR(4)),
-			Color::Red => self.window.attrset(pancurses::COLOR_PAIR(5)),
-			Color::White => self.window.attrset(pancurses::COLOR_PAIR(6)),
+			Color::White => self.window.attrset(pancurses::COLOR_PAIR(0)),
+			Color::Black => self.window.attrset(pancurses::COLOR_PAIR(1)),
+			Color::Blue => self.window.attrset(pancurses::COLOR_PAIR(2)),
+			Color::Cyan => self.window.attrset(pancurses::COLOR_PAIR(3)),
+			Color::Green => self.window.attrset(pancurses::COLOR_PAIR(4)),
+			Color::Magenta => self.window.attrset(pancurses::COLOR_PAIR(5)),
+			Color::Red => self.window.attrset(pancurses::COLOR_PAIR(6)),
 			Color::Yellow => self.window.attrset(pancurses::COLOR_PAIR(7))
 		};
 	}


### PR DESCRIPTION
In PR #66 (45baada92940979b8616c375a52a30bcc60b36bd) the colors in
COLOR_TABLE were sorted by name:
  https://github.com/MitMaro/git-interactive-rebase-tool/pull/66/files#diff-2ce3f8d26915325bbd02de9e0056281eL25

However, color pair #0 apparently has some special handling. In iTerm2,
for instance, setting the fg color of color pair #0 to "white" keeps
using the default foreground color, while another color pair with the
fg color set to "white" uses the color configured for ANSI white.

Linux man for use_default_colors(3) says:
https://linux.die.net/man/3/use_default_colors
> Other curses implementations do not allow an application to modify color pair 0.

While man page for start_color(3) has this about to say about init_pair():
https://linux.die.net/man/3/start_color
> Color pair 0 is assumed to be white on black, but is actually whatever
> the terminal implements before color is initialized. It cannot be
> modified by the application.
> ...
> As an extension, ncurses allows you to set color pair 0 via the
> assume_default_colors routine