### PR TITLE
Refactor and improve view line_segment

### DIFF
--- a/src/display/display_color.rs
+++ b/src/display/display_color.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DisplayColor {
 	ActionBreak,
 	ActionDrop,

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -1,6 +1,24 @@
 use crate::display::display_color::DisplayColor;
-use crate::display::Display;
 use unicode_segmentation::UnicodeSegmentation;
+
+pub(super) struct SegmentPartial {
+	content: String,
+	length: usize,
+}
+
+impl SegmentPartial {
+	fn new(content: String, length: usize) -> Self {
+		Self { content, length }
+	}
+
+	pub(super) fn get_content(&self) -> &str {
+		self.content.as_str()
+	}
+
+	pub(super) fn get_length(&self) -> usize {
+		self.length
+	}
+}
 
 pub(crate) struct LineSegment {
 	color: DisplayColor,
@@ -13,25 +31,11 @@ pub(crate) struct LineSegment {
 
 impl LineSegment {
 	pub(crate) fn new(text: &str) -> Self {
-		Self {
-			text: String::from(text),
-			color: DisplayColor::Normal,
-			reverse: false,
-			dim: false,
-			length: UnicodeSegmentation::graphemes(text, true).count(),
-			underline: false,
-		}
+		Self::new_with_color_and_style(text, DisplayColor::Normal, false, false, false)
 	}
 
 	pub(crate) fn new_with_color(text: &str, color: DisplayColor) -> Self {
-		Self {
-			text: String::from(text),
-			color,
-			reverse: false,
-			dim: false,
-			length: UnicodeSegmentation::graphemes(text, true).count(),
-			underline: false,
-		}
+		Self::new_with_color_and_style(text, color, false, false, false)
 	}
 
 	pub(crate) fn new_with_color_and_style(
@@ -52,29 +56,264 @@ impl LineSegment {
 		}
 	}
 
+	pub(super) fn get_color(&self) -> DisplayColor {
+		self.color
+	}
+
+	pub(super) fn is_dimmed(&self) -> bool {
+		self.dim
+	}
+
+	pub(super) fn is_underlined(&self) -> bool {
+		self.underline
+	}
+
+	pub(super) fn is_reversed(&self) -> bool {
+		self.reverse
+	}
+
 	pub(super) fn get_length(&self) -> usize {
 		self.length
 	}
 
-	pub(super) fn draw(&self, left: usize, max_width: usize, selected: bool, display: &Display) -> (usize, usize) {
-		display.color(self.color, selected);
-		display.set_style(self.dim, self.underline, self.reverse);
+	pub(super) fn get_partial_segment(&self, left: usize, max_width: usize) -> SegmentPartial {
 		let segment_length = UnicodeSegmentation::graphemes(self.text.as_str(), true).count();
 
+		// segment is hidden to the left of the line/scroll
 		if segment_length <= left {
-			(0, segment_length)
+			SegmentPartial::new(String::from(""), 0)
 		}
 		else if segment_length - left >= max_width {
 			let graphemes = UnicodeSegmentation::graphemes(self.text.as_str(), true);
 			let partial_line = graphemes.skip(left).take(max_width).collect::<String>();
-			display.draw_str(partial_line.as_str());
-			(max_width, segment_length)
+			SegmentPartial::new(partial_line, max_width)
 		}
 		else {
 			let graphemes = UnicodeSegmentation::graphemes(self.text.as_str(), true);
 			let partial_line = graphemes.skip(left).collect::<String>();
-			display.draw_str(partial_line.as_str());
-			(segment_length - left, segment_length)
+			SegmentPartial::new(partial_line, segment_length - left)
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::display::display_color::DisplayColor;
+	use crate::view::line_segment::LineSegment;
+
+	#[test]
+	fn line_segment_case_new() {
+		let line_segment = LineSegment::new("D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh");
+
+		assert_eq!(line_segment.get_color(), DisplayColor::Normal);
+		assert_eq!(line_segment.is_dimmed(), false);
+		assert_eq!(line_segment.is_underlined(), false);
+		assert_eq!(line_segment.is_reversed(), false);
+		assert_eq!(line_segment.get_length(), 68);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color() {
+		let line_segment = LineSegment::new_with_color("Árvíztűrő tükörfúrógép", DisplayColor::IndicatorColor);
+
+		assert_eq!(line_segment.get_color(), DisplayColor::IndicatorColor);
+		assert_eq!(line_segment.is_dimmed(), false);
+		assert_eq!(line_segment.is_underlined(), false);
+		assert_eq!(line_segment.is_reversed(), false);
+		assert_eq!(line_segment.get_length(), 22);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color_and_style_all_styles_enabled() {
+		let line_segment = LineSegment::new_with_color_and_style(
+			"Sævör grét áðan því úlpan var ónýt",
+			DisplayColor::IndicatorColor,
+			true,
+			true,
+			true,
+		);
+
+		assert_eq!(line_segment.get_color(), DisplayColor::IndicatorColor);
+		assert_eq!(line_segment.is_dimmed(), true);
+		assert_eq!(line_segment.is_underlined(), true);
+		assert_eq!(line_segment.is_reversed(), true);
+		assert_eq!(line_segment.get_length(), 34);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color_and_style_all_styles_disabled() {
+		let line_segment = LineSegment::new_with_color_and_style(
+			"? דג סקרן שט בים מאוכזב ולפתע מצא לו חברה איך הקליטה",
+			DisplayColor::IndicatorColor,
+			false,
+			false,
+			false,
+		);
+
+		assert_eq!(line_segment.get_color(), DisplayColor::IndicatorColor);
+		assert_eq!(line_segment.is_dimmed(), false);
+		assert_eq!(line_segment.is_underlined(), false);
+		assert_eq!(line_segment.is_reversed(), false);
+		assert_eq!(line_segment.get_length(), 52);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color_and_style_all_styles_dimmed() {
+		let line_segment =
+			LineSegment::new_with_color_and_style("Test String", DisplayColor::IndicatorColor, true, false, false);
+
+		assert_eq!(line_segment.is_dimmed(), true);
+		assert_eq!(line_segment.is_underlined(), false);
+		assert_eq!(line_segment.is_reversed(), false);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color_and_style_all_styles_underlined() {
+		let line_segment =
+			LineSegment::new_with_color_and_style("Test String", DisplayColor::IndicatorColor, false, true, false);
+
+		assert_eq!(line_segment.is_dimmed(), false);
+		assert_eq!(line_segment.is_underlined(), true);
+		assert_eq!(line_segment.is_reversed(), false);
+	}
+
+	#[test]
+	fn line_segment_case_new_with_color_and_style_all_styles_reversed() {
+		let line_segment =
+			LineSegment::new_with_color_and_style("Test String", DisplayColor::IndicatorColor, false, false, true);
+
+		assert_eq!(line_segment.is_dimmed(), false);
+		assert_eq!(line_segment.is_underlined(), false);
+		assert_eq!(line_segment.is_reversed(), true);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_full_segment_exact_fit() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 10);
+
+		assert_eq!(partial.get_content(), "1234567890");
+		assert_eq!(partial.get_length(), 10);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_full_segment_width_one_over() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 11);
+
+		assert_eq!(partial.get_content(), "1234567890");
+		assert_eq!(partial.get_length(), 10);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_one_less() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 9);
+
+		assert_eq!(partial.get_content(), "123456789");
+		assert_eq!(partial.get_length(), 9);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_left_one() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(1, 9);
+
+		assert_eq!(partial.get_content(), "234567890");
+		assert_eq!(partial.get_length(), 9);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_left_middle() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(5, 5);
+
+		assert_eq!(partial.get_content(), "67890");
+		assert_eq!(partial.get_length(), 5);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_left_middle_and_extra_max_width() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(5, 6);
+
+		assert_eq!(partial.get_content(), "67890");
+		assert_eq!(partial.get_length(), 5);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_one_left_in_segment() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(9, 1);
+
+		assert_eq!(partial.get_content(), "0");
+		assert_eq!(partial.get_length(), 1);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_width_one_left_in_segment_with_extra_max_width() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(9, 2);
+
+		assert_eq!(partial.get_content(), "0");
+		assert_eq!(partial.get_length(), 1);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_one_max_width() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 1);
+
+		assert_eq!(partial.get_content(), "1");
+		assert_eq!(partial.get_length(), 1);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_two_max_width() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 2);
+
+		assert_eq!(partial.get_content(), "12");
+		assert_eq!(partial.get_length(), 2);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_no_max_width() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(0, 0);
+
+		assert_eq!(partial.get_content(), "");
+		assert_eq!(partial.get_length(), 0);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_left_at_segment_length() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(10, 1);
+
+		assert_eq!(partial.get_content(), "");
+		assert_eq!(partial.get_length(), 0);
+	}
+
+	#[test]
+	fn line_segment_case_get_partial_segment_partial_segment_left_after_segment_length() {
+		let line_segment = LineSegment::new("1234567890");
+
+		let partial = line_segment.get_partial_segment(11, 1);
+
+		assert_eq!(partial.get_content(), "");
+		assert_eq!(partial.get_length(), 0);
 	}
 }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -80,6 +80,8 @@ impl<'v> View<'v> {
 				self.display.set_style(scroll_indicator_index != index, false, true);
 				self.display.draw_str(" ");
 			}
+			self.display.color(DisplayColor::Normal, false);
+			self.display.set_style(false, false, false);
 			index += 1;
 		}
 
@@ -99,17 +101,23 @@ impl<'v> View<'v> {
 			if i == line.get_number_of_pinned_segment() {
 				left_start = left;
 			}
-			let (amount_drawn, segment_size) =
-				segment.draw(left_start, window_width - start, line.get_selected(), &self.display);
-			start += amount_drawn;
-			if start >= window_width {
-				break;
-			}
-			if amount_drawn > 0 {
+
+			let partial = segment.get_partial_segment(left_start, window_width - start);
+
+			if partial.get_length() > 0 {
+				self.display.color(segment.get_color(), line.get_selected());
+				self.display
+					.set_style(segment.is_dimmed(), segment.is_underlined(), segment.is_reversed());
+				self.display.draw_str(partial.get_content());
+
+				start += partial.get_length();
+				if start >= window_width {
+					break;
+				}
 				left_start = 0;
 			}
 			else {
-				left_start -= segment_size;
+				left_start -= segment.get_length();
 			}
 		}
 


### PR DESCRIPTION
This change updates the line segment struct to return a segment partial
instead of directly drawing the line segment internally. This decouples
the line segment struct from the display module. The functionality for
drawing a line segment to the display has been migrated into the view.

Additionally tests have been added to the line segment struct to ensure
that the partial calculation for the line segment is performing as
expected.