### PR TITLE
Ignore cognitive complexity for get_input

### DIFF
--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -20,6 +20,7 @@ impl<'i> InputHandler<'i> {
 		}
 	}
 
+	#[allow(clippy::cognitive_complexity)]
 	pub fn get_input(&self) -> Input {
 		let c = self.get_next_input();
 


### PR DESCRIPTION
This function cannot really be simplified any further than it already is.