### PR TITLE
Fix GitHub action macos builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         run: "./scripts/format.bash"
   macos:
     name: MacOS
-    runs-on: [macos]
+    runs-on: [macos-latest]
     steps:
       - uses: actions/checkout@v2
       # Install Rust until actions/virtual-environments#6 is resolved

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -37,7 +37,7 @@ jobs:
         run: "./.github/scripts/update-tag.bash"
   macos:
     name: MacOS
-    runs-on: [macos]
+    runs-on: [macos-latest]
     env:
         TARGET_RELEASE_ID: 18843342
         GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build-macos:
-        runs-on: [macos]
+        runs-on: [macos-latest]
         steps:
             - name: "Checkout project"
               uses: actions/checkout@v2


### PR DESCRIPTION
# What

At some point GitHub removed/renamed the macos runs-on value and now it has to be macos-latest. This change renames the value to match the required value for GitHub actions.