### PR TITLE
Fix right scroll bar cutting character

### DIFF
--- a/src/scroll/scroll_position.rs
+++ b/src/scroll/scroll_position.rs
@@ -45,6 +45,8 @@ impl ScrollPosition {
 	}
 
 	fn set_horizontal_scroll(&self, new_value: usize, view_width: usize, max_line_width: usize) {
+		// shrink view for a possible scroll bar
+		let view_width = view_width - 1;
 		if (new_value + view_width) > max_line_width {
 			if view_width > max_line_width {
 				self.left_value.replace(0);


### PR DESCRIPTION
# What

When the scroll bar was visible the last character of lines would not be visible. This change allows the horizontal scroll cursor to move one further character to support displaying the last character when the scroll bar is displayed.

fixes #213 