### PR TITLE
Add support for up key back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added page up and down to help view
 - Added page up and down to show commit
+- Most missing key bindings for special keys
 
 ### Changed
 - Change page up and page down to scroll half the height of the view area

--- a/src/input/utils.rs
+++ b/src/input/utils.rs
@@ -46,6 +46,7 @@ pub(super) fn curses_input_to_string(input: Input) -> String {
 		Input::KeySLeft => String::from("ShiftLeft"),
 		Input::KeySR => String::from("ShiftUp"),
 		Input::KeySRight => String::from("ShiftRight"),
+		Input::KeyUp => String::from("Up"),
 		_ => String::from("Other"),
 	}
 }


### PR DESCRIPTION

The up key was accidentally removed when the other special keys were added. This adds the support for the up key.