### PR TITLE
Refactor commit status

### DIFF
--- a/src/commit/file_stat.rs
+++ b/src/commit/file_stat.rs
@@ -1,9 +1,9 @@
-use git2::Delta;
+use crate::commit::status::Status;
 
 /// Represents a file change within a Git repository
 #[derive(Debug, PartialEq)]
 pub(crate) struct FileStat {
-	status: Delta,
+	status: Status,
 	to_name: String,
 	from_name: String,
 }
@@ -13,7 +13,7 @@ impl FileStat {
 	///
 	/// The `from_name` should be the source file name, the `to_name` the destination file name.
 	/// When the file change is not a copy or rename, `from_name` and `to_name` should be equal.
-	pub(super) fn new(from_name: String, to_name: String, status: Delta) -> Self {
+	pub(super) fn new(from_name: String, to_name: String, status: Status) -> Self {
 		FileStat {
 			status,
 			to_name,
@@ -22,7 +22,7 @@ impl FileStat {
 	}
 
 	/// Get the status of this file change
-	pub(crate) fn get_status(&self) -> &Delta {
+	pub(crate) fn get_status(&self) -> &Status {
 		&self.status
 	}
 
@@ -40,12 +40,12 @@ impl FileStat {
 #[cfg(test)]
 mod tests {
 	use crate::commit::file_stat::FileStat;
-	use git2::Delta;
+	use crate::commit::status::Status;
 
 	#[test]
 	fn commit_user_file_stat() {
-		let file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Delta::Renamed);
-		assert_eq!(*file_stat.get_status(), Delta::Renamed);
+		let file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		assert_eq!(*file_stat.get_status(), Status::Renamed);
 		assert_eq!(file_stat.get_from_name(), "/from/path");
 		assert_eq!(file_stat.get_to_name(), "/to/path");
 	}

--- a/src/commit/mod.rs
+++ b/src/commit/mod.rs
@@ -1,4 +1,5 @@
 mod file_stat;
+pub(crate) mod status;
 mod user;
 mod utils;
 

--- a/src/commit/status.rs
+++ b/src/commit/status.rs
@@ -1,0 +1,37 @@
+use git2::Delta;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Status {
+	/// Entry does not exist in old version
+	Added,
+	/// Entry does not exist in new version
+	Deleted,
+	/// Entry content changed between old and new
+	Modified,
+	/// Entry was renamed between old and new
+	Renamed,
+	/// Entry was copied from another old entry
+	Copied,
+	/// Type of entry changed between old and new
+	Typechange,
+	/// Other type of change not normally found in a rebase
+	Other,
+}
+
+impl Status {
+	pub(super) fn new_from_git_delta(delta: Delta) -> Self {
+		match delta {
+			Delta::Added => Status::Added,
+			Delta::Conflicted => Status::Other,
+			Delta::Copied => Status::Copied,
+			Delta::Deleted => Status::Deleted,
+			Delta::Ignored => Status::Other,
+			Delta::Modified => Status::Modified,
+			Delta::Renamed => Status::Renamed,
+			Delta::Typechange => Status::Typechange,
+			Delta::Unmodified => Status::Other,
+			Delta::Unreadable => Status::Other,
+			Delta::Untracked => Status::Other,
+		}
+	}
+}

--- a/src/show_commit/data.rs
+++ b/src/show_commit/data.rs
@@ -121,7 +121,7 @@ impl Data {
 						let stat_to_name = stat.get_to_name();
 						let stat_from_name = stat.get_from_name();
 						let stat_view_line = ViewLine::new(get_stat_item_segments(
-							*stat.get_status(),
+							stat.get_status(),
 							stat_to_name.as_str(),
 							stat_from_name.as_str(),
 							is_full_width,

--- a/src/show_commit/util.rs
+++ b/src/show_commit/util.rs
@@ -1,81 +1,66 @@
+use crate::commit::status::Status;
 use crate::display::display_color::DisplayColor;
 use crate::view::line_segment::LineSegment;
-use git2::Delta;
 
-pub(super) fn get_file_stat_color(status: Delta) -> DisplayColor {
+pub(super) fn get_file_stat_color(status: &Status) -> DisplayColor {
 	match status {
-		Delta::Added => DisplayColor::DiffAddColor,
-		Delta::Copied => DisplayColor::DiffAddColor,
-		Delta::Deleted => DisplayColor::DiffRemoveColor,
-		Delta::Modified => DisplayColor::DiffChangeColor,
-		Delta::Renamed => DisplayColor::DiffChangeColor,
-		Delta::Typechange => DisplayColor::DiffChangeColor,
-
-		// these should never happen in a rebase
-		Delta::Conflicted => DisplayColor::Normal,
-		Delta::Ignored => DisplayColor::Normal,
-		Delta::Unmodified => DisplayColor::Normal,
-		Delta::Unreadable => DisplayColor::Normal,
-		Delta::Untracked => DisplayColor::Normal,
+		Status::Added => DisplayColor::DiffAddColor,
+		Status::Copied => DisplayColor::DiffAddColor,
+		Status::Deleted => DisplayColor::DiffRemoveColor,
+		Status::Modified => DisplayColor::DiffChangeColor,
+		Status::Renamed => DisplayColor::DiffChangeColor,
+		Status::Typechange => DisplayColor::DiffChangeColor,
+		// this should never happen in a rebase
+		Status::Other => DisplayColor::Normal,
 	}
 }
 
-pub(super) fn get_file_stat_abbreviated(status: Delta) -> String {
+pub(super) fn get_file_stat_abbreviated(status: &Status) -> String {
 	match status {
-		Delta::Added => String::from("A "),
-		Delta::Copied => String::from("C "),
-		Delta::Deleted => String::from("D "),
-		Delta::Modified => String::from("M "),
-		Delta::Renamed => String::from("R "),
-		Delta::Typechange => String::from("T "),
-
-		// these should never happen in a rebase
-		Delta::Conflicted => String::from("X "),
-		Delta::Ignored => String::from("X "),
-		Delta::Unmodified => String::from("X "),
-		Delta::Unreadable => String::from("X "),
-		Delta::Untracked => String::from("X "),
+		Status::Added => String::from("A "),
+		Status::Copied => String::from("C "),
+		Status::Deleted => String::from("D "),
+		Status::Modified => String::from("M "),
+		Status::Renamed => String::from("R "),
+		Status::Typechange => String::from("T "),
+		// this should never happen in a rebase
+		Status::Other => String::from("X "),
 	}
 }
 
-pub(super) fn get_file_stat_long(status: Delta) -> String {
+pub(super) fn get_file_stat_long(status: &Status) -> String {
 	match status {
-		Delta::Added => format!("{:>8}: ", "added"),
-		Delta::Copied => format!("{:>8}: ", "copied"),
-		Delta::Deleted => format!("{:>8}: ", "deleted"),
-		Delta::Modified => format!("{:>8}: ", "modified"),
-		Delta::Renamed => format!("{:>8}: ", "renamed"),
-		Delta::Typechange => format!("{:>8}: ", "changed"),
-
-		// these should never happen in a rebase
-		Delta::Conflicted => format!("{:>8}: ", "unknown"),
-		Delta::Ignored => format!("{:>8}: ", "unknown"),
-		Delta::Unmodified => format!("{:>8}: ", "unknown"),
-		Delta::Unreadable => format!("{:>8}: ", "unknown"),
-		Delta::Untracked => format!("{:>8}: ", "unknown"),
+		Status::Added => format!("{:>8}: ", "added"),
+		Status::Copied => format!("{:>8}: ", "copied"),
+		Status::Deleted => format!("{:>8}: ", "deleted"),
+		Status::Modified => format!("{:>8}: ", "modified"),
+		Status::Renamed => format!("{:>8}: ", "renamed"),
+		Status::Typechange => format!("{:>8}: ", "changed"),
+		// this should never happen in a rebase
+		Status::Other => format!("{:>8}: ", "unknown"),
 	}
 }
 
 pub(super) fn get_stat_item_segments(
-	status: Delta,
+	status: &Status,
 	to_name: &str,
 	from_name: &str,
 	is_full_width: bool,
 ) -> Vec<LineSegment>
 {
 	let status_name = if is_full_width {
-		get_file_stat_long(status)
+		get_file_stat_long(&status)
 	}
 	else {
-		get_file_stat_abbreviated(status)
+		get_file_stat_abbreviated(&status)
 	};
 
-	let color = get_file_stat_color(status);
+	let color = get_file_stat_color(&status);
 
 	let to_file_indicator = if is_full_width { " -> " } else { ">" };
 
 	match status {
-		Delta::Copied => {
+		Status::Copied => {
 			vec![
 				LineSegment::new_with_color(status_name.as_str(), color),
 				LineSegment::new_with_color(to_name, DisplayColor::Normal),
@@ -83,7 +68,7 @@ pub(super) fn get_stat_item_segments(
 				LineSegment::new_with_color(from_name, DisplayColor::DiffAddColor),
 			]
 		},
-		Delta::Renamed => {
+		Status::Renamed => {
 			vec![
 				LineSegment::new_with_color(status_name.as_str(), color),
 				LineSegment::new_with_color(to_name, DisplayColor::DiffRemoveColor),


### PR DESCRIPTION
Change the commit status from using the raw `git2::Delta` data structure to use a new `Status` enum.