### PR TITLE
Disable underlining in Windows

### DIFF
--- a/src/display/display.rs
+++ b/src/display/display.rs
@@ -56,7 +56,8 @@ impl<'d> Display<'d> {
 	}
 
 	pub fn set_underline(&self, on: bool) {
-		if on {
+		// Windows uses blue text for underlined words
+		if !cfg!(windows) && on {
 			self.curses.attron(pancurses::A_UNDERLINE);
 		}
 		else {


### PR DESCRIPTION
Windows does not properly support underlining in the terminal and instead it turns the text blue. This change disables underlining for Windows.

closes #191 