### PR TITLE
Simplify comment char usage

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -42,6 +42,15 @@ pub(crate) struct Config {
 impl Config {
 	pub(crate) fn new() -> Result<Self, String> {
 		let git_config = open_git_config()?;
+
+		let comment_char = get_string(&git_config, "core.commentChar", "#")?;
+		let comment_char = if comment_char.as_str().eq("auto") {
+			String::from("#")
+		}
+		else {
+			comment_char
+		};
+
 		Ok(Config {
 			theme: Theme {
 				color_foreground: get_color(&git_config, "interactive-rebase-tool.foregroundColor", Color::Default)?,
@@ -74,7 +83,7 @@ impl Config {
 				)?,
 			},
 			auto_select_next: get_bool(&git_config, "interactive-rebase-tool.autoSelectNext", false)?,
-			comment_char: get_string(&git_config, "core.commentChar", "#")?,
+			comment_char,
 			editor: get_string(&git_config, "core.editor", editor_from_env().as_str())?,
 			input_abort: get_input(&git_config, "interactive-rebase-tool.inputAbort", "q")?,
 			input_action_break: get_input(&git_config, "interactive-rebase-tool.inputActionBreak", "b")?,

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -132,7 +132,7 @@ impl<'e> ExternalEditor<'e> {
 
 	fn process_finish(&mut self, git_interactive: &mut GitInteractive) -> ProcessResult {
 		let mut result = ProcessResultBuilder::new();
-		if let Err(e) = git_interactive.reload_file(self.config.comment_char.as_str()) {
+		if let Err(e) = git_interactive.reload_file() {
 			result = result.error(e.as_str(), State::ExternalEditor);
 			self.state = ExternalEditorState::Error;
 		}

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::io::Write;
 use std::path::PathBuf;
 
-fn load_filepath(path: &PathBuf, config_comment_char: &str) -> Result<Vec<Line>, String> {
+fn load_filepath(path: &PathBuf, comment_char: &str) -> Result<Vec<Line>, String> {
 	let mut file = match File::open(&path) {
 		Ok(file) => file,
 		Err(why) => {
@@ -22,13 +22,6 @@ fn load_filepath(path: &PathBuf, config_comment_char: &str) -> Result<Vec<Line>,
 			return Err(format!("Error reading file, {}\nReason: {}", path.display(), why));
 		},
 	}
-	let comment_char = if config_comment_char.eq("auto") {
-		"#"
-	}
-	else {
-		config_comment_char
-	};
-
 	// catch noop rebases
 	s.lines()
 		.filter(|l| !l.starts_with(comment_char) && !l.is_empty())
@@ -46,6 +39,7 @@ pub(crate) struct GitInteractive {
 	lines: Vec<Line>,
 	selected_line_index: usize,
 	visual_index_start: usize,
+	comment_char: String,
 }
 
 impl GitInteractive {
@@ -58,6 +52,7 @@ impl GitInteractive {
 			lines,
 			selected_line_index: 1,
 			visual_index_start: 1,
+			comment_char: String::from(comment_char),
 		})
 	}
 
@@ -83,8 +78,8 @@ impl GitInteractive {
 		Ok(())
 	}
 
-	pub(crate) fn reload_file(&mut self, comment_char: &str) -> Result<(), String> {
-		let lines = load_filepath(&self.filepath, comment_char)?;
+	pub(crate) fn reload_file(&mut self) -> Result<(), String> {
+		let lines = load_filepath(&self.filepath, self.comment_char.as_str())?;
 
 		self.lines = lines;
 		Ok(())


### PR DESCRIPTION
The comment character handling was fairly awkward requiring the value to be modified and passed around when it should not have been needed. This change handles the "auto" value of the comment character within the configuration and internalizes the usage of the comment character when reading the rebase TODO file to the GitInteractive struct.