### PR TITLE
Fix ANSI colors on MacOS (and others)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install build-essential libncursesw5-dev pkg-config liblzma-dev
       - name: Test
-        run: cargo test
+        run: cargo test -- --test-threads=1
       - name: Build
         run: cargo build --release
       - name: Test Run
@@ -30,7 +30,7 @@ jobs:
         with:
           toolchain: stable
       - name: Test
-        run: cargo test
+        run: cargo test -- --test-threads=1
       - name: Build
         run: cargo build --release
       - name: Test Run
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test
-        run: cargo test --target x86_64-pc-windows-msvc --release
+        run: cargo test --target x86_64-pc-windows-msvc --release -- --test-threads=1
       - name: Build
         run: cargo build --target x86_64-pc-windows-msvc --release
       - name: Test Run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1] - 2020-01-26
+
+### Fixed
+- ANSI color support broken on MacOS ([#219](https://github.com/MitMaro/git-interactive-rebase-tool/issues/219)) 
+
 ## [1.2.0] - 2020-01-11
 
 ### Added
 - Support for 256-color terminals
-- Highlight of selected line(s) on 256-color terminals
-- Full support for external editor
+- Highlight of selected line(s) on 256-color terminals ([#148](https://github.com/MitMaro/git-interactive-rebase-tool/issues/148)
+- Full support for external editor ([#60](https://github.com/MitMaro/git-interactive-rebase-tool/issues/60))
 
 ### Fixed
-- Missing ncursesw dependency listing for deb build
-- Performance issue with show commit
-- Visual mode index error when changing action or swapping lines
+- Missing ncursesw dependency listing for deb build ([#170](https://github.com/MitMaro/git-interactive-rebase-tool/issues/170))
+- Performance issue with show commit ([#167](https://github.com/MitMaro/git-interactive-rebase-tool/issues/167))
+- Visual mode index error when changing action or swapping lines ([195](https://github.com/MitMaro/git-interactive-rebase-tool/issues/195)))
 - Fixed crash with scrolling to max length
-- A empty rebase file now returns a zero exit code
-- External editing loop when an external editor returns an empty file
+- A empty rebase file now returns a zero exit code ([#197](https://github.com/MitMaro/git-interactive-rebase-tool/issues/197))
+- External editing loop when an external editor returns an empty file ([#196](https://github.com/MitMaro/git-interactive-rebase-tool/issues/196))
 
 ### Removed
 - Unused `errorColor` configuration
@@ -105,7 +110,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial project release
 
-[Unreleased]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/1.2.0...HEAD
+[Unreleased]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/0.7.0...1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "git-interactive-rebase-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-interactive-rebase-tool"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Tim Oram <dev@mitmaro.ca>"]
 license = "GPL-3.0-or-later"
 description = "Full feature terminal based sequence editor for git interactive rebase. Written in Rust using ncurses."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Git 1.7.8+. Written in Rust using ncurses.
 ![Git Interactive Rebase Tool](/docs/assets/images/git-interactive-rebase-demo.gif?raw=true)
 
 **This is the documentation for the development build. For the current stable release please use the
-[1.2.x documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/1.2.0/README.md).**
+[1.2.x documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/1.2.1/README.md).**
 
 ## Install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
 
 test_script:
   - if [%APPVEYOR_REPO_TAG%]==[false] (
+      cargo test --target x86_64-pc-windows-msvc -- --test-threads=1 &&
       cargo run --target x86_64-pc-windows-msvc --release -- --version
     )
 

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -8,4 +8,4 @@ rust_version="nightly-2019-09-13"
 
 rustup update "$rust_version"
 rustup component add rustfmt --toolchain "$rust_version"
-cargo +"$rust_version"  fmt --all -- --check
+cargo +"$rust_version" fmt --all -- --check

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -4,5 +4,5 @@ set -e
 set -u
 set -o pipefail
 
-cargo test
-cargo test --release
+cargo test -- --test-threads=1
+cargo test --release -- --test-threads=1

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,6 @@ mod utils;
 use crate::config::theme::Theme;
 use crate::config::utils::{editor_from_env, get_bool, get_color, get_input, get_string, open_git_config};
 use crate::display::color::Color;
-use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
@@ -45,25 +44,29 @@ impl Config {
 		let git_config = open_git_config()?;
 		Ok(Config {
 			theme: Theme {
-				color_foreground: get_color(&git_config, "interactive-rebase-tool.foregroundColor", Color::White)?,
+				color_foreground: get_color(&git_config, "interactive-rebase-tool.foregroundColor", Color::Default)?,
 				color_background: get_color(&git_config, "interactive-rebase-tool.backgroundColor", Color::Default)?,
 				color_selected_background: get_color(
 					&git_config,
 					"interactive-rebase-tool.selectedBackgroundColor",
-					Color::try_from("35,35,40").unwrap(),
+					Color::Index(237),
 				)?,
-				color_indicator: get_color(&git_config, "interactive-rebase-tool.indicatorColor", Color::Cyan)?,
-				color_action_break: get_color(&git_config, "interactive-rebase-tool.breakColor", Color::White)?,
-				color_action_drop: get_color(&git_config, "interactive-rebase-tool.dropColor", Color::Red)?,
-				color_action_edit: get_color(&git_config, "interactive-rebase-tool.editColor", Color::Blue)?,
-				color_action_exec: get_color(&git_config, "interactive-rebase-tool.execColor", Color::White)?,
-				color_action_fixup: get_color(&git_config, "interactive-rebase-tool.fixupColor", Color::Magenta)?,
-				color_action_pick: get_color(&git_config, "interactive-rebase-tool.pickColor", Color::Green)?,
-				color_action_reword: get_color(&git_config, "interactive-rebase-tool.rewordColor", Color::Yellow)?,
-				color_action_squash: get_color(&git_config, "interactive-rebase-tool.squashColor", Color::Cyan)?,
-				color_diff_add: get_color(&git_config, "interactive-rebase-tool.diffAddColor", Color::Green)?,
-				color_diff_change: get_color(&git_config, "interactive-rebase-tool.diffChangeColor", Color::Yellow)?,
-				color_diff_remove: get_color(&git_config, "interactive-rebase-tool.diffRemoveColor", Color::Red)?,
+				color_indicator: get_color(&git_config, "interactive-rebase-tool.indicatorColor", Color::LightCyan)?,
+				color_action_break: get_color(&git_config, "interactive-rebase-tool.breakColor", Color::LightWhite)?,
+				color_action_drop: get_color(&git_config, "interactive-rebase-tool.dropColor", Color::LightRed)?,
+				color_action_edit: get_color(&git_config, "interactive-rebase-tool.editColor", Color::LightBlue)?,
+				color_action_exec: get_color(&git_config, "interactive-rebase-tool.execColor", Color::LightWhite)?,
+				color_action_fixup: get_color(&git_config, "interactive-rebase-tool.fixupColor", Color::LightMagenta)?,
+				color_action_pick: get_color(&git_config, "interactive-rebase-tool.pickColor", Color::LightGreen)?,
+				color_action_reword: get_color(&git_config, "interactive-rebase-tool.rewordColor", Color::LightYellow)?,
+				color_action_squash: get_color(&git_config, "interactive-rebase-tool.squashColor", Color::LightCyan)?,
+				color_diff_add: get_color(&git_config, "interactive-rebase-tool.diffAddColor", Color::LightGreen)?,
+				color_diff_change: get_color(
+					&git_config,
+					"interactive-rebase-tool.diffChangeColor",
+					Color::LightYellow,
+				)?,
+				color_diff_remove: get_color(&git_config, "interactive-rebase-tool.diffRemoveColor", Color::LightRed)?,
 				character_vertical_spacing: get_string(
 					&git_config,
 					"interactive-rebase-tool.verticalSpacingCharacter",

--- a/src/display/color.rs
+++ b/src/display/color.rs
@@ -2,15 +2,24 @@ use std::convert::TryFrom;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum Color {
-	White,
-	Black,
-	Blue,
-	Cyan,
-	Green,
-	Magenta,
-	Red,
-	Yellow,
+	LightWhite,
+	LightBlack,
+	LightBlue,
+	LightCyan,
+	LightGreen,
+	LightMagenta,
+	LightRed,
+	LightYellow,
+	DarkWhite,
+	DarkBlack,
+	DarkBlue,
+	DarkCyan,
+	DarkGreen,
+	DarkMagenta,
+	DarkRed,
+	DarkYellow,
 	Default,
+	Index(i16),
 	RGB { red: i16, green: i16, blue: i16 },
 }
 
@@ -19,34 +28,54 @@ impl TryFrom<&str> for Color {
 
 	fn try_from(s: &str) -> Result<Self, Self::Error> {
 		match s {
-			"black" => Ok(Color::Black),
-			"blue" => Ok(Color::Blue),
-			"cyan" => Ok(Color::Cyan),
-			"green" => Ok(Color::Green),
-			"magenta" => Ok(Color::Magenta),
-			"red" => Ok(Color::Red),
-			"white" => Ok(Color::White),
-			"yellow" => Ok(Color::Yellow),
+			"black" => Ok(Color::LightBlack),
+			"blue" => Ok(Color::LightBlue),
+			"cyan" => Ok(Color::LightCyan),
+			"green" => Ok(Color::LightGreen),
+			"magenta" => Ok(Color::LightMagenta),
+			"red" => Ok(Color::LightRed),
+			"white" => Ok(Color::LightWhite),
+			"yellow" => Ok(Color::LightYellow),
+			"light black" => Ok(Color::LightBlack),
+			"light blue" => Ok(Color::LightBlue),
+			"light cyan" => Ok(Color::LightCyan),
+			"light green" => Ok(Color::LightGreen),
+			"light magenta" => Ok(Color::LightMagenta),
+			"light red" => Ok(Color::LightRed),
+			"light white" => Ok(Color::LightWhite),
+			"light yellow" => Ok(Color::LightYellow),
+			"dark black" => Ok(Color::DarkBlack),
+			"dark blue" => Ok(Color::DarkBlue),
+			"dark cyan" => Ok(Color::DarkCyan),
+			"dark green" => Ok(Color::DarkGreen),
+			"dark magenta" => Ok(Color::DarkMagenta),
+			"dark red" => Ok(Color::DarkRed),
+			"dark white" => Ok(Color::DarkWhite),
+			"dark yellow" => Ok(Color::DarkYellow),
 			"transparent" | "-1" => Ok(Color::Default),
 			_ => {
 				let matches: Vec<&str> = s.split(',').collect();
 
-				if matches.len() == 3 {
-					let red = matches.get(0).unwrap().parse::<i16>().unwrap_or(-1);
-					let green = matches.get(1).unwrap().parse::<i16>().unwrap_or(-1);
-					let blue = matches.get(2).unwrap().parse::<i16>().unwrap_or(-1);
+				match matches.len() {
+					1 => {
+						let color_index = s.parse::<i16>();
+						match color_index {
+							Ok(i) if i >= 0 && i < 256 => Ok(Color::Index(i)),
+							_ => Err(format!("Invalid color value: {}", s)),
+						}
+					},
+					3 => {
+						let red = matches.get(0).unwrap().parse::<i16>().unwrap_or(-1);
+						let green = matches.get(1).unwrap().parse::<i16>().unwrap_or(-1);
+						let blue = matches.get(2).unwrap().parse::<i16>().unwrap_or(-1);
 
-					if red > -1 && green > -1 && blue > -1 && red < 256 && green < 256 && blue < 256 {
-						// values need to be mapped to 0-1000
-						return Ok(Color::RGB {
-							red: ((f64::from(red) / 255.0) * 1000.0) as i16,
-							green: ((f64::from(green) / 255.0) * 1000.0) as i16,
-							blue: ((f64::from(blue) / 255.0) * 1000.0) as i16,
-						});
-					}
-					return Err(format!("Invalid color string: {}. Values must be within 0-255.", s));
+						if red > -1 && green > -1 && blue > -1 && red < 256 && green < 256 && blue < 256 {
+							return Ok(Color::RGB { red, green, blue });
+						}
+						Err(format!("Invalid color string: {}. Values must be within 0-255.", s))
+					},
+					_ => Err(format!("Invalid color value: {}", s)),
 				}
-				Err(format!("Invalid color string: {}", s))
 			},
 		}
 	}
@@ -59,42 +88,131 @@ mod tests {
 
 	#[test]
 	fn action_try_from_str_black() {
-		assert_eq!(Color::try_from("black").unwrap(), Color::Black);
+		assert_eq!(Color::try_from("black").unwrap(), Color::LightBlack);
+	}
+
+	#[test]
+	fn action_try_from_str_light_black() {
+		assert_eq!(Color::try_from("light black").unwrap(), Color::LightBlack);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_black() {
+		assert_eq!(Color::try_from("dark black").unwrap(), Color::DarkBlack);
 	}
 
 	#[test]
 	fn action_try_from_str_blue() {
-		assert_eq!(Color::try_from("blue").unwrap(), Color::Blue);
+		assert_eq!(Color::try_from("blue").unwrap(), Color::LightBlue);
+	}
+
+	#[test]
+	fn action_try_from_str_light_blue() {
+		assert_eq!(Color::try_from("light blue").unwrap(), Color::LightBlue);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_blue() {
+		assert_eq!(Color::try_from("dark blue").unwrap(), Color::DarkBlue);
 	}
 
 	#[test]
 	fn action_try_from_str_cyan() {
-		assert_eq!(Color::try_from("cyan").unwrap(), Color::Cyan);
+		assert_eq!(Color::try_from("cyan").unwrap(), Color::LightCyan);
+	}
+
+	#[test]
+	fn action_try_from_str_light_cyan() {
+		assert_eq!(Color::try_from("light cyan").unwrap(), Color::LightCyan);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_cyan() {
+		assert_eq!(Color::try_from("dark cyan").unwrap(), Color::DarkCyan);
 	}
 
 	#[test]
 	fn action_try_from_str_green() {
-		assert_eq!(Color::try_from("green").unwrap(), Color::Green);
+		assert_eq!(Color::try_from("green").unwrap(), Color::LightGreen);
+	}
+
+	#[test]
+	fn action_try_from_str_light_green() {
+		assert_eq!(Color::try_from("light green").unwrap(), Color::LightGreen);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_green() {
+		assert_eq!(Color::try_from("dark green").unwrap(), Color::DarkGreen);
 	}
 
 	#[test]
 	fn action_try_from_str_magenta() {
-		assert_eq!(Color::try_from("magenta").unwrap(), Color::Magenta);
+		assert_eq!(Color::try_from("magenta").unwrap(), Color::LightMagenta);
+	}
+
+	#[test]
+	fn action_try_from_str_light_magenta() {
+		assert_eq!(Color::try_from("light magenta").unwrap(), Color::LightMagenta);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_magenta() {
+		assert_eq!(Color::try_from("dark magenta").unwrap(), Color::DarkMagenta);
 	}
 
 	#[test]
 	fn action_try_from_str_red() {
-		assert_eq!(Color::try_from("red").unwrap(), Color::Red);
+		assert_eq!(Color::try_from("red").unwrap(), Color::LightRed);
+	}
+
+	#[test]
+	fn action_try_from_str_light_red() {
+		assert_eq!(Color::try_from("light red").unwrap(), Color::LightRed);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_red() {
+		assert_eq!(Color::try_from("dark red").unwrap(), Color::DarkRed);
 	}
 
 	#[test]
 	fn action_try_from_str_white() {
-		assert_eq!(Color::try_from("white").unwrap(), Color::White);
+		assert_eq!(Color::try_from("white").unwrap(), Color::LightWhite);
 	}
 
 	#[test]
 	fn action_try_from_str_yellow() {
-		assert_eq!(Color::try_from("yellow").unwrap(), Color::Yellow);
+		assert_eq!(Color::try_from("yellow").unwrap(), Color::LightYellow);
+	}
+
+	#[test]
+	fn action_try_from_str_light_yellow() {
+		assert_eq!(Color::try_from("light yellow").unwrap(), Color::LightYellow);
+	}
+
+	#[test]
+	fn action_try_from_str_dark_yellow() {
+		assert_eq!(Color::try_from("dark yellow").unwrap(), Color::DarkYellow);
+	}
+
+	#[test]
+	fn action_try_from_color_index_minimum() {
+		assert_eq!(Color::try_from("0").unwrap(), Color::Index(0));
+	}
+
+	#[test]
+	fn action_try_from_color_index_maximum() {
+		assert_eq!(Color::try_from("255").unwrap(), Color::Index(255));
+	}
+
+	#[test]
+	fn action_try_from_color_rgb_color() {
+		assert_eq!(Color::try_from("100,101,102").unwrap(), Color::RGB {
+			red: 100,
+			green: 101,
+			blue: 102
+		});
 	}
 
 	#[test]
@@ -170,7 +288,26 @@ mod tests {
 	}
 
 	#[test]
-	fn action_try_from_str_invalid() {
-		assert_eq!(Color::try_from("invalid").unwrap_err(), "Invalid color string: invalid");
+	fn action_try_from_color_index_invalid_upper_limit() {
+		assert_eq!(Color::try_from("256").unwrap_err(), "Invalid color value: 256");
+	}
+
+	#[test]
+	fn action_try_from_color_index_invalid_lower_limit() {
+		// -1 is transparent/default and a valid value
+		assert_eq!(Color::try_from("-2").unwrap_err(), "Invalid color value: -2");
+	}
+
+	#[test]
+	fn action_try_from_str_invalid_single_value() {
+		assert_eq!(Color::try_from("invalid").unwrap_err(), "Invalid color value: invalid");
+	}
+
+	#[test]
+	fn action_try_from_str_invalid_multiple_value() {
+		assert_eq!(
+			Color::try_from("invalid,invalid").unwrap_err(),
+			"Invalid color value: invalid,invalid"
+		);
 	}
 }

--- a/src/display/color_mode.rs
+++ b/src/display/color_mode.rs
@@ -1,0 +1,79 @@
+use crate::display::color_mode::ColorMode::{EightBit, FourBit, TrueColor};
+
+#[derive(Debug, PartialEq)]
+pub(super) enum ColorMode {
+	TwoTone,
+	ThreeBit,
+	FourBit,
+	EightBit,
+	TrueColor,
+}
+
+impl ColorMode {
+	pub(super) fn has_minimum_four_bit_color(&self) -> bool {
+		*self == FourBit || *self == EightBit || *self == TrueColor
+	}
+
+	pub(super) fn has_true_color(&self) -> bool {
+		*self == TrueColor
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::display::color_mode::ColorMode;
+
+	#[test]
+	fn color_mode_has_minimum_four_bit_color_two_tone() {
+		assert!(!ColorMode::TwoTone.has_minimum_four_bit_color());
+	}
+
+	#[test]
+	fn color_mode_has_minimum_four_bit_color_three_bit() {
+		assert!(!ColorMode::ThreeBit.has_minimum_four_bit_color());
+	}
+
+	#[test]
+	fn color_mode_has_minimum_four_bit_color_four_bit() {
+		assert!(ColorMode::FourBit.has_minimum_four_bit_color());
+	}
+
+	#[test]
+	fn color_mode_has_minimum_four_bit_color_eight_bit() {
+		assert!(ColorMode::EightBit.has_minimum_four_bit_color());
+	}
+
+	#[test]
+	fn color_mode_has_minimum_four_bit_color_true_color() {
+		assert!(ColorMode::TrueColor.has_minimum_four_bit_color());
+	}
+	#[test]
+	fn color_mode_has_true_color_two_tone() {
+		assert!(!ColorMode::TwoTone.has_true_color());
+	}
+
+	#[test]
+	fn color_mode_has_true_color_three_bit() {
+		assert!(!ColorMode::ThreeBit.has_true_color());
+	}
+
+	#[test]
+	fn color_mode_has_true_color_four_bit() {
+		assert!(!ColorMode::FourBit.has_true_color());
+	}
+
+	#[test]
+	fn color_mode_has_true_color_eight_bit() {
+		assert!(!ColorMode::EightBit.has_true_color());
+	}
+
+	#[test]
+	fn color_mode_has_true_color_true_color() {
+		assert!(ColorMode::TrueColor.has_true_color());
+	}
+
+	#[test]
+	fn color_mode_equals_other_color_mode() {
+		assert!(ColorMode::TrueColor == ColorMode::TrueColor);
+	}
+}

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod color;
 mod color_manager;
+mod color_mode;
 pub(crate) mod curses;
 pub(crate) mod display_color;
+mod utils;
 
 use crate::config::Config;
 use crate::display::color_manager::ColorManager;

--- a/src/display/utils.rs
+++ b/src/display/utils.rs
@@ -1,0 +1,218 @@
+use crate::display::color_mode::ColorMode;
+use std::env::var;
+
+pub(super) fn detect_color_mode(number_of_colors: i16) -> ColorMode {
+	// assume 16 colors on Windows
+	if cfg!(windows) {
+		// TODO Windows 10 build 14931 and higher support true color
+		// TODO Windows 10 build 10586 and higher support 256 colors
+		return ColorMode::ThreeBit;
+	}
+
+	// respect COLORTERM being truecolor or 24bit
+	if let Ok(color_term) = var("COLORTERM") {
+		if color_term == "truecolor" || color_term == "24bit" {
+			return ColorMode::TrueColor;
+		}
+	}
+
+	// VTE based terms should all be setting COLORTERM, but just in case
+	if let Ok(vte_version) = var("VTE_VERSION") {
+		let vte_version = vte_version.parse::<i32>().unwrap_or(0);
+
+		if vte_version >= 3600 {
+			// version 0.36.00
+			return ColorMode::TrueColor;
+		}
+		else if vte_version > 0 {
+			return ColorMode::EightBit;
+		}
+	}
+
+	// Apple has some special cases
+	if let Ok(term_program) = var("TERM_PROGRAM") {
+		// Apple Terminal sometimes pretends to support TrueColor, but it's 8bit
+		// TODO iTerm does support truecolor, but does not support the way that colors are set
+		if term_program == "Apple_Terminal" || term_program == "iTerm.app" {
+			return ColorMode::EightBit;
+		}
+	}
+
+	// Assume terminals with `-256` are 8bit, this is technically what curses does internally
+	if let Ok(term) = var("TERM") {
+		if term.contains("-256") {
+			return ColorMode::EightBit;
+		}
+	}
+
+	// at this point there is no way to detect truecolor support, so the best we can get is 8bit
+	match number_of_colors {
+		n if n >= 256 => ColorMode::EightBit,
+		n if n >= 16 => ColorMode::FourBit,
+		n if n >= 8 => ColorMode::ThreeBit,
+		_ => ColorMode::TwoTone,
+	}
+}
+
+#[cfg(all(windows, test))]
+mod tests {
+	use crate::display::color_mode::ColorMode;
+	use crate::display::utils::detect_color_mode;
+
+	#[test]
+	fn detect_color_mode_windows() {
+		assert_eq!(detect_color_mode(2), ColorMode::ThreeBit);
+	}
+}
+
+#[cfg(all(unix, test))]
+mod tests {
+	use crate::display::color_mode::ColorMode;
+	use crate::display::utils::detect_color_mode;
+	use std::env::{remove_var, set_var};
+
+	fn clear_env() {
+		remove_var("COLORTERM");
+		remove_var("VTE_VERSION");
+		remove_var("TERM_PROGRAM");
+		remove_var("TERM");
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_2_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(2), ColorMode::TwoTone);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_8_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(8), ColorMode::ThreeBit);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_less_8_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(7), ColorMode::TwoTone);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_16_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(16), ColorMode::FourBit);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_less_16_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(15), ColorMode::ThreeBit);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_256_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(256), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_less_256_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(255), ColorMode::FourBit);
+	}
+
+	#[test]
+	fn detect_color_mode_no_env_more_256_colors() {
+		clear_env();
+		assert_eq!(detect_color_mode(257), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_term_env_no_256() {
+		clear_env();
+		set_var("TERM", "XTERM");
+		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+	}
+
+	#[test]
+	fn detect_color_mode_term_env_with_256() {
+		clear_env();
+		set_var("TERM", "XTERM-256");
+		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_term_program_env_apple_terminal() {
+		clear_env();
+		set_var("TERM_PROGRAM", "Apple_Terminal");
+		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_term_program_env_iterm() {
+		clear_env();
+		set_var("TERM_PROGRAM", "iTerm.app");
+		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_term_program_env_other() {
+		clear_env();
+		set_var("TERM_PROGRAM", "other");
+		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+	}
+
+	#[test]
+	fn detect_color_mode_vte_version_0_36_00() {
+		clear_env();
+		set_var("VTE_VERSION", "3600");
+		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+	}
+
+	#[test]
+	fn detect_color_mode_vte_version_greater_0_36_00() {
+		clear_env();
+		set_var("VTE_VERSION", "3601");
+		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+	}
+
+	#[test]
+	fn detect_color_mode_vte_version_less_0_36_00() {
+		clear_env();
+		set_var("VTE_VERSION", "1");
+		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+	}
+
+	#[test]
+	fn detect_color_mode_vte_version_0() {
+		clear_env();
+		set_var("VTE_VERSION", "0");
+		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+	}
+	#[test]
+	fn detect_color_mode_vte_version_invalid() {
+		clear_env();
+		set_var("VTE_VERSION", "invalid");
+		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+	}
+
+	#[test]
+	fn detect_color_mode_colorterm_env_is_truecolor() {
+		clear_env();
+		set_var("COLORTERM", "truecolor");
+		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+	}
+
+	#[test]
+	fn detect_color_mode_colorterm_env_is_24bit() {
+		clear_env();
+		set_var("COLORTERM", "24bit");
+		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+	}
+
+	#[test]
+	fn detect_color_mode_colorterm_env_is_other() {
+		clear_env();
+		set_var("COLORTERM", "other");
+		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+	}
+}

--- a/src/external_editor/argument_tolkenizer.rs
+++ b/src/external_editor/argument_tolkenizer.rs
@@ -18,7 +18,6 @@ pub(super) fn tolkenize(input: &str) -> Option<Vec<String>> {
 
 	let mut tokens = vec![];
 	for (i, c) in input.chars().enumerate() {
-		// 		eprintln!("'{}' '{}'", i, c);
 		match state {
 			State::Normal => {
 				if c == '\\' {


### PR DESCRIPTION
# Description

The version of curses that is used on Unix like systems does not properly support truecolor. Because of this, existing colour codes indexes were being overwritten to provide support for arbitrary custom colours. This worked fine in the terminal emulators tested on Linux, as the colours were reset back to their originals when the tool exited. However, on MacOS, the colour changes would remain after the tool exited, until the terminal was restarted.

To fix this, in terminals that do not support overwriting colours, a provided colour triplet will be matched against the closest ANSI indexed colour.

fixes #219 


### Fresh Terminal

![girt-before](https://user-images.githubusercontent.com/177427/73145686-943dd980-4089-11ea-889c-467e8efbd21a.png)

### Current Master

![girt-master-bug](https://user-images.githubusercontent.com/177427/73145703-a750a980-4089-11ea-9705-9a4766e22894.png)

### With this PR

![girt-colors-okay](https://user-images.githubusercontent.com/177427/73145710-b33c6b80-4089-11ea-9b37-7429db24e00f.png)

