### PR TITLE
Fix visual mode set action and swap line bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Missing ncursesw dependency listing for deb build
 - Performance issue with show commit
+- Visual mode index error when changing action or swapping lines
 
 ### Removed
 - Unused `errorColor` configuration

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -111,7 +111,7 @@ impl GitInteractive {
 		}
 
 		let range = if self.selected_line_index <= self.visual_index_start {
-			self.selected_line_index..self.visual_index_start
+			self.selected_line_index..self.visual_index_start + 1
 		}
 		else {
 			self.visual_index_start..self.selected_line_index + 1
@@ -140,7 +140,7 @@ impl GitInteractive {
 		}
 
 		let range = if self.selected_line_index <= self.visual_index_start {
-			self.selected_line_index..self.visual_index_start
+			self.selected_line_index..self.visual_index_start + 1
 		}
 		else {
 			self.visual_index_start..self.selected_line_index + 1
@@ -172,7 +172,7 @@ impl GitInteractive {
 	#[allow(clippy::range_plus_one)]
 	pub fn set_visual_range_action(&mut self, action: Action) {
 		let range = if self.selected_line_index <= self.visual_index_start {
-			self.selected_line_index..self.visual_index_start
+			self.selected_line_index..self.visual_index_start + 1
 		}
 		else {
 			self.visual_index_start..self.selected_line_index + 1


### PR DESCRIPTION
When attempting to set the action or move lines in visual mode where the selected range start is after the range end, the last item in the selected range would not have the action correctly set or be swapped with the other lines.