### PR TITLE
Fix style not reset on empty line

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -74,6 +74,9 @@ impl<'v> View<'v> {
 		let scroll_indicator_index = get_scroll_position_index(top, number_of_lines, height);
 		let show_scroll_bar = height < number_of_lines;
 
+		self.display.color(DisplayColor::Normal, false);
+		self.display.set_style(false, false, false);
+
 		let mut index: usize = 0;
 		for line in lines.iter().skip(top).take(height) {
 			self.draw_view_line(line, left, show_scroll_bar);


### PR DESCRIPTION
# What

Any styles that are applied before an empty line are kept for the empty line. This resulted in a line with a underline or reversed color where the line should have appeared empty. This change reset the style and color before starting the render of the line segments.

This was introduced with a recent refactor of the line segment rendering.