### PR TITLE
Fix iTerm 2 issue

### DIFF
--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -48,7 +48,7 @@ pub mod mockcurses {
 		pub fn attroff(&self, _attributes: chtype) {}
 		pub fn attron(&self, _attributes: chtype) {}
 		pub fn attrset(&self, _attributes: chtype) {}
-		pub fn clear(&self) {}
+		pub fn erase(&self) {}
 		pub fn get_max_y(&self) -> i32 {self.max_y}
 		pub fn getch(&self) -> Option<Input> {Some(self.next_char)}
 		pub fn keypad(&self, _a: bool) {}

--- a/src/window.rs
+++ b/src/window.rs
@@ -72,7 +72,7 @@ impl Window {
 	}
 	
 	pub fn draw(&self, lines: &[Line], selected_index: usize) {
-		self.window.clear();
+		self.window.erase();
 		self.draw_title();
 		let window_height = self.get_window_height();
 		
@@ -161,7 +161,7 @@ impl Window {
 			.output()
 		;
 		
-		self.window.clear();
+		self.window.erase();
 		self.draw_title();
 		match result {
 			Ok(output) => {
@@ -226,7 +226,7 @@ impl Window {
 	}
 	
 	pub fn draw_help(&self) {
-		self.window.clear();
+		self.window.erase();
 		self.draw_title();
 		self.set_color(self.config.foreground_color);
 		self.window.addstr("\n Key        Action\n");
@@ -320,7 +320,7 @@ impl Window {
 	}
 
 	pub fn draw_prompt(&self, message: &str) {
-		self.window.clear();
+		self.window.erase();
 		self.draw_title();
 		self.window.addstr(&format!("\n{} ", message));
 	}
@@ -366,9 +366,6 @@ impl Window {
 	}
 
 	pub fn end(&self) {
-		self.window.clear();
-		self.window.refresh();
-		pancurses::curs_set(1);
 		pancurses::endwin();
 	}
 }


### PR DESCRIPTION
Use erase() instead of clear() on window update. Remove unnecessary steps in window.end().

Fix for #86 .

Using erase instead of clear also should improve performance a little: https://lists.gnu.org/archive/html/bug-ncurses/2014-01/msg00007.html