### PR TITLE
Run environment variable based test in one thread

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install build-essential libncursesw5-dev pkg-config liblzma-dev
       - name: Test
-        run: cargo test -- --test-threads=1
+        run: cargo test --
       - name: Build
         run: cargo build --release
       - name: Test Run
@@ -30,7 +30,7 @@ jobs:
         with:
           toolchain: stable
       - name: Test
-        run: cargo test -- --test-threads=1
+        run: cargo test --
       - name: Build
         run: cargo build --release
       - name: Test Run
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test
-        run: cargo test --target x86_64-pc-windows-msvc --release -- --test-threads=1
+        run: cargo test --target x86_64-pc-windows-msvc --release --
       - name: Build
         run: cargo build --target x86_64-pc-windows-msvc --release
       - name: Test Run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -58,6 +58,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "git-interactive-rebase-tool"
 version = "1.2.1"
 dependencies = [
@@ -65,6 +73,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial_test 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -74,7 +83,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,8 +100,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
-version = "0.2.48"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -101,7 +115,7 @@ version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -112,9 +126,17 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -136,7 +158,7 @@ version = "5.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -158,11 +180,35 @@ name = "pancurses"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ncurses 5.98.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdcurses-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,7 +217,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,6 +231,22 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +257,52 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serial_test"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial_test_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -211,11 +319,21 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syn"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -233,7 +351,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -262,6 +380,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -332,24 +455,38 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+"checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum ncurses 5.98.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ddf9a2b0b4526dc8c5a57c859b0f4415b7b3258c487aaa11e07fbde2877744d"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d3058bc37c433096b2ac7afef1c5cdfae49ede0a4ffec3dfc1df1df0959d0ff0"
+"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum pdcurses-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90e12bfe55b7080fdfa0742f7a22ce7d5d1da250ca064ae6b81c843a2084fa2a"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serial_test 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f74862f16557830c73deefde614c906f8af0157e064b64f156e32a0b12d7114c"
+"checksum serial_test_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c188479c8b700998829c168d7a4c21032660b0dd2ed87a0b166c85811750740"
 "checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -357,6 +494,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ version = "0.7.2"
 default-features = false
 features = []
 
+[dev-dependencies]
+serial_test = "*"
+
 [features]
 default = []
 nightly = []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
 
 test_script:
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo test --target x86_64-pc-windows-msvc -- --test-threads=1 &&
+      cargo test --target x86_64-pc-windows-msvc -- &&
       cargo run --target x86_64-pc-windows-msvc --release -- --version
     )
 

--- a/scripts/build-debian.bash
+++ b/scripts/build-debian.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-set -u
-set -o pipefail
-
-cargo build --release

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -4,5 +4,4 @@ set -e
 set -u
 set -o pipefail
 
-cargo test -- --test-threads=1
-cargo test --release -- --test-threads=1
+cargo test --

--- a/src/commit/utils.rs
+++ b/src/commit/utils.rs
@@ -83,6 +83,7 @@ mod tests {
 	// we test what is possible
 	use crate::commit::utils::load_commit_state;
 	use git2::Delta;
+	use serial_test::serial;
 	use std::env::set_var;
 	use std::path::Path;
 
@@ -99,6 +100,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_hash() {
 		set_git_dir("simple");
 		let commit = load_commit_state("18d82dcc4c36cade807d7cf79700b6bbad8080b9").unwrap();
@@ -106,6 +108,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_author() {
 		set_git_dir("simple");
 		let commit = load_commit_state("18d82dcc4c36cade807d7cf79700b6bbad8080b9").unwrap();
@@ -113,6 +116,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_date() {
 		set_git_dir("simple");
 		let commit = load_commit_state("18d82dcc4c36cade807d7cf79700b6bbad8080b9").unwrap();
@@ -120,6 +124,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_body() {
 		set_git_dir("simple");
 		let commit = load_commit_state("18d82dcc4c36cade807d7cf79700b6bbad8080b9").unwrap();
@@ -130,6 +135,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_committer_match_author() {
 		set_git_dir("simple");
 		let commit = load_commit_state("ac950e31a96660e55d8034948b5d9b985c97692d").unwrap();
@@ -137,6 +143,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_committer_not_match_author() {
 		set_git_dir("simple");
 		let commit = load_commit_state("2836dcdcbd040f9157652dd3db0d584a44d4793d").unwrap();
@@ -147,6 +154,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_modified_file() {
 		set_git_dir("simple");
 		let commit = load_commit_state("1cc0456637cb220155e957c641f483e60724c581").unwrap();
@@ -157,6 +165,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_added_file() {
 		set_git_dir("simple");
 		let commit = load_commit_state("c1ac7f2c32f9e00012f409572d223c9457ae497b").unwrap();
@@ -167,6 +176,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_deleted_file() {
 		set_git_dir("simple");
 		let commit = load_commit_state("d85479638307e4db37e1f1f2c3c807f7ff36a0ff").unwrap();
@@ -177,6 +187,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_renamed_file() {
 		set_git_dir("simple");
 		let commit = load_commit_state("aed0fd1db3e73c0e568677ae8903a11c5fbc5659").unwrap();
@@ -188,6 +199,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn commit_utils_load_commit_state_load_copied_file() {
 		set_git_dir("simple");
 		let commit = load_commit_state("c028f42bdb2a5a9f80adea23d95eb240b994a6c2").unwrap();

--- a/src/display/utils.rs
+++ b/src/display/utils.rs
@@ -69,6 +69,7 @@ mod tests {
 mod tests {
 	use crate::display::color_mode::ColorMode;
 	use crate::display::utils::detect_color_mode;
+	use serial_test::serial;
 	use std::env::{remove_var, set_var};
 
 	fn clear_env() {
@@ -79,54 +80,63 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_2_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(2), ColorMode::TwoTone);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_8_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(8), ColorMode::ThreeBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_less_8_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(7), ColorMode::TwoTone);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_16_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(16), ColorMode::FourBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_less_16_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(15), ColorMode::ThreeBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_256_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(256), ColorMode::EightBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_less_256_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(255), ColorMode::FourBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_no_env_more_256_colors() {
 		clear_env();
 		assert_eq!(detect_color_mode(257), ColorMode::EightBit);
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_term_env_no_256() {
 		clear_env();
 		set_var("TERM", "XTERM");
@@ -134,6 +144,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_term_env_with_256() {
 		clear_env();
 		set_var("TERM", "XTERM-256");
@@ -141,6 +152,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_term_program_env_apple_terminal() {
 		clear_env();
 		set_var("TERM_PROGRAM", "Apple_Terminal");
@@ -148,6 +160,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_term_program_env_iterm() {
 		clear_env();
 		set_var("TERM_PROGRAM", "iTerm.app");
@@ -155,6 +168,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_term_program_env_other() {
 		clear_env();
 		set_var("TERM_PROGRAM", "other");
@@ -162,6 +176,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_vte_version_0_36_00() {
 		clear_env();
 		set_var("VTE_VERSION", "3600");
@@ -169,6 +184,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_vte_version_greater_0_36_00() {
 		clear_env();
 		set_var("VTE_VERSION", "3601");
@@ -176,6 +192,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_vte_version_less_0_36_00() {
 		clear_env();
 		set_var("VTE_VERSION", "1");
@@ -183,12 +200,14 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_vte_version_0() {
 		clear_env();
 		set_var("VTE_VERSION", "0");
 		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
 	}
 	#[test]
+	#[serial]
 	fn detect_color_mode_vte_version_invalid() {
 		clear_env();
 		set_var("VTE_VERSION", "invalid");
@@ -196,6 +215,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_colorterm_env_is_truecolor() {
 		clear_env();
 		set_var("COLORTERM", "truecolor");
@@ -203,6 +223,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_colorterm_env_is_24bit() {
 		clear_env();
 		set_var("COLORTERM", "24bit");
@@ -210,6 +231,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn detect_color_mode_colorterm_env_is_other() {
 		clear_env();
 		set_var("COLORTERM", "other");


### PR DESCRIPTION
Environment based tests need to be run in a single thread since the environment change may be overwritten by the changes in other threads. This change adds the serial_test attribute library and marks the tests that use environment variables to run serially. The previous attempt of forcing one test thread for all tests has also been reverted.