### PR TITLE
Improve page up/page down support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 2020-03-14
+
+### Added
+- Added page up and down to help view
+- Added page up and down to show commit
+
+### Changed
+- Change page up and page down to scroll half the height of the view area
+
 ## [1.2.1] - 2020-01-26
 
 ### Fixed

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -64,6 +64,12 @@ impl<'h> ProcessModule for Help<'h> {
 			Input::MoveCursorUp => {
 				self.scroll_position.scroll_up(view_height, self.get_help_lines().len());
 			},
+			Input::MoveCursorPageDown => {
+				self.scroll_position.page_down(view_height, self.get_help_lines().len());
+			},
+			Input::MoveCursorPageUp => {
+				self.scroll_position.page_up(view_height, self.get_help_lines().len());
+			},
 			Input::Resize => {
 				self.scroll_position.reset();
 			},
@@ -121,7 +127,7 @@ impl<'h> Help<'h> {
 			normal_mode_help_lines,
 			normal_mode_max_help_line_length,
 			return_state: State::List(false),
-			scroll_position: ScrollPosition::new(3, 6, 3),
+			scroll_position: ScrollPosition::new(3),
 			visual_mode_help_lines,
 			visual_mode_max_help_line_length,
 		}

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -165,7 +165,7 @@ impl<'l> List<'l> {
 			config,
 			normal_footer_compact: get_normal_footer_compact(config),
 			normal_footer_full: get_normal_footer_full(config),
-			scroll_position: ScrollPosition::new(2, 1, 1),
+			scroll_position: ScrollPosition::new(2),
 			state: ListState::Normal,
 			visual_footer_compact: get_visual_footer_compact(config),
 			visual_footer_full: get_visual_footer_full(config),
@@ -188,7 +188,7 @@ impl<'l> List<'l> {
 	{
 		let input = input_handler.get_input();
 		let mut result = HandleInputResultBuilder::new(input);
-		let (view_width, _) = view.get_view_size();
+		let (view_width, view_height) = view.get_view_size();
 		match input {
 			Input::Help => {
 				result = result.help(State::List(false));
@@ -239,8 +239,8 @@ impl<'l> List<'l> {
 			},
 			Input::MoveCursorDown => git_interactive.move_cursor_down(1),
 			Input::MoveCursorUp => git_interactive.move_cursor_up(1),
-			Input::MoveCursorPageDown => git_interactive.move_cursor_down(5),
-			Input::MoveCursorPageUp => git_interactive.move_cursor_up(5),
+			Input::MoveCursorPageDown => git_interactive.move_cursor_down(view_height / 2),
+			Input::MoveCursorPageUp => git_interactive.move_cursor_up(view_height / 2),
 			Input::ToggleVisualMode => {
 				git_interactive.start_visual_mode();
 				self.state = ListState::Visual;
@@ -261,7 +261,7 @@ impl<'l> List<'l> {
 	{
 		let input = input_handler.get_input();
 		let mut result = HandleInputResultBuilder::new(input);
-		let (view_width, _) = view.get_view_size();
+		let (view_width, view_height) = view.get_view_size();
 		match input {
 			Input::Help => {
 				result = result.help(State::List(true));
@@ -298,10 +298,10 @@ impl<'l> List<'l> {
 				git_interactive.move_cursor_up(1);
 			},
 			Input::MoveCursorPageDown => {
-				git_interactive.move_cursor_down(5);
+				git_interactive.move_cursor_down(view_height / 2);
 			},
 			Input::MoveCursorPageUp => {
-				git_interactive.move_cursor_up(5);
+				git_interactive.move_cursor_up(view_height / 2);
 			},
 			Input::ActionDrop => git_interactive.set_visual_range_action(Action::Drop),
 			Input::ActionEdit => git_interactive.set_visual_range_action(Action::Edit),

--- a/src/scroll/scroll_position.rs
+++ b/src/scroll/scroll_position.rs
@@ -1,20 +1,22 @@
 use std::cell::RefCell;
 
+#[derive(Debug, PartialEq)]
+enum ScrollDirection {
+	Up,
+	Down,
+}
+
 pub(crate) struct ScrollPosition {
-	big_scroll: usize,
 	left_value: RefCell<usize>,
 	padding: usize,
-	small_scroll: usize,
 	top_value: RefCell<usize>,
 }
 
 impl ScrollPosition {
-	pub(crate) fn new(padding: usize, big_scroll: usize, small_scroll: usize) -> Self {
+	pub(crate) fn new(padding: usize) -> Self {
 		Self {
-			big_scroll,
 			left_value: RefCell::new(0),
 			padding,
-			small_scroll,
 			top_value: RefCell::new(0),
 		}
 	}
@@ -25,11 +27,19 @@ impl ScrollPosition {
 	}
 
 	pub(crate) fn scroll_up(&self, window_height: usize, lines_length: usize) {
-		self.update_top(true, window_height, lines_length);
+		self.update_top(1, ScrollDirection::Up, window_height, lines_length);
 	}
 
 	pub(crate) fn scroll_down(&self, window_height: usize, lines_length: usize) {
-		self.update_top(false, window_height, lines_length);
+		self.update_top(1, ScrollDirection::Down, window_height, lines_length);
+	}
+
+	pub(crate) fn page_up(&self, window_height: usize, lines_length: usize) {
+		self.update_top(window_height / 2, ScrollDirection::Up, window_height, lines_length);
+	}
+
+	pub(crate) fn page_down(&self, window_height: usize, lines_length: usize) {
+		self.update_top(window_height / 2, ScrollDirection::Down, window_height, lines_length);
 	}
 
 	pub(crate) fn scroll_left(&self, view_width: usize, max_line_width: usize) {
@@ -60,25 +70,22 @@ impl ScrollPosition {
 		}
 	}
 
-	pub(crate) fn ensure_cursor_visible(&self, cursor: usize, window_height: usize, lines_length: usize) {
+	pub(crate) fn ensure_cursor_visible(&self, cursor_position: usize, window_height: usize, lines_length: usize) {
 		let view_height = window_height - self.padding;
 
 		let current_value = *self.top_value.borrow();
 
-		// TODO I think this can be simplified
-		self.top_value.replace(match cursor {
+		self.top_value.replace(match cursor_position {
 			// show all if list is view height is long enough
 			_ if lines_length <= view_height => 0,
 			// last item selected, set top to show bottom of lines
-			s if s >= lines_length - 1 => lines_length - view_height,
+			p if p >= lines_length - 1 => lines_length - view_height,
 			// if on top two of list set top to top of list
-			s if s < 1 => 0,
+			p if p < 1 => 0,
 			// if selected item is hidden above top, shift top up
-			s if s < current_value => s,
-			// if starting scrolling, hide top two
-			s if current_value == 0 && s >= view_height => 1,
+			p if p < current_value => p,
 			// if selected item is hidden below, shift top down
-			s if s >= current_value + view_height => s - view_height + 1,
+			p if p >= current_value + view_height => p - view_height + 1,
 			_ => current_value,
 		});
 	}
@@ -91,7 +98,7 @@ impl ScrollPosition {
 		*self.left_value.borrow()
 	}
 
-	fn update_top(&self, scroll_up: bool, window_height: usize, lines_length: usize) {
+	fn update_top(&self, amount: usize, direction: ScrollDirection, window_height: usize, lines_length: usize) {
 		let view_height = window_height - self.padding;
 
 		if view_height >= lines_length {
@@ -99,15 +106,9 @@ impl ScrollPosition {
 			return;
 		}
 
-		let amount = match view_height {
-			h if h > 20 => self.big_scroll,
-			h if h > 10 => self.small_scroll,
-			_ => 1,
-		};
-
 		let current_value = *self.top_value.borrow();
 
-		if scroll_up {
+		if direction == ScrollDirection::Up {
 			if current_value < amount {
 				self.reset();
 			}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -75,6 +75,14 @@ impl ProcessModule for ShowCommit {
 				self.scroll_position
 					.scroll_up(view_height, self.get_commit_stats_length())
 			},
+			Input::MoveCursorPageDown => {
+				self.scroll_position
+					.page_down(view_height, self.get_commit_stats_length())
+			},
+			Input::MoveCursorPageUp => {
+				self.scroll_position
+					.page_up(view_height, self.get_commit_stats_length())
+			},
 			Input::Resize => {
 				self.scroll_position
 					.scroll_up(view_height, self.get_commit_stats_length());
@@ -117,7 +125,7 @@ impl ShowCommit {
 		Self {
 			commit: None,
 			data: Data::new(),
-			scroll_position: ScrollPosition::new(3, 6, 3),
+			scroll_position: ScrollPosition::new(3),
 		}
 	}
 


### PR DESCRIPTION
# Description

Add page up and down support to the help and show commit views. Also modify the page up and down support to scroll half a view height instead of miscellaneous movements that existed previously.