### PR TITLE
Fix missing ncursesw in deb build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Highlight of selected line(s) on 256-color terminals
 
 ### Fixed
+- Missing ncursesw dependency listing for deb build
 - Performance issue with show commit
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ copyright = "Tim Oram <dev@mitmaro.ca>"
 license-file = ["LICENSE", "2"]
 extended-description = """\
 Full feature terminal based sequence editor for git interactive rebase. Written in Rust using ncurses."""
-depends = "libncurses5 (>= 6), libgcc1 (>= 1:6), libtinfo5 (>= 6), zlib1g (>= 1:1), libc6 (>= 2)"
+depends = "libncursesw5 (>= 6), libgcc1 (>= 1:6), libtinfo5 (>= 6), zlib1g (>= 1:1), libc6 (>= 2)"
 section = "utility"
 priority = "optional"
 assets = [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Git 1.7.8+. Written in Rust using ncurses.
 ![Git Interactive Rebase Tool](/docs/assets/images/git-interactive-rebase-demo.gif?raw=true)
 
 **This is the documentation for the development build. For the current stable release please use the
-[1.1.0 documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/1.1.0/README.md).**
+[1.1.x documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/1.1.0/README.md).**
 
 ## Install
 


### PR DESCRIPTION
The libncursesw5 dependency was missing and instead was referencing libncurses5 instead.

Closes #170 