### PR TITLE
Proof-of-concept for multi-line selection

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,5 @@
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Action {
 	Drop,
 	Edit,

--- a/src/action.rs
+++ b/src/action.rs
@@ -23,8 +23,8 @@ pub fn action_from_str(s: &str) -> Result<Action, String> {
 	}
 }
 
-pub fn action_to_str(action: &Action) -> String {
-	String::from(match *action {
+pub fn action_to_str(action: Action) -> String {
+	String::from(match action {
 		Action::Drop => "drop",
 		Action::Edit => "edit",
 		Action::Exec => "exec",
@@ -45,13 +45,13 @@ mod tests {
 
 	#[test]
 	fn action_to_str_all() {
-		assert_eq!(action_to_str(&Action::Drop), "drop");
-		assert_eq!(action_to_str(&Action::Edit), "edit");
-		assert_eq!(action_to_str(&Action::Exec), "exec");
-		assert_eq!(action_to_str(&Action::Fixup), "fixup");
-		assert_eq!(action_to_str(&Action::Pick), "pick");
-		assert_eq!(action_to_str(&Action::Reword), "reword");
-		assert_eq!(action_to_str(&Action::Squash), "squash");
+		assert_eq!(action_to_str(Action::Drop), "drop");
+		assert_eq!(action_to_str(Action::Edit), "edit");
+		assert_eq!(action_to_str(Action::Exec), "exec");
+		assert_eq!(action_to_str(Action::Fixup), "fixup");
+		assert_eq!(action_to_str(Action::Pick), "pick");
+		assert_eq!(action_to_str(Action::Reword), "reword");
+		assert_eq!(action_to_str(Action::Squash), "squash");
 	}
 	
 	#[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -316,7 +316,7 @@ mod tests {
 		app.process_input();
 		app.window.window.next_char = PancursesInput::Character('p');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[1].get_action(), Action::Pick);
+		assert_eq!(app.git_interactive.get_lines()[1].get_action(), Action::Pick);
 	}
 	
 	#[test]
@@ -324,7 +324,7 @@ mod tests {
 		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('r');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Reword);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Reword);
 	}
 	
 	#[test]
@@ -332,7 +332,7 @@ mod tests {
 		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('e');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Edit);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Edit);
 	}
 
 	#[test]
@@ -340,22 +340,22 @@ mod tests {
 		let mut app = test_setup("test/git-rebase-todo-exec.in", "#");
 		app.window.window.next_char = PancursesInput::Character('p');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 		app.window.window.next_char = PancursesInput::Character('r');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 		app.window.window.next_char = PancursesInput::Character('e');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 		app.window.window.next_char = PancursesInput::Character('s');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 		app.window.window.next_char = PancursesInput::Character('f');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 		app.window.window.next_char = PancursesInput::Character('d');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Exec);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Exec);
 	}
 
 	#[test]
@@ -363,7 +363,7 @@ mod tests {
 		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('s');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Squash);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Squash);
 	}
 	
 	#[test]
@@ -371,7 +371,7 @@ mod tests {
 		let mut app = test_setup("test/git-rebase-todo-all-actions.in", "#");
 		app.window.window.next_char = PancursesInput::Character('d');
 		app.process_input();
-		assert_eq!(*app.git_interactive.get_lines()[0].get_action(), Action::Drop);
+		assert_eq!(app.git_interactive.get_lines()[0].get_action(), Action::Drop);
 	}
 	
 	#[test]

--- a/src/application.rs
+++ b/src/application.rs
@@ -62,7 +62,8 @@ impl Application {
 			State::List => {
 				self.window.draw(
 					self.git_interactive.get_lines(),
-					*self.git_interactive.get_selected_line_index()
+					*self.git_interactive.get_selected_line_index(),
+					self.git_interactive.get_anchor_line_index(),
 				);
 			},
 			State::ShowCommit => {
@@ -143,6 +144,10 @@ impl Application {
 			},
 			Input::SwapSelectedUp => {
 				self.git_interactive.swap_selected_up();
+				self.reset_top();
+			},
+			Input::ToggleSelection => {
+				self.git_interactive.toggle_selection();
 				self.reset_top();
 			},
 			Input::MoveCursorDown => {

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -157,7 +157,7 @@ impl GitInteractive {
 	
 	pub fn set_selected_line_action(&mut self, action: Action) {
 		for line_index in self.get_selected_lines() {
-			if *self.lines[line_index - 1].get_action() != Action::Exec {
+			if self.lines[line_index - 1].get_action() != Action::Exec {
 				self.lines[line_index - 1].set_action(action);
 			}
 		}

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -11,7 +11,8 @@ pub struct GitInteractive {
 	git_root: PathBuf,
 	filepath: PathBuf,
 	lines: Vec<Line>,
-	selected_line_index: usize
+	selected_line_index: usize,
+	anchor_line_index: Option<usize>,
 }
 
 impl GitInteractive {
@@ -59,7 +60,8 @@ impl GitInteractive {
 					git_root,
 					filepath: path,
 					lines,
-					selected_line_index: 1
+					selected_line_index: 1,
+					anchor_line_index: None,
 				}
 			),
 			Err(e) => Err(format!(
@@ -99,6 +101,13 @@ impl GitInteractive {
 		self.lines.clear();
 	}
 	
+	pub fn toggle_selection(&mut self) {
+		self.anchor_line_index = match self.anchor_line_index {
+			None => Some(self.selected_line_index),
+			Some(_) => None
+		}
+	}
+
 	pub fn move_cursor_up(&mut self, amount: usize) {
 		self.selected_line_index = match amount {
 			a if a >= self.selected_line_index => 1,
@@ -138,6 +147,10 @@ impl GitInteractive {
 	
 	pub fn get_selected_line_index(&self) -> &usize {
 		&self.selected_line_index
+	}
+
+	pub fn get_anchor_line_index(&self) -> Option<usize> {
+		self.anchor_line_index
 	}
 	
 	pub fn get_git_root(&self) -> &PathBuf {

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,6 +13,7 @@ pub enum Input {
 	Squash,
 	SwapSelectedDown,
 	SwapSelectedUp,
+	ToggleSelection,
 	MoveCursorDown,
 	MoveCursorUp,
 	MoveCursorPageDown,

--- a/src/line.rs
+++ b/src/line.rs
@@ -43,8 +43,8 @@ impl Line {
 		}
 	}
 	
-	pub fn get_action(&self) -> &Action {
-		&self.action
+	pub fn get_action(&self) -> Action {
+		self.action
 	}
 	pub fn get_hash_or_command(&self) -> &String {
 		&self.hash_or_command
@@ -54,7 +54,7 @@ impl Line {
 	}
 	
 	pub fn to_text(&self) -> String {
-		format!("{} {} {}", action_to_str(&self.action), self.hash_or_command, self.comment)
+		format!("{} {} {}", action_to_str(self.action), self.hash_or_command, self.comment)
 	}
 }
 
@@ -93,7 +93,7 @@ mod tests {
 	#[test]
 	fn getters() {
 		let line = Line::new("pick aaa comment").unwrap();
-		assert_eq!(line.get_action(), &Action::Pick);
+		assert_eq!(line.get_action(), Action::Pick);
 		assert_eq!(line.get_hash_or_command(), &"aaa");
 		assert_eq!(line.get_comment(), &"comment");
 	}

--- a/src/window.rs
+++ b/src/window.rs
@@ -313,6 +313,7 @@ impl Window {
 			Some(PancursesInput::Character(c)) if c == 'd' => Input::Drop,
 			Some(PancursesInput::Character(c)) if c == 'j' => Input::SwapSelectedDown,
 			Some(PancursesInput::Character(c)) if c == 'k' => Input::SwapSelectedUp,
+			// TODO: ESC to remove multi-selection?
 			Some(PancursesInput::Character(c)) if c == 'V' => Input::ToggleSelection,
 			Some(PancursesInput::KeyDown) => Input::MoveCursorDown,
 			Some(PancursesInput::KeyUp) => Input::MoveCursorUp,

--- a/src/window.rs
+++ b/src/window.rs
@@ -127,7 +127,7 @@ impl Window {
 		
 		self.window.addstr(if part_of_group { "|" } else { " " });
 		self.window.addstr(if selected { "> " } else { "  " });
-		match *line.get_action() {
+		match line.get_action() {
 			Action::Pick => self.set_color(self.config.pick_color),
 			Action::Reword => self.set_color(self.config.reword_color),
 			Action::Edit => self.set_color(self.config.edit_color),


### PR DESCRIPTION
As suggested here https://github.com/MitMaro/git-interactive-rebase-tool/issues/24#issuecomment-432330794 , this adds a "V" command to toggle multi-line selection.

When multi-line selection is enabled the currently selected line becomes an "anchor" point. As the user moves the cursor, the range of lines from the anchor to the currently focused line is considered "selected".

The actions are updated to act on all lines in the selection.

Let me know what you think!

(Now that https://github.com/MitMaro/git-interactive-rebase-tool/pull/79 is merged, I'm able to submit this as a proper PR)