### PR TITLE
Fix bad usage of unwrap inside is_some

### DIFF
--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -91,8 +91,8 @@ impl<'i> InputHandler<'i> {
 	fn get_next_input(&self) -> PancursesInput {
 		loop {
 			let c = self.display.getch();
-			if c.is_some() {
-				break c.unwrap();
+			if let Some(input) = c {
+				break input;
 			}
 		}
 	}


### PR DESCRIPTION
Clippy caught a new bad code practice with using an unwrap inside of a if is_some block. This can be trivially converted to a if let.