### PR TITLE
Fix broken colours in Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ Git 1.7.8+. Written in Rust using ncurses.
 
 ### Windows
 
-    git config --global sequence.editor "'C:/path/to/interactive-rebase-tool'"
+#### Standard Command Pompt
+
+    git config --global sequence.editor "'C:/path/to/interactive-rebase-tool.exe'"
+
+#### GitBash
+
+GitBash requires the use of `winpty` in order to work correctly, so to set the editor use:
+
+    git config --global sequence.editor "winpty /c/path/to/interactive-rebase-tool.exe"
+
+#### Notes
+
+Windows before version 10 has [serious rendering issues with saturated darker colors](https://devblogs.microsoft.com/commandline/updating-the-windows-console-colors/),
+such as the blue color, that are completely illegible on modern displays. While it is possible to avoid using the
+saturated colors, a better option is to update the theme using Microsoft's [ColorTool](https://github.com/Microsoft/Terminal/tree/master/src/tools/ColorTool).
 
 ## Usage
 

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -1,82 +1,96 @@
 use crate::config::Theme;
 use crate::display::display_color::DisplayColor;
 use crate::display::Curses;
+use pancurses::chtype;
 
 pub(in crate::display) struct ColorManager {
-	action_break: (i16, i16),
-	action_drop: (i16, i16),
-	action_edit: (i16, i16),
-	action_exec: (i16, i16),
-	action_fixup: (i16, i16),
-	action_pick: (i16, i16),
-	action_reword: (i16, i16),
-	action_squash: (i16, i16),
-	diff_add: (i16, i16),
-	diff_change: (i16, i16),
-	diff_remove: (i16, i16),
-	indicator: (i16, i16),
-	normal: (i16, i16),
+	action_break: (chtype, chtype),
+	action_drop: (chtype, chtype),
+	action_edit: (chtype, chtype),
+	action_exec: (chtype, chtype),
+	action_fixup: (chtype, chtype),
+	action_pick: (chtype, chtype),
+	action_reword: (chtype, chtype),
+	action_squash: (chtype, chtype),
+	diff_add: (chtype, chtype),
+	diff_change: (chtype, chtype),
+	diff_remove: (chtype, chtype),
+	indicator: (chtype, chtype),
+	normal: (chtype, chtype),
 }
 
 impl ColorManager {
 	pub fn new(theme: &Theme, curses: &mut Curses) -> Self {
 		Self {
-			normal: (
-				curses.init_color_pair(theme.color_foreground, theme.color_background),
-				curses.init_color_pair(theme.color_foreground, theme.color_selected_background),
+			normal: curses.register_selectable_color_pairs(
+				theme.color_foreground,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			indicator: (
-				curses.init_color_pair(theme.color_indicator, theme.color_background),
-				curses.init_color_pair(theme.color_indicator, theme.color_selected_background),
+			indicator: curses.register_selectable_color_pairs(
+				theme.color_indicator,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_break: (
-				curses.init_color_pair(theme.color_action_break, theme.color_background),
-				curses.init_color_pair(theme.color_action_break, theme.color_selected_background),
+			action_break: curses.register_selectable_color_pairs(
+				theme.color_action_break,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_drop: (
-				curses.init_color_pair(theme.color_action_drop, theme.color_background),
-				curses.init_color_pair(theme.color_action_drop, theme.color_selected_background),
+			action_drop: curses.register_selectable_color_pairs(
+				theme.color_action_drop,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_edit: (
-				curses.init_color_pair(theme.color_action_edit, theme.color_background),
-				curses.init_color_pair(theme.color_action_edit, theme.color_selected_background),
+			action_edit: curses.register_selectable_color_pairs(
+				theme.color_action_edit,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_exec: (
-				curses.init_color_pair(theme.color_action_exec, theme.color_background),
-				curses.init_color_pair(theme.color_action_exec, theme.color_selected_background),
+			action_exec: curses.register_selectable_color_pairs(
+				theme.color_action_exec,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_fixup: (
-				curses.init_color_pair(theme.color_action_fixup, theme.color_background),
-				curses.init_color_pair(theme.color_action_fixup, theme.color_selected_background),
+			action_fixup: curses.register_selectable_color_pairs(
+				theme.color_action_fixup,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_pick: (
-				curses.init_color_pair(theme.color_action_pick, theme.color_background),
-				curses.init_color_pair(theme.color_action_pick, theme.color_selected_background),
+			action_pick: curses.register_selectable_color_pairs(
+				theme.color_action_pick,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_reword: (
-				curses.init_color_pair(theme.color_action_reword, theme.color_background),
-				curses.init_color_pair(theme.color_action_reword, theme.color_selected_background),
+			action_reword: curses.register_selectable_color_pairs(
+				theme.color_action_reword,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			action_squash: (
-				curses.init_color_pair(theme.color_action_squash, theme.color_background),
-				curses.init_color_pair(theme.color_action_squash, theme.color_selected_background),
+			action_squash: curses.register_selectable_color_pairs(
+				theme.color_action_squash,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			diff_add: (
-				curses.init_color_pair(theme.color_diff_add, theme.color_background),
-				curses.init_color_pair(theme.color_diff_add, theme.color_selected_background),
+			diff_add: curses.register_selectable_color_pairs(
+				theme.color_diff_add,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			diff_change: (
-				curses.init_color_pair(theme.color_diff_change, theme.color_background),
-				curses.init_color_pair(theme.color_diff_change, theme.color_selected_background),
+			diff_change: curses.register_selectable_color_pairs(
+				theme.color_diff_change,
+				theme.color_background,
+				theme.color_selected_background,
 			),
-			diff_remove: (
-				curses.init_color_pair(theme.color_diff_remove, theme.color_background),
-				curses.init_color_pair(theme.color_diff_remove, theme.color_selected_background),
+			diff_remove: curses.register_selectable_color_pairs(
+				theme.color_diff_remove,
+				theme.color_background,
+				theme.color_selected_background,
 			),
 		}
 	}
 
-	pub fn get_color(&self, color: DisplayColor, selected: bool) -> i16 {
+	pub fn get_color(&self, color: DisplayColor, selected: bool) -> chtype {
 		if selected {
 			match color {
 				DisplayColor::ActionBreak => self.action_break.1,

--- a/src/display/curses.rs
+++ b/src/display/curses.rs
@@ -74,12 +74,27 @@ impl Curses {
 		}
 	}
 
-	pub fn init_color_pair(&mut self, foreground: Color, background: Color) -> i16 {
+	fn init_color_pair(&mut self, foreground: Color, background: Color) -> chtype {
 		let index = self.color_pair_index;
 		self.color_pair_index += 1;
 		pancurses::init_pair(index, self.init_color(foreground), self.init_color(background));
 		// curses seems to init a pair for i16 but read with u64
-		pancurses::COLOR_PAIR(index as chtype) as i16
+		pancurses::COLOR_PAIR(index as chtype)
+	}
+
+	pub fn register_selectable_color_pairs(
+		&mut self,
+		foreground: Color,
+		background: Color,
+		selected_background: Color,
+	) -> (chtype, chtype)
+	{
+		let standard_pair = self.init_color_pair(foreground, background);
+		if self.number_of_colors > 16 {
+			return (standard_pair, self.init_color_pair(foreground, selected_background));
+		}
+		// when there is not enough color pairs to support selected
+		(standard_pair, standard_pair)
 	}
 
 	pub fn erase(&self) {

--- a/src/display/display.rs
+++ b/src/display/display.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::display::color_manager::ColorManager;
 use crate::display::display_color::DisplayColor;
 use crate::display::Curses;
-use pancurses::{chtype, Input};
+use pancurses::Input;
 use std::cell::RefCell;
 
 pub struct Display<'d> {
@@ -37,9 +37,7 @@ impl<'d> Display<'d> {
 	}
 
 	pub fn color(&self, color: DisplayColor, selected: bool) {
-		let selected = selected && self.curses.number_of_colors > 8;
-		self.curses
-			.attrset(self.color_manager.get_color(color, selected) as chtype);
+		self.curses.attrset(self.color_manager.get_color(color, selected));
 	}
 
 	pub fn set_style(&self, dim: bool, underline: bool, reverse: bool) {


### PR DESCRIPTION
Fix broken colours in Windows. The cast from the pancurses chtyped to i16 did not work as expected on Windows. This change instead uses the chtype directly. As well, Windows only supports a total of 16 colour pairs and the tool requires over 16 total colour pairs. This is fixed by ensuring over 16 colour pairs instead of 8 pairs.

closes #189 