### PR TITLE
Drop 32bit Windows build and speed up CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ to a location on your `PATH`.
 
 ##### Install
 
-Download the tool from the [releases page][releases] and save it to a known location. There are 32-bit and 64-bit
-versions if you are unsure which binary to download, you probably want the 64-bit build.
+Download the tool from the [releases page][releases] and save it to a known location.
 
 ##### Configure Git
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,40 +10,26 @@ environment:
     CRATE_NAME: git-interactive-rebase-tool
 
   matrix:
-    # MinGW
-    # GNU builds are broken for some reason
-    # - TARGET: i686-pc-windows-gnu
-    # - TARGET: x86_64-pc-windows-gnu
-
-    # MSVC
-    - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
 
 install:
   - ps: >-
-      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
         $Env:PATH += ';C:\msys64\mingw64\bin'
-      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
-        $Env:PATH += ';C:\msys64\mingw32\bin'
-      }
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain %RUST_VERSION%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -Vv
   - cargo -V
 
 test_script:
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release &&
-      cargo run --target %TARGET% -- --version &&
-      cargo run --target %TARGET% --release -- --version
+      cargo build --target x86_64-pc-windows-msvc --release &&
+      cargo test --target x86_64-pc-windows-msvc --release &&
+      cargo run --target x86_64-pc-windows-msvc --release -- --version
     )
 
 before_deploy:
-  - cargo rustc --target %TARGET% --release --bin interactive-rebase-tool -- -C lto
+  - cargo rustc --target x86_64-pc-windows-msvc --release --bin interactive-rebase-tool -- -C lto
   - ps: ci\before-deploy.ps1
 
 deploy:

--- a/ci/before-deploy.ps1
+++ b/ci/before-deploy.ps1
@@ -8,9 +8,9 @@ Set-Location $ENV:Temp
 New-Item -Type Directory -Name $STAGE
 Set-Location $STAGE
 
-$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-x86_64-pc-windows-msvc.zip"
 
-Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\interactive-rebase-tool.exe" '.\'
+Copy-Item "$SRC_DIR\target\x86_64-pc-windows-msvc\release\interactive-rebase-tool.exe" '.\'
 
 7z a "$ZIP" *
 


### PR DESCRIPTION
The 32-bit Windows version takes 10-15 minutes to build on AppVeyor. Since most people are running a 64-bit operating system I'm going to drop support.