### PR TITLE
Fixed a crash on scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Missing ncursesw dependency listing for deb build
 - Performance issue with show commit
 - Visual mode index error when changing action or swapping lines
+- Fixed crash with scrolling to max length
 
 ### Removed
 - Unused `errorColor` configuration

--- a/src/show_commit/data.rs
+++ b/src/show_commit/data.rs
@@ -140,7 +140,7 @@ impl Data {
 
 	pub fn get_max_line_length(&self, start: usize, end: usize) -> usize {
 		let mut max_length = 0;
-		for len in self.line_lengths[start..=end].iter() {
+		for len in self.line_lengths[start..=end.min(self.line_lengths.len() - 1)].iter() {
 			if *len > max_length {
 				max_length = *len;
 			}


### PR DESCRIPTION
What this PR does:
- Adds a `.min` before indexing line lengths