### PR TITLE
Implement #60 (shell out to editor) + misc changes

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -199,21 +199,22 @@ mod tests {
 	use config::Config;
 	use git_config::GitConfig;
 
-	#[test]
-	fn application_read_all_actions() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
+	fn test_setup(todo_file: &str, comment_char: &str) -> Application {
+		let gi = GitInteractive::new_from_filepath(todo_file, comment_char).unwrap();
 		let config = Config::new(&GitConfig::new().unwrap());
 		let window = Window::new(config);
-		let app = Application::new(gi, window, config);
+		Application::new(gi, window, config)
+	}
+
+	#[test]
+	fn application_read_all_actions() {
+		let app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		assert_eq!(app.git_interactive.get_lines().len(), 14);
 	}
 	
 	#[test]
 	fn application_show_help() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('?');
 		app.process_input();
 		assert_eq!(app.state, State::Help);
@@ -222,10 +223,7 @@ mod tests {
 	#[test]
 	fn application_show_commit() {
 		// first commit in
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-show-commit.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-show-commit.in", "#");
 		app.window.window.next_char = PancursesInput::Character('c');
 		app.process_input();
 		assert_eq!(app.state, State::ShowCommit);
@@ -233,10 +231,7 @@ mod tests {
 	
 	#[test]
 	fn application_scroll_basic() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-long.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-long.in", "#");
 		app.window.window.next_char = PancursesInput::KeyDown;
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_selected_line_index(), 2);
@@ -253,10 +248,7 @@ mod tests {
 
 	#[test]
 	fn application_scroll_limits() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-short.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-short.in", "#");
 		app.window.window.next_char = PancursesInput::KeyUp;
 		app.process_input();
 		app.process_input();
@@ -276,10 +268,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_pick() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		// first item is already pick
 		app.window.window.next_char = PancursesInput::KeyDown;
 		app.process_input();
@@ -290,10 +279,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_reword() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('r');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Reword);
@@ -301,10 +287,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_edit() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('e');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Edit);
@@ -312,10 +295,7 @@ mod tests {
 
 	#[test]
 	fn application_not_set_exec_action() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-exec.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-exec.in", "#");
 		app.window.window.next_char = PancursesInput::Character('p');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
@@ -338,10 +318,7 @@ mod tests {
 
 	#[test]
 	fn application_set_squash() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('s');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Squash);
@@ -349,10 +326,7 @@ mod tests {
 	
 	#[test]
 	fn application_set_drop() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('d');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Drop);
@@ -360,10 +334,7 @@ mod tests {
 	
 	#[test]
 	fn application_swap_down() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('j');
 		app.process_input();
 		assert_eq!(*app.git_interactive.get_lines()[0].get_hash_or_command(), "bbb");
@@ -373,10 +344,7 @@ mod tests {
 	
 	#[test]
 	fn application_swap_up() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::KeyDown;
 		app.process_input();
 		app.window.window.next_char = PancursesInput::Character('k');
@@ -388,10 +356,7 @@ mod tests {
 	
 	#[test]
 	fn application_quit() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('Q');
 		app.process_input();
 		assert_eq!(app.exit_code.unwrap(), 0);
@@ -400,10 +365,7 @@ mod tests {
 	
 	#[test]
 	fn application_finish() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-todo-all-actions.in", "#").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('W');
 		app.process_input();
 		assert_eq!(app.exit_code.unwrap(), 0);
@@ -412,10 +374,7 @@ mod tests {
 
 	#[test]
 	fn application_alternative_comment_character() {
-		let gi = GitInteractive::new_from_filepath("test/git-rebase-alternative-comment-character.in", "%").unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
-		let mut app = Application::new(gi, window, config);
+		let mut app = test_setup("test/git-rebase-alternative-comment-character.in", "%");
 		app.window.window.next_char = PancursesInput::Character('W');
 		app.process_input();
 		assert_eq!(app.exit_code.unwrap(), 0);

--- a/src/application.rs
+++ b/src/application.rs
@@ -201,8 +201,8 @@ mod tests {
 
 	fn test_setup(todo_file: &str, comment_char: &str) -> Application {
 		let gi = GitInteractive::new_from_filepath(todo_file, comment_char).unwrap();
-		let config = Config::new(&GitConfig::new().unwrap());
-		let window = Window::new(config);
+		let config = Config::new(GitConfig::new().unwrap());
+		let window = Window::new(config.clone());
 		Application::new(gi, window, config)
 	}
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 use color::Color;
 use git_config::GitConfig;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
+	pub comment_char: String,
 	pub foreground_color: Color,
 	pub indicator_color: Color,
 	pub error_color: Color,
@@ -33,8 +34,9 @@ fn string_to_color(color_string: &str, default_color: Color) -> Color {
 }
 
 impl Config {
-	pub fn new(git_config: &GitConfig) -> Self {
+	pub fn new(git_config: GitConfig) -> Self {
 		Config {
+			comment_char: git_config.comment_char,
 			foreground_color: string_to_color(git_config.foreground_color.as_ref(), Color::White),
 			indicator_color: string_to_color(git_config.indicator_color.as_ref(), Color::Yellow),
 			error_color: string_to_color(git_config.error_color.as_ref(), Color::Red),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use color::Color;
 use git_config::GitConfig;
+use std::ffi::OsString;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -17,6 +18,7 @@ pub struct Config {
 	pub fixup_color: Color,
 	pub drop_color: Color,
 	pub auto_select_next: bool,
+	pub editor: OsString,
 }
 
 fn string_to_color(color_string: &str, default_color: Color) -> Color {
@@ -50,6 +52,7 @@ impl Config {
 			fixup_color: string_to_color(git_config.fixup_color.as_ref(), Color::Magenta),
 			drop_color: string_to_color(git_config.drop_color.as_ref(), Color::Red),
 			auto_select_next: git_config.auto_select_next,
+			editor: git_config.editor,
 		}
 	}
 }

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -1,7 +1,4 @@
-use git2::ConfigLevel;
-use git2::Config;
-use std::env;
-use std::path::Path;
+use git2;
 
 #[derive(Debug)]
 pub struct GitConfig {
@@ -22,89 +19,40 @@ pub struct GitConfig {
 }
 
 impl GitConfig {
-	pub fn new() -> Result<Self, String> {
-		let cfg = Config::open_default();
-
-		match cfg {
-			Ok(mut config) => {
-				if let Some(val) = env::var_os("GIT_DIR") {
-					match val.into_string() {
-						Ok(s) => {
-							let mut p = s.to_owned();
-							p.push_str("/config");
-							match config.add_file(Path::new(&p), ConfigLevel::Local, false) {
-								Ok(_v) => {},
-								Err(_e) => {}
-							}
-						},
-						Err(_e) => {}
-					}
-				}
-
-				Ok(GitConfig {
-					comment_char: match config.get_string("core.commentChar") {
-						Ok(comment_char_value) => comment_char_value,
-						Err(_msg) => String::from("#")
-					},
-					foreground_color: match config.get_string("interactive-rebase-tool.foregroundColor") {
-						Ok(foreground_color_value) => foreground_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					indicator_color: match config.get_string("interactive-rebase-tool.indicatorColor") {
-						Ok(indicator_color_value) => indicator_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					error_color: match config.get_string("interactive-rebase-tool.errorColor") {
-						Ok(error_color_value) => error_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					diff_add_color: match config.get_string("interactive-rebase-tool.diffAddColor") {
-						Ok(diff_add_color_value) => diff_add_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					diff_remove_color: match config.get_string("interactive-rebase-tool.diffRemoveColor") {
-						Ok(diff_remove_color_value) => diff_remove_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					pick_color: match config.get_string("interactive-rebase-tool.pickColor") {
-						Ok(pick_color_value) => pick_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					reword_color: match config.get_string("interactive-rebase-tool.rewordColor") {
-						Ok(reword_color_value) => reword_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					edit_color: match config.get_string("interactive-rebase-tool.editColor") {
-						Ok(edit_color_value) => edit_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					exec_color: match config.get_string("interactive-rebase-tool.execColor") {
-						Ok(exec_color_value) => exec_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					squash_color: match config.get_string("interactive-rebase-tool.squashColor") {
-						Ok(squash_color_value) => squash_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					fixup_color: match config.get_string("interactive-rebase-tool.fixupColor") {
-						Ok(fixup_color_value) => fixup_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					drop_color: match config.get_string("interactive-rebase-tool.dropColor") {
-						Ok(drop_color_value) => drop_color_value.to_lowercase(),
-						Err(_msg) => String::from("")
-					},
-					auto_select_next: match config.get_bool("interactive-rebase-tool.autoSelectNext") {
-						Ok(auto_select_next_value) => auto_select_next_value,
-						Err(_msg) => false
-					},
-				})
+	pub fn new() -> Result<Self, git2::Error> {
+		let config = git2::Repository::open_from_env()?.config()?;
+		Ok(GitConfig {
+			comment_char: get_string(&config, "core.commentChar")?.unwrap_or_else(|| String::from("#")),
+			foreground_color: get_color(&config, "interactive-rebase-tool.foregroundColor")?,
+			indicator_color: get_color(&config, "interactive-rebase-tool.indicatorColor")?,
+			error_color: get_color(&config, "interactive-rebase-tool.errorColor")?,
+			diff_add_color: get_color(&config, "interactive-rebase-tool.diffAddColor")?,
+			diff_remove_color: get_color(&config, "interactive-rebase-tool.diffRemoveColor")?,
+			pick_color: get_color(&config, "interactive-rebase-tool.pickColor")?,
+			reword_color: get_color(&config, "interactive-rebase-tool.rewordColor")?,
+			edit_color: get_color(&config, "interactive-rebase-tool.editColor")?,
+			exec_color: get_color(&config, "interactive-rebase-tool.execColor")?,
+			squash_color: get_color(&config, "interactive-rebase-tool.squashColor")?,
+			fixup_color: get_color(&config, "interactive-rebase-tool.fixupColor")?,
+			drop_color: get_color(&config, "interactive-rebase-tool.dropColor")?,
+			auto_select_next: match config.get_bool("interactive-rebase-tool.autoSelectNext") {
+				Ok(auto_select_next_value) => auto_select_next_value,
+				Err(_msg) => false
 			},
-			Err(msg) => {
-				Err(format!(
-					"Error reading git config, Reason {}\n", msg
-				))
-			}
-		}
+		})
 	}
+}
+
+fn get_string(config: &git2::Config, name: &str) -> Result<Option<String>, git2::Error> {
+	match config.get_string(name) {
+		Ok(v) => Ok(Some(v)),
+		Err(ref e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+		Err(e) => Err(e)
+	}
+}
+
+fn get_color(config: &git2::Config, name: &str) -> Result<String, git2::Error> {
+	// TODO: could make colors in GitConfig an Option<String> and move this to config.rs
+	Ok(get_string(config, name)?.map(|s| s.to_lowercase())
+		.unwrap_or_default())
 }

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -69,7 +69,7 @@ impl GitInteractive {
 		}
 	}
 	
-	pub fn write_file(&self) -> Result<(), String> {
+	pub fn write_file(&self) -> Result<String, String> {
 		let mut file = match File::create(&self.filepath) {
 			Ok(file) => file,
 			Err(why) => {
@@ -90,7 +90,9 @@ impl GitInteractive {
 				}
 			}
 		}
-		Ok(())
+		// Return the path to the todo file. Since it was constructed from str originally,
+		// converting back should be safe...
+		Ok(self.filepath.to_str().map(String::from).unwrap())
 	}
 	
 	pub fn clear(&mut self) {

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 use std::fs::File;
 use std::path::PathBuf;
-use std::error::Error;
 use std::io::Read;
 use std::io::Write;
 
@@ -24,7 +23,7 @@ impl GitInteractive {
 			Err(why) => {
 				return Err(format!(
 					"Error opening file, {}\n\
-					Reason: {}", path.display(), why.description()
+					Reason: {}", path.display(), why
 				));
 			}
 		};
@@ -35,7 +34,7 @@ impl GitInteractive {
 			Err(why) => {
 				return Err(format!(
 					"Error reading file, {}\n\
-					Reason: {}", path.display(), why.description()
+					Reason: {}", path.display(), why
 				));
 			}
 		}
@@ -76,7 +75,7 @@ impl GitInteractive {
 			Err(why) => {
 				return Err(format!(
 					"Error opening file, {}\n\
-					Reason: {}", self.filepath.display(), why.description()
+					Reason: {}", self.filepath.display(), why
 				));
 			}
 		};
@@ -86,7 +85,7 @@ impl GitInteractive {
 				Ok(_) => {},
 				Err(why) => {
 					return Err(format!(
-						"Error writing to file, {}", why.description()
+						"Error writing to file, {}", why
 					));
 				}
 			}

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,5 +18,6 @@ pub enum Input {
 	MoveCursorPageDown,
 	MoveCursorPageUp,
 	Resize,
+	OpenInEditor,
 	Other,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
 
 	let git_config = match GitConfig::new() {
 		Ok(gc) => gc,
-		Err(msg) => error_handler(&msg, 1),
+		Err(msg) => error_handler(&format!("Error reading git config: {}", msg), 1),
 	};
 
 	let config = Config::new(&git_config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,6 @@ fn main() {
 		Err(msg) => error_handler(&format!("Error reading git config: {}", msg), 1),
 	};
 
-	let config = Config::new(&git_config);
-
 	let git_interactive = match GitInteractive::new_from_filepath(filepath, &git_config.comment_char) {
 		Ok(gi) => gi,
 		Err(msg) => error_handler(&msg, 1),
@@ -55,7 +53,8 @@ fn main() {
 		error_handler("Nothing to rebase", 1);
 	}
 
-	let window = Window::new(config);
+	let config = Config::new(git_config);
+	let window = Window::new(config.clone()); // TODO: shouldn't need two copies of `config`
 
 	let mut application = Application::new(git_interactive, window, config);
 

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -19,6 +19,7 @@ pub mod mockcurses {
 	};
 
 	pub fn curs_set(_visibility: i32) {}
+	pub fn def_prog_mode() -> i32 {0}
 	pub fn endwin() {}
 	pub fn has_colors() -> bool {
 		false
@@ -31,6 +32,7 @@ pub mod mockcurses {
 		}
 	}
 	pub fn noecho() {}
+	pub fn reset_prog_mode() -> i32 {0}
 	pub fn resize_term(_nlines: i32, _ncols: i32) {}
 	pub fn start_color() {}
 	pub fn use_default_colors() {}

--- a/src/window.rs
+++ b/src/window.rs
@@ -317,10 +317,14 @@ impl Window {
 		}
 	}
 
-	pub fn draw_confirm(&self, message: &str) {
+	pub fn draw_prompt(&self, message: &str) {
 		self.window.clear();
 		self.draw_title();
-		self.window.addstr(&format!("\n{} (y/n)? ", message));
+		self.window.addstr(&format!("\n{} ", message));
+	}
+
+	pub fn draw_confirm(&self, message: &str) {
+		self.draw_prompt(&format!("{}(y/n)? ", message));
 	}
 
 	pub fn get_confirm(&self) -> bool {

--- a/src/window.rs
+++ b/src/window.rs
@@ -144,7 +144,7 @@ impl Window {
 		self.window.mvaddstr(
 			self.window.get_max_y() - 1,
 			0,
-			"Actions: [ up, down, q/Q, w/W, c, j, k, p, r, e, s, f, d, ? ]"
+			"Actions: [ up, down, q/Q, w/W, c, j, k, p, r, e, s, f, d, !, ? ]"
 		);
 		self.set_dim(false);
 	}
@@ -249,6 +249,7 @@ impl Window {
 		self.draw_help_command("s", "Set selected commit to be squashed");
 		self.draw_help_command("f", "Set selected commit to be fixed-up");
 		self.draw_help_command("d", "Set selected commit to be dropped");
+		self.draw_help_command("!", "Open the todo file in the default editor");
 		self.set_color(self.config.indicator_color);
 		self.window.addstr("\n\nHit any key to close help");
 		self.window.refresh();
@@ -313,6 +314,7 @@ impl Window {
 			Some(PancursesInput::KeyPPage) => Input::MoveCursorPageUp,
 			Some(PancursesInput::KeyNPage) => Input::MoveCursorPageDown,
 			Some(PancursesInput::KeyResize) => Input::Resize,
+			Some(PancursesInput::Character(c)) if c == '!' => Input::OpenInEditor,
 			_ => Input::Other,
 		}
 	}
@@ -351,6 +353,16 @@ impl Window {
 			x if x >= 4 => (x - 4) as usize,
 			_ => 4
 		}
+	}
+
+	/// Leaves curses mode, runs the specified callback, and re-enables curses.
+	pub fn leave_temporarily<F, T>(callback: F) -> T
+		where F: FnOnce() -> T {
+		pancurses::def_prog_mode();
+		pancurses::endwin();
+		let rv = callback();
+		pancurses::reset_prog_mode();
+		rv
 	}
 
 	pub fn end(&self) {


### PR DESCRIPTION
This PR contains two minor standalone changes (the first two commits - 16adaf96f78c035776cd88778aa97d2b7981b185 and 4e33f1c2c3c2feb3682ad7d8384bb8989227827a) and a possible solution to #60 (the rest of commits). I would appreciate some feedback on this.

I was unsure which data should be stored in what object, so I simply added `comment_char` and `editor` to both `GitConfig` and `Config`, and made `GitInteractive::write_file()` return the path to the file written (so that it could be handed to the external editor). It doesn't feel ideal, but I'm not sure what would be better.

I didn't write tests because I wanted to get some feedback first (and perhaps any ideas on what you think should be minimally tested).

I tried to document the changes in commit messages and left 3 TODO markers throughout the code.

Let me know what you think!