### PR TITLE
Move load commit to the show commit module

### DIFF
--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -1,4 +1,3 @@
-use crate::commit::Commit;
 use crate::list::action::Action;
 use crate::list::line::Line;
 use std::cmp;
@@ -207,14 +206,6 @@ impl GitInteractive {
 				self.selected_line_index += 1;
 			}
 		}
-	}
-
-	pub(crate) fn load_commit_stats(&self) -> Result<Commit, String> {
-		let selected_action = self.lines[self.selected_line_index - 1].get_action();
-		if *selected_action != Action::Exec && *selected_action != Action::Break {
-			return Ok(Commit::from_commit_hash(self.get_selected_line_hash().as_str())?);
-		}
-		Err(String::from("Cannot load commit for the selected action"))
 	}
 
 	pub(crate) fn is_noop(&self) -> bool {

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -24,7 +24,9 @@ pub(crate) struct ShowCommit {
 
 impl ProcessModule for ShowCommit {
 	fn activate(&mut self, _: State, git_interactive: &GitInteractive) {
-		self.commit = Some(git_interactive.load_commit_stats());
+		self.commit = Some(Commit::from_commit_hash(
+			git_interactive.get_selected_line_hash().as_str(),
+		));
 	}
 
 	fn deactivate(&mut self) {


### PR DESCRIPTION
# Description

The `load_commit_stats` function in the `git_interactive` struct is only used in the show_commit module. This change moves that functionality into that show_commit module where it is needed.