### PR TITLE
Cleanup and update linting

### DIFF
--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -6,4 +6,4 @@ set -o pipefail
 
 rustup update stable
 rustup component add clippy --toolchain stable
-cargo +stable clippy --all-features -- -D warnings -A clippy::new_ret_no_self
+cargo +stable clippy --all-features -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-
 mod cli;
 mod commit;
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,7 @@
 #![allow(missing_docs)]
 #![allow(single_use_lifetimes)]
 #![deny(trivial_casts)]
-// TODO enable this linting rule
-#![allow(trivial_numeric_casts)]
+#![deny(trivial_numeric_casts)]
 // TODO enable this linting rule
 #![allow(unreachable_pub)]
 #![deny(unsafe_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,24 @@
+#![deny(warnings)]
+#![deny(anonymous_parameters)]
+#![deny(bare_trait_objects)]
+#![allow(box_pointers)]
+#![allow(elided_lifetimes_in_paths)]
+#![deny(missing_copy_implementations)]
+#![deny(missing_debug_implementations)]
+#![allow(missing_docs)]
+#![allow(single_use_lifetimes)]
+#![deny(trivial_casts)]
+// TODO enable this linting rule
+#![allow(trivial_numeric_casts)]
+// TODO enable this linting rule
+#![allow(unreachable_pub)]
+#![deny(unsafe_code)]
+#![deny(unused_extern_crates)]
+#![deny(unused_import_braces)]
+#![deny(unused_qualifications)]
+#![allow(unused_results)]
+#![deny(variant_size_differences)]
+
 mod cli;
 mod commit;
 mod config;

--- a/src/scroll/scroll_position.rs
+++ b/src/scroll/scroll_position.rs
@@ -12,10 +12,10 @@ impl ScrollPosition {
 	pub fn new(padding: usize, big_scroll: usize, small_scroll: usize) -> Self {
 		Self {
 			big_scroll,
-			left_value: RefCell::new(0 as usize),
+			left_value: RefCell::new(0),
 			padding,
 			small_scroll,
-			top_value: RefCell::new(0 as usize),
+			top_value: RefCell::new(0),
 		}
 	}
 
@@ -59,7 +59,7 @@ impl ScrollPosition {
 	}
 
 	pub fn ensure_cursor_visible(&self, cursor: usize, window_height: usize, lines_length: usize) {
-		let view_height = window_height as usize - self.padding;
+		let view_height = window_height - self.padding;
 
 		let current_value = *self.top_value.borrow();
 
@@ -90,7 +90,7 @@ impl ScrollPosition {
 	}
 
 	fn update_top(&self, scroll_up: bool, window_height: usize, lines_length: usize) {
-		let view_height = window_height as usize - self.padding;
+		let view_height = window_height - self.padding;
 
 		if view_height >= lines_length {
 			self.reset();

--- a/src/show_commit/show_commit.rs
+++ b/src/show_commit/show_commit.rs
@@ -77,7 +77,7 @@ impl ProcessModule for ShowCommit {
 			},
 			Input::Resize => {
 				self.scroll_position
-					.scroll_up(view_height as usize, self.get_commit_stats_length());
+					.scroll_up(view_height, self.get_commit_stats_length());
 			},
 			_ => {
 				result = result.state(State::List(false));


### PR DESCRIPTION
- Remove old Clippy attributes that are no longer used
- Remove disabled Clippy rule that no longer applies
- Enable a host of rustc linting rules that are not enabled by default
- Enable trivial numeric cast and fix code that used a trivial cast