### PR TITLE
 Improve performance of show commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for 256-color terminals
 - Highlight of selected line(s) on 256-color terminals
 
+### Fixed
+- Performance issue with show commit
+
 ### Removed
 - Unused `errorColor` configuration
 

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -4,6 +4,8 @@ set -e
 set -u
 set -o pipefail
 
-rustup update nightly
-rustup component add rustfmt --toolchain nightly
-cargo +nightly fmt --all -- --check
+rust_version="nightly-2019-09-13"
+
+rustup update "$rust_version"
+rustup component add rustfmt --toolchain "$rust_version"
+cargo +"$rust_version"  fmt --all -- --check

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -39,7 +39,6 @@ fn load_filepath(path: &PathBuf, comment_char: &str) -> Result<Vec<Line>, String
 pub struct GitInteractive {
 	filepath: PathBuf,
 	lines: Vec<Line>,
-	selected_commit_stats: Option<Commit>,
 	selected_line_index: usize,
 	visual_index_start: usize,
 }
@@ -52,7 +51,6 @@ impl GitInteractive {
 		Ok(GitInteractive {
 			filepath: path,
 			lines,
-			selected_commit_stats: None,
 			selected_line_index: 1,
 			visual_index_start: 1,
 		})
@@ -211,22 +209,16 @@ impl GitInteractive {
 		}
 	}
 
-	// TODO this is kind of clunky and might be replaceable with a RefCell
-	pub fn load_commit_stats(&mut self) -> Result<(), String> {
+	pub fn load_commit_stats(&self) -> Result<Commit, String> {
 		let selected_action = self.lines[self.selected_line_index - 1].get_action();
 		if *selected_action != Action::Exec && *selected_action != Action::Break {
-			self.selected_commit_stats = Some(Commit::from_commit_hash(self.get_selected_line_hash().as_str())?);
-			return Ok(());
+			return Ok(Commit::from_commit_hash(self.get_selected_line_hash().as_str())?);
 		}
 		Err(String::from("Cannot load commit for the selected action"))
 	}
 
 	pub fn is_noop(&self) -> bool {
 		!self.lines.is_empty() && *self.lines[0].get_action() == Action::Noop
-	}
-
-	pub fn get_commit_stats(&self) -> &Option<Commit> {
-		&self.selected_commit_stats
 	}
 
 	pub fn get_selected_line_hash(&self) -> &String {

--- a/src/help/help.rs
+++ b/src/help/help.rs
@@ -93,7 +93,7 @@ impl<'h> ProcessModule for Help<'h> {
 		}
 
 		view.draw_view_lines(
-			view_lines,
+			&view_lines,
 			self.scroll_position.get_top_position(),
 			self.scroll_position.get_left_position(),
 			view_height - 3,

--- a/src/list/list.rs
+++ b/src/list/list.rs
@@ -116,7 +116,7 @@ impl<'l> ProcessModule for List<'l> {
 		view.draw_title(true);
 
 		view.draw_view_lines(
-			view_lines,
+			&view_lines,
 			self.scroll_position.get_top_position(),
 			self.scroll_position.get_left_position(),
 			view_height - 2,

--- a/src/show_commit/data.rs
+++ b/src/show_commit/data.rs
@@ -1,0 +1,150 @@
+use crate::commit::Commit;
+use crate::constants::MINIMUM_FULL_WINDOW_WIDTH;
+use crate::display::DisplayColor;
+use crate::show_commit::util::get_stat_item_segments;
+use crate::view::{LineSegment, ViewLine};
+use std::cmp;
+use unicode_segmentation::UnicodeSegmentation;
+
+pub struct Data {
+	height: usize,
+	width: usize,
+	lines: Vec<ViewLine>,
+	line_lengths: Vec<usize>,
+	max_line_length: usize,
+}
+
+impl Data {
+	pub fn new() -> Self {
+		Self {
+			height: 0,
+			width: 0,
+			lines: Vec::new(),
+			line_lengths: Vec::new(),
+			max_line_length: 0,
+		}
+	}
+
+	pub fn reset(&mut self) {
+		self.height = 0;
+		self.width = 0;
+		self.lines.clear();
+		self.line_lengths.clear();
+		self.max_line_length = 0;
+	}
+
+	pub fn update(&mut self, commit: &Commit, window_width: usize, window_height: usize) {
+		if window_width != self.width || window_height != self.height {
+			self.reset();
+
+			self.height = window_height;
+			self.width = window_width;
+
+			let is_full_width = window_width >= MINIMUM_FULL_WINDOW_WIDTH;
+
+			let full_hash = commit.get_hash();
+			let author = commit.get_author();
+			let committer = commit.get_committer();
+			let date = commit.get_date();
+			let body = commit.get_body();
+			let file_stats = commit.get_file_stats();
+
+			let hash_line = if is_full_width {
+				format!("Commit: {}", full_hash)
+			}
+			else {
+				let max_index = cmp::min(full_hash.len(), 8);
+				format!("{:8} ", full_hash[0..max_index].to_string())
+			};
+
+			self.lines.push(ViewLine::new(vec![LineSegment::new_with_color(
+				hash_line.as_str(),
+				DisplayColor::IndicatorColor,
+			)]));
+			self.line_lengths.push(hash_line.len());
+
+			let date_line = if is_full_width {
+				format!("Date: {}", date.format("%c %z"))
+			}
+			else {
+				format!("{}", date.format("%c %z"))
+			};
+
+			self.lines
+				.push(ViewLine::new(vec![LineSegment::new(date_line.as_str())]));
+			self.line_lengths.push(date_line.len());
+
+			if let Some(a) = author.to_string() {
+				let author_line = if is_full_width {
+					format!("Author: {}", a)
+				}
+				else {
+					format!("A: {}", a)
+				};
+				self.lines
+					.push(ViewLine::new(vec![LineSegment::new(author_line.as_str())]));
+				self.line_lengths
+					.push(UnicodeSegmentation::graphemes(author_line.as_str(), true).count());
+			}
+
+			if let Some(c) = committer.to_string() {
+				let committer_line = if is_full_width {
+					format!("Committer: {}", c)
+				}
+				else {
+					format!("C: {}", c)
+				};
+				self.lines
+					.push(ViewLine::new(vec![LineSegment::new(committer_line.as_str())]));
+				self.line_lengths
+					.push(UnicodeSegmentation::graphemes(committer_line.as_str(), true).count());
+			}
+
+			match body {
+				Some(b) => {
+					for line in b.lines() {
+						self.lines.push(ViewLine::new(vec![LineSegment::new(line)]));
+						self.line_lengths
+							.push(UnicodeSegmentation::graphemes(line, true).count());
+					}
+				},
+				None => {},
+			}
+
+			self.lines.push(ViewLine::new(vec![LineSegment::new("")]));
+			self.line_lengths.push(0);
+
+			match file_stats {
+				Some(stats) => {
+					for stat in stats {
+						let stat_to_name = stat.get_to_name();
+						let stat_from_name = stat.get_from_name();
+						let stat_view_line = ViewLine::new(get_stat_item_segments(
+							*stat.get_status(),
+							stat_to_name.as_str(),
+							stat_from_name.as_str(),
+							is_full_width,
+						));
+						self.line_lengths.push(stat_view_line.get_length());
+						self.lines.push(stat_view_line);
+					}
+				},
+				None => {},
+			}
+		}
+	}
+
+	pub fn get_lines(&self) -> &Vec<ViewLine> {
+		&self.lines
+	}
+
+	pub fn get_max_line_length(&self, start: usize, end: usize) -> usize {
+		let mut max_length = 0;
+		for len in self.line_lengths[start..=end].iter() {
+			if *len > max_length {
+				max_length = *len;
+			}
+		}
+		max_length
+	}
+}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -1,3 +1,4 @@
+mod data;
 #[allow(clippy::module_inception)]
 mod show_commit;
 mod util;

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -6,6 +6,7 @@ pub struct LineSegment {
 	dim: bool,
 	reverse: bool,
 	text: String,
+	length: usize,
 	underline: bool,
 }
 
@@ -16,6 +17,7 @@ impl LineSegment {
 			color: DisplayColor::Normal,
 			reverse: false,
 			dim: false,
+			length: UnicodeSegmentation::graphemes(text, true).count(),
 			underline: false,
 		}
 	}
@@ -26,6 +28,7 @@ impl LineSegment {
 			color,
 			reverse: false,
 			dim: false,
+			length: UnicodeSegmentation::graphemes(text, true).count(),
 			underline: false,
 		}
 	}
@@ -43,8 +46,13 @@ impl LineSegment {
 			color,
 			reverse,
 			dim,
+			length: UnicodeSegmentation::graphemes(text, true).count(),
 			underline,
 		}
+	}
+
+	pub fn get_length(&self) -> usize {
+		self.length
 	}
 
 	pub fn draw(&self, left: usize, max_width: usize, selected: bool, display: &Display) -> (usize, usize) {

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -62,7 +62,7 @@ impl<'v> View<'v> {
 		self.display.refresh();
 	}
 
-	pub fn draw_view_lines(&self, lines: Vec<ViewLine>, top: usize, left: usize, height: usize) {
+	pub fn draw_view_lines(&self, lines: &[ViewLine], top: usize, left: usize, height: usize) {
 		let number_of_lines = lines.len();
 
 		let scroll_indicator_index = get_scroll_position(top, number_of_lines, height);

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -23,6 +23,14 @@ impl ViewLine {
 		}
 	}
 
+	pub fn get_length(&self) -> usize {
+		let mut length = 0;
+		for s in self.segments.iter() {
+			length += s.get_length();
+		}
+		length
+	}
+
 	pub fn set_selected(mut self, selected: bool) -> Self {
 		self.selected = selected;
 		self


### PR DESCRIPTION
This change adds two caches that greatly speed up show commit. The first
is to cache the Unicode lengths so that they do not need to be
calculated for every render. The second is to ensure that the call to
libgit2 for retrieving the commit information is only made once and not
on every render loop. This should reduce the overall render time by
about ten fold.

Closes #167 