### PR TITLE
Fix list view position reset on module change

### DIFF
--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -45,10 +45,6 @@ pub(crate) struct List<'l> {
 }
 
 impl<'l> ProcessModule for List<'l> {
-	fn deactivate(&mut self) {
-		self.view_data.reset();
-	}
-
 	fn process(&mut self, _: &mut GitInteractive, _: &View) -> ProcessResult {
 		ProcessResult::new()
 	}


### PR DESCRIPTION
# Description

The list view scroll position and data was being reset every time that the module was switched. This removes the reset of the data on deactivate of the list view module.