### PR TITLE
Add diff view to show commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - 2020-03-14
 
 ### Added
+- A diff view to show commit
 - Page up and down to help view
 - Page up and down to show commit
 - Most missing key bindings for special keys
 - Builtin help for show commit
 - Number of files change in show commit
 - Number of total additions and deletions in show commit
-- The Git "diff.renames" and "diff.rename_limit" options are now respected during show commit 
+- The Git "diff.renames" and "diff.rename_limit" options are now respected during show commit
 
 ### Changed
 - Change page up and page down to scroll half the height of the view area

--- a/README.md
+++ b/README.md
@@ -110,32 +110,58 @@ git config --global interactive-rebase-tool.foregroundColor black
 
 Some values from your Git Config are directly used by this application.
 
-| Key                                   | Description |
-| ------------------------------------- | ----------- |
-| [`core.commentChar`][coreCommentChar] | Read when reading the TODO file to excluded commented lines |
-| [`core.editor`][coreEditor]           | Read when deciding what editor to open when trigger the external editor |
-| [`diff.renames`][diffRenames]         | Used by show commit when generating a diff |
-| [`diff.renameLimit`][diffRenameLimit] | Used by show commit when generating a diff |
+| Key                                          | Description |
+| -------------------------------------------- | ----------- |
+| [`core.commentChar`][coreCommentChar]        | Read when reading the TODO file to excluded commented lines |
+| [`core.editor`][coreEditor]                  | Read when deciding what editor to open when trigger the external editor |
+| [`diff.context`][diffContext]                | Used by show commit when generating a diff |
+| [`diff.interhunk_lines`][diffInterhunkLines] | Used by show commit when generating a diff |
+| [`diff.renameLimit`][diffRenameLimit]        | Used by show commit when generating a diff |
+| [`diff.renames`][diffRenames]                | Used by show commit when generating a diff |
 
 [coreCommentChar]:https://git-scm.com/docs/git-config#Documentation/git-config.txt-corecommentChar
 [coreEditor]:https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeditor
-[diffRenames]:https://git-scm.com/docs/diff-config/#Documentation/diff-config.txt-diffrenames
+[diffContext]:https://git-scm.com/docs/diff-config/#Documentation/diff-config.txt-diffcontext
+[diffInterhunkLines]:https://git-scm.com/docs/diff-config/#Documentation/diff-config.txt-diffinterHunkContext
 [diffRenameLimit]:https://git-scm.com/docs/diff-config/#Documentation/diff-config.txt-diffrenameLimit
+[diffRenames]:https://git-scm.com/docs/diff-config/#Documentation/diff-config.txt-diffrenames
 
 #### General
 
-| Key                        | Default | Type   | Description |
-| -------------------------- | ------- | ------ | ----------- |
-| `autoSelectNext`           | false   | bool   | If true, auto select the next line after action modification |
-| `verticalSpacingCharacter` | ~       | String | Vertical spacing character. Can be set to an empty string. |
+| Key                        | Default | Type    | Description |
+| -------------------------- | ------- | ------- | ----------- |
+| `autoSelectNext`           | false   | bool    | If true, auto select the next line after action modification |
+| `diffIgnoreWhitespace`     | none    | String¹ | The width of the tab character |
+| `diffShowWhitespace`       | both    | String² | The width of the tab character |
+| `diffSpaceSymbol`          | ·       | String  | The visible symbol for the space character. Only used when `diffShowWhitespace` is enabled. |
+| `diffTabSymbol`            | →       | String  | The visible symbol for the tab character. Only used when `diffShowWhitespace` is enabled. |
+| `diffTabWidth`             | 4       | Integer | The width of the tab character |
+| `verticalSpacingCharacter` | ~       | String  | Vertical spacing character. Can be set to an empty string. |
+
+¹ Ignore whitespace can be:
+- `change` to ignore changed whitespace in diffs, same as the [`--ignore-space-change`][diffIgnoreSpaceChange] flag
+- `true`, `on` or `all` to ignore all whitespace in diffs, same as the [`--ignore-all-space`][diffIgnoreAllSpace] flag
+- `false`, `off`, `none` to not ignore whitespace in diffs
+
+² Show whitespace can be:
+- `leading` to show leading whitespace only
+- `trailing` to show trailing whitespace only
+- `true`, `on` or `both` to show both leading and trailing whitespace
+- `false`, `off`, `none` to show no whitespace
+
+[diffIgnoreSpaceChange]:https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---ignore-space-change
+[diffIgnoreAllSpace]:https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---ignore-all-space
 
 #### Colors
 
 The valid colors are the [eight original 8 ANSI colors][ANSIColors]. They are `black`, `blue`, `cyan`, `green`,
-`magenta`, `red`, `white` and `yellow`. Each terminal controls the exact color for these color names. On terminals that
+`magenta`, `red`, `white` and `yellow`. Dimmed versions of the 8 ANSI colors colors can be used by prefixing the color
+ with `dark`, for example `dark red`. Each terminal controls the exact color for these color names. On terminals that
 support 256 colors, a color triplet with the format `<red>,<green>,<blue>` can be used. Each color has a range of 0 to
 255 with `255, 255, 255` resulting in white and `0,0,0` resulting in black. A value of `-1` or `transparent` can be used
 to use the default terminal color.
+
+[ANSIColors]:https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit
 
 | Key                       | Default  | Type  | Description |
 | ------------------------- | -------- | ----- | ----------- |
@@ -143,6 +169,8 @@ to use the default terminal color.
 | `diffAddColor`            | green    | Color | Color used for lines and files added in a diff |
 | `diffChangeColor`         | yellow   | Color | Color used for lines and files changed in a diff |
 | `diffRemoveColor`         | red      | Color | Color used for lines and files removed in a diff |
+| `diffContextColor`        | white    | Color | Color used for lines and files removed in a diff |
+| `diffWhitespace`          | black    | Color | Color used for lines and files removed in a diff |
 | `dropColor`               | red      | Color | Color used for the drop action |
 | `editColor`               | blue     | Color | Color used for the edit action |
 | `fixupColor`              | magenta  | Color | Color used for the fixup action |
@@ -181,7 +209,8 @@ to use the default terminal color.
 | `inputMoveUp`              | Up       | String | Key for moving the cursor up |
 | `inputOpenInExternalEditor`| !        | String | Key for opening the external editor |
 | `inputRebase`              | w        | String | Key for rebasing with confirmation |
-| `inputShowCommit`          | c        | String | Key for showing the selected commit |
+| `inputShowCommit`          | c        | String | Key for showing the overview of the selected commit |
+| `inputShowDiff`            | d        | String | Key for showing the diff of the selected commit |
 | `inputToggleVisualMode`    | v        | String | Key for toggling visual mode |
 
 ##### Changing Key Bindings
@@ -321,7 +350,6 @@ Git Interactive Rebase Tool is released under the GPLv3 license. See [LICENSE](L
 
 See [Third Party Licenses](THIRD_PARTY_LICENSES) for licenses for third-party libraries used by this project.
 
-[ANSIColors]:https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit
 [appveyor-build]:https://ci.appveyor.com/project/MitMaro/git-interactive-rebase-tool/branch/master
 [cargo]:https://github.com/rust-lang/cargo
 [crates-io]:https://crates.io/crates/git-interactive-rebase-tool

--- a/src/config/diff_ignore_whitespace_setting.rs
+++ b/src/config/diff_ignore_whitespace_setting.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) enum DiffIgnoreWhitespaceSetting {
+	None,
+	All,
+	Change,
+}

--- a/src/config/diff_show_whitespace_setting.rs
+++ b/src/config/diff_show_whitespace_setting.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) enum DiffShowWhitespaceSetting {
+	None,
+	Trailing,
+	Leading,
+	Both,
+}

--- a/src/config/git_config.rs
+++ b/src/config/git_config.rs
@@ -4,6 +4,8 @@ use git2::Config;
 #[derive(Clone, Debug)]
 pub(crate) struct GitConfig {
 	pub(crate) comment_char: String,
+	pub(crate) diff_context: u32,
+	pub(crate) diff_interhunk_lines: u32,
 	pub(crate) diff_rename_limit: u32,
 	pub(crate) diff_renames: bool,
 	pub(crate) diff_copies: bool,
@@ -20,12 +22,14 @@ impl GitConfig {
 			comment_char
 		};
 
-		let git_diff_renames = get_string(&git_config, "diff.renames", "true")?;
+		let git_diff_renames = get_string(&git_config, "diff.renames", "true")?.to_lowercase();
 		let diff_renames = git_diff_renames.as_str() != "false";
 		let diff_copies = git_diff_renames.as_str() == "copy" || git_diff_renames.as_str() == "copies";
 
 		Ok(Self {
 			comment_char,
+			diff_context: get_unsigned_integer(&git_config, "diff.context", 3)?,
+			diff_interhunk_lines: get_unsigned_integer(&git_config, "diff.interHunkContext", 0)?,
 			diff_rename_limit: get_unsigned_integer(&git_config, "diff.renameLimit", 200)?,
 			diff_renames,
 			diff_copies,

--- a/src/config/key_bindings.rs
+++ b/src/config/key_bindings.rs
@@ -28,6 +28,7 @@ pub(crate) struct KeyBindings {
 	pub(crate) open_in_external_editor: String,
 	pub(crate) rebase: String,
 	pub(crate) show_commit: String,
+	pub(crate) show_diff: String,
 	pub(crate) toggle_visual_mode: String,
 }
 
@@ -59,6 +60,7 @@ impl KeyBindings {
 			open_in_external_editor: get_input(&git_config, "interactive-rebase-tool.inputOpenInExternalEditor", "!")?,
 			rebase: get_input(&git_config, "interactive-rebase-tool.inputRebase", "w")?,
 			show_commit: get_input(&git_config, "interactive-rebase-tool.inputShowCommit", "c")?,
+			show_diff: get_input(&git_config, "interactive-rebase-tool.inputShowDiff", "d")?,
 			toggle_visual_mode: get_input(&git_config, "interactive-rebase-tool.inputToggleVisualMode", "v")?,
 		})
 	}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,16 +1,32 @@
+pub(crate) mod diff_ignore_whitespace_setting;
+pub(crate) mod diff_show_whitespace_setting;
 pub(crate) mod git_config;
 pub(crate) mod key_bindings;
 pub(crate) mod theme;
 mod utils;
 
+use crate::config::diff_ignore_whitespace_setting::DiffIgnoreWhitespaceSetting;
+use crate::config::diff_show_whitespace_setting::DiffShowWhitespaceSetting;
 use crate::config::git_config::GitConfig;
 use crate::config::key_bindings::KeyBindings;
 use crate::config::theme::Theme;
-use crate::config::utils::{get_bool, open_git_config};
+use crate::config::utils::{
+	get_bool,
+	get_diff_ignore_whitespace,
+	get_diff_show_whitespace,
+	get_string,
+	get_unsigned_integer,
+	open_git_config,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
 	pub(crate) auto_select_next: bool,
+	pub(crate) diff_ignore_whitespace: DiffIgnoreWhitespaceSetting,
+	pub(crate) diff_show_whitespace: DiffShowWhitespaceSetting,
+	pub(crate) diff_tab_width: u32,
+	pub(crate) diff_tab_symbol: String,
+	pub(crate) diff_space_symbol: String,
 	pub(crate) git: GitConfig,
 	pub(crate) key_bindings: KeyBindings,
 	pub(crate) theme: Theme,
@@ -22,6 +38,11 @@ impl Config {
 
 		Ok(Config {
 			auto_select_next: get_bool(&git_config, "interactive-rebase-tool.autoSelectNext", false)?,
+			diff_ignore_whitespace: get_diff_ignore_whitespace(&git_config)?,
+			diff_show_whitespace: get_diff_show_whitespace(&git_config)?,
+			diff_tab_width: get_unsigned_integer(&git_config, "interactive-rebase-tool.diffTabWidth", 4)?,
+			diff_tab_symbol: get_string(&git_config, "interactive-rebase-tool.diffTabSymbol", "→")?,
+			diff_space_symbol: get_string(&git_config, "interactive-rebase-tool.diffSpaceSymbol", "·")?,
 			git: GitConfig::new(&git_config)?,
 			key_bindings: KeyBindings::new(&git_config)?,
 			theme: Theme::new(&git_config)?,

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -19,6 +19,8 @@ pub(crate) struct Theme {
 	pub(crate) color_diff_add: Color,
 	pub(crate) color_diff_change: Color,
 	pub(crate) color_diff_remove: Color,
+	pub(crate) color_diff_context: Color,
+	pub(crate) color_diff_whitespace: Color,
 	pub(crate) character_vertical_spacing: String,
 }
 
@@ -48,6 +50,12 @@ impl Theme {
 				Color::LightYellow,
 			)?,
 			color_diff_remove: get_color(&git_config, "interactive-rebase-tool.diffRemoveColor", Color::LightRed)?,
+			color_diff_context: get_color(
+				&git_config,
+				"interactive-rebase-tool.diffContextColor",
+				Color::LightWhite,
+			)?,
+			color_diff_whitespace: get_color(&git_config, "interactive-rebase-tool.diffWhitespace", Color::LightBlack)?,
 			character_vertical_spacing: get_string(
 				&git_config,
 				"interactive-rebase-tool.verticalSpacingCharacter",

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -1,3 +1,5 @@
+use crate::config::diff_ignore_whitespace_setting::DiffIgnoreWhitespaceSetting;
+use crate::config::diff_show_whitespace_setting::DiffShowWhitespaceSetting;
 use crate::display::color::Color;
 use git2::Config;
 use std::convert::TryFrom;
@@ -103,5 +105,38 @@ pub(super) fn open_git_config() -> Result<Config, String> {
 			}
 		},
 		Err(e) => Err(format!("Error reading git config: {}", e)),
+	}
+}
+
+pub(super) fn get_diff_show_whitespace(git_config: &Config) -> Result<DiffShowWhitespaceSetting, String> {
+	let diff_show_whitespace = get_string(git_config, "interactive-rebase-tool.diffShowWhitespace", "both")?;
+
+	match diff_show_whitespace.to_lowercase().as_str() {
+		"true" | "on" | "both" => Ok(DiffShowWhitespaceSetting::Both),
+		"trailing" => Ok(DiffShowWhitespaceSetting::Trailing),
+		"leading" => Ok(DiffShowWhitespaceSetting::Leading),
+		"false" | "off" | "none" => Ok(DiffShowWhitespaceSetting::None),
+		_ => {
+			Err(format!(
+				"Error reading git config: {} is invalid for \"interactive-rebase-tool.diffShowWhitespace\"",
+				diff_show_whitespace
+			))
+		},
+	}
+}
+
+pub(super) fn get_diff_ignore_whitespace(git_config: &Config) -> Result<DiffIgnoreWhitespaceSetting, String> {
+	let diff_ignore_whitespace = get_string(git_config, "interactive-rebase-tool.diffIgnoreWhitespace", "none")?;
+
+	match diff_ignore_whitespace.to_lowercase().as_str() {
+		"true" | "on" | "all" => Ok(DiffIgnoreWhitespaceSetting::All),
+		"change" => Ok(DiffIgnoreWhitespaceSetting::Change),
+		"false" | "off" | "none" => Ok(DiffIgnoreWhitespaceSetting::None),
+		_ => {
+			Err(format!(
+				"Error reading git config: {} is invalid for \"interactive-rebase-tool.diffIgnoreWhitespace\"",
+				diff_ignore_whitespace
+			))
+		},
 	}
 }

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -15,6 +15,8 @@ pub(super) struct ColorManager {
 	diff_add: (chtype, chtype),
 	diff_change: (chtype, chtype),
 	diff_remove: (chtype, chtype),
+	diff_context: (chtype, chtype),
+	diff_whitespace: (chtype, chtype),
 	indicator: (chtype, chtype),
 	normal: (chtype, chtype),
 }
@@ -87,6 +89,16 @@ impl ColorManager {
 				theme.color_background,
 				theme.color_selected_background,
 			),
+			diff_context: curses.register_selectable_color_pairs(
+				theme.color_diff_context,
+				theme.color_background,
+				theme.color_selected_background,
+			),
+			diff_whitespace: curses.register_selectable_color_pairs(
+				theme.color_diff_whitespace,
+				theme.color_background,
+				theme.color_selected_background,
+			),
 		}
 	}
 
@@ -106,6 +118,8 @@ impl ColorManager {
 				DisplayColor::DiffAddColor => self.diff_add.1,
 				DisplayColor::DiffRemoveColor => self.diff_remove.1,
 				DisplayColor::DiffChangeColor => self.diff_change.1,
+				DisplayColor::DiffContextColor => self.diff_context.1,
+				DisplayColor::DiffWhitespaceColor => self.diff_whitespace.1,
 			}
 		}
 		else {
@@ -123,6 +137,8 @@ impl ColorManager {
 				DisplayColor::DiffAddColor => self.diff_add.0,
 				DisplayColor::DiffRemoveColor => self.diff_remove.0,
 				DisplayColor::DiffChangeColor => self.diff_change.0,
+				DisplayColor::DiffContextColor => self.diff_context.0,
+				DisplayColor::DiffWhitespaceColor => self.diff_whitespace.0,
 			}
 		}
 	}

--- a/src/display/display_color.rs
+++ b/src/display/display_color.rs
@@ -11,6 +11,8 @@ pub(crate) enum DisplayColor {
 	DiffAddColor,
 	DiffChangeColor,
 	DiffRemoveColor,
+	DiffContextColor,
+	DiffWhitespaceColor,
 	IndicatorColor,
 	Normal,
 }

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct Help<'h> {
 	normal_mode_help_lines: [(&'h str, &'h str); 22],
 	return_state: State,
 	visual_mode_help_lines: [(&'h str, &'h str); 14],
-	show_commit_help_lines: [(&'h str, &'h str); 7],
+	show_commit_help_lines: [(&'h str, &'h str); 8],
 	view_data: Option<ViewData>,
 }
 

--- a/src/help/utils.rs
+++ b/src/help/utils.rs
@@ -71,7 +71,7 @@ pub(super) fn get_list_visual_mode_help_lines(key_bindings: &KeyBindings) -> [(&
 	]
 }
 
-pub(super) fn get_show_commit_help_lines(key_bindings: &KeyBindings) -> [(&str, &str); 7] {
+pub(super) fn get_show_commit_help_lines(key_bindings: &KeyBindings) -> [(&str, &str); 8] {
 	[
 		(key_bindings.move_up.as_str(), "Scroll up"),
 		(key_bindings.move_down.as_str(), "Scroll down"),
@@ -79,6 +79,7 @@ pub(super) fn get_show_commit_help_lines(key_bindings: &KeyBindings) -> [(&str, 
 		(key_bindings.move_down_step.as_str(), "Scroll down half a page"),
 		(key_bindings.move_right.as_str(), "Scroll right"),
 		(key_bindings.move_left.as_str(), "Scroll left"),
+		(key_bindings.show_diff.as_str(), "Show full diff"),
 		(key_bindings.help.as_str(), "Show help"),
 	]
 }

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -59,6 +59,7 @@ impl<'i> InputHandler<'i> {
 			i if i == self.key_bindings.move_right.as_str() => Input::MoveCursorRight,
 			i if i == self.key_bindings.move_up_step.as_str() => Input::MoveCursorPageUp,
 			i if i == self.key_bindings.move_down_step.as_str() => Input::MoveCursorPageDown,
+			i if i == self.key_bindings.show_diff.as_str() => Input::ShowDiff,
 			"Resize" => Input::Resize,
 			_ => Input::Other,
 		}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -31,6 +31,7 @@ pub(crate) enum Input {
 	Rebase,
 	Resize,
 	ShowCommit,
+	ShowDiff,
 	SwapSelectedDown,
 	SwapSelectedUp,
 	ToggleVisualMode,

--- a/src/show_commit/delta.rs
+++ b/src/show_commit/delta.rs
@@ -1,0 +1,53 @@
+use crate::show_commit::diff_line::DiffLine;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Delta {
+	old_start: u32,
+	old_lines: u32,
+	new_start: u32,
+	new_lines: u32,
+	context: String,
+	lines: Vec<DiffLine>,
+}
+
+impl Delta {
+	pub(super) fn new(header: &str, old_start: u32, new_start: u32, old_lines: u32, new_lines: u32) -> Self {
+		let context = header.split('@').last().unwrap_or("").trim();
+		Self {
+			old_start,
+			old_lines,
+			new_start,
+			new_lines,
+			context: String::from(context),
+			lines: vec![],
+		}
+	}
+
+	pub(crate) fn add_line(&mut self, diff_line: DiffLine) {
+		self.lines.push(diff_line);
+	}
+
+	pub(crate) fn context(&self) -> &str {
+		self.context.as_str()
+	}
+
+	pub(crate) fn lines(&self) -> &Vec<DiffLine> {
+		&self.lines
+	}
+
+	pub(crate) fn old_start(&self) -> u32 {
+		self.old_start
+	}
+
+	pub(crate) fn old_lines(&self) -> u32 {
+		self.old_lines
+	}
+
+	pub(crate) fn new_start(&self) -> u32 {
+		self.new_start
+	}
+
+	pub(crate) fn new_lines(&self) -> u32 {
+		self.new_lines
+	}
+}

--- a/src/show_commit/diff_line.rs
+++ b/src/show_commit/diff_line.rs
@@ -1,0 +1,76 @@
+use crate::show_commit::diff_line::Origin::{Addition, Context, Deletion};
+
+#[derive(Debug, Clone)]
+pub(crate) enum Origin {
+	Context,
+	Addition,
+	Deletion,
+}
+
+impl Origin {
+	pub(crate) fn from_chr(c: char) -> Self {
+		match c {
+			' ' => Context,
+			'+' => Addition,
+			'-' => Deletion,
+			'=' => Context,
+			'>' => Addition,
+			'<' => Deletion,
+			_ => panic!("Invalid diff origin: {}", c),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DiffLine {
+	end_of_file: bool,
+	line: String,
+	new_line_number: Option<u32>,
+	old_line_number: Option<u32>,
+	origin: Origin,
+}
+
+impl DiffLine {
+	pub(super) fn new(
+		origin: Origin,
+		line: &str,
+		old_line_number: Option<u32>,
+		new_line_number: Option<u32>,
+		end_of_file: bool,
+	) -> Self
+	{
+		Self {
+			end_of_file,
+			// remove the end of file marker from diff
+			line: if end_of_file {
+				line.replace("\n\\ No newline at end of file\n", "")
+			}
+			else {
+				String::from(line)
+			},
+			new_line_number,
+			old_line_number,
+			origin,
+		}
+	}
+
+	pub(crate) fn line(&self) -> &str {
+		self.line.as_str()
+	}
+
+	pub(crate) fn new_line_number(&self) -> Option<u32> {
+		self.new_line_number
+	}
+
+	pub(crate) fn old_line_number(&self) -> Option<u32> {
+		self.old_line_number
+	}
+
+	pub(crate) fn origin(&self) -> &Origin {
+		&self.origin
+	}
+
+	pub(crate) fn end_of_file(&self) -> bool {
+		self.end_of_file
+	}
+}

--- a/src/show_commit/file_stats_builder.rs
+++ b/src/show_commit/file_stats_builder.rs
@@ -1,0 +1,61 @@
+use crate::show_commit::delta::Delta;
+use crate::show_commit::diff_line::DiffLine;
+use crate::show_commit::file_stat::FileStat;
+use crate::show_commit::status::Status;
+
+#[derive(Debug, Clone)]
+pub(super) struct FileStatsBuilder {
+	delta: Option<Delta>,
+	file_stat: Option<FileStat>,
+	file_stats: Vec<FileStat>,
+}
+
+impl FileStatsBuilder {
+	pub(crate) fn new() -> Self {
+		Self {
+			delta: None,
+			file_stat: None,
+			file_stats: vec![],
+		}
+	}
+
+	fn close_delta(&mut self) {
+		if let Some(d) = &self.delta {
+			match &mut self.file_stat {
+				Some(fs) => fs.add_delta(d.clone()),
+				None => panic!("add_file_stat must be called once before adding a delta"),
+			}
+		}
+	}
+
+	fn close_file_stat(&mut self) {
+		if let Some(fs) = &self.file_stat {
+			self.file_stats.push(fs.clone());
+		}
+	}
+
+	pub(crate) fn add_file_stat(&mut self, from_name: String, to_name: String, status: Status) {
+		self.close_delta();
+		self.close_file_stat();
+		self.delta = None;
+		self.file_stat = Some(FileStat::new(from_name, to_name, status));
+	}
+
+	pub(crate) fn add_delta(&mut self, header: &str, old_start: u32, new_start: u32, old_lines: u32, new_lines: u32) {
+		self.close_delta();
+		self.delta = Some(Delta::new(header, old_start, new_start, old_lines, new_lines));
+	}
+
+	pub(crate) fn add_diff_line(&mut self, diff_line: DiffLine) {
+		match &mut self.delta {
+			Some(d) => d.add_line(diff_line),
+			None => panic!("add_delta must be called once before adding a diff line"),
+		}
+	}
+
+	pub(crate) fn build(mut self) -> Vec<FileStat> {
+		self.close_delta();
+		self.close_file_stat();
+		self.file_stats
+	}
+}

--- a/src/show_commit/show_commit_state.rs
+++ b/src/show_commit/show_commit_state.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum ShowCommitState {
+	Overview,
+	Diff,
+}

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -2,21 +2,94 @@ use crate::config::key_bindings::KeyBindings;
 use crate::display::display_color::DisplayColor;
 use crate::input::utils::get_input_short_name;
 use crate::show_commit::commit::Commit;
-use crate::show_commit::util::{get_files_changed_summary, get_stat_item_segments};
+use crate::show_commit::diff_line::{DiffLine, Origin};
+use crate::show_commit::util::{
+	get_files_changed_summary,
+	get_partition_index_on_whitespace_for_line,
+	get_stat_item_segments,
+};
 use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 
+pub(super) struct ViewBuilderOptions {
+	space_character: String,
+	tab_character: String,
+	tab_width: usize,
+	show_leading_whitespace: bool,
+	show_trailing_whitespace: bool,
+}
+
+impl ViewBuilderOptions {
+	pub(crate) fn new(
+		tab_width: usize,
+		tab_character: &str,
+		space_character: &str,
+		show_leading_whitespace: bool,
+		show_trailing_whitespace: bool,
+	) -> Self
+	{
+		Self {
+			space_character: String::from(space_character),
+			tab_character: String::from(tab_character),
+			tab_width,
+			show_leading_whitespace,
+			show_trailing_whitespace,
+		}
+	}
+}
+
 pub(super) struct ViewBuilder<'d> {
 	key_bindings: &'d KeyBindings,
+	invisible_tab_string: String,
+	visible_tab_string: String,
+	visible_space_string: String,
+	show_leading_whitespace: bool,
+	show_trailing_whitespace: bool,
 }
 
 impl<'d> ViewBuilder<'d> {
-	pub(crate) fn new(key_bindings: &'d KeyBindings) -> Self {
-		Self { key_bindings }
+	pub(crate) fn new(options: ViewBuilderOptions, key_bindings: &'d KeyBindings) -> Self {
+		Self {
+			key_bindings,
+			invisible_tab_string: " ".repeat(options.tab_width),
+			visible_tab_string: format!("{0:width$}", options.tab_character, width = options.tab_width),
+			visible_space_string: options.space_character,
+			show_leading_whitespace: options.show_leading_whitespace,
+			show_trailing_whitespace: options.show_trailing_whitespace,
+		}
 	}
 
 	fn get_overview_footer(&self, is_full_width: bool) -> String {
+		if is_full_width {
+			format!(
+				" {}, {}, {}, {}, {}, {}, {}, {}, Any other key to close",
+				self.key_bindings.move_up,
+				self.key_bindings.move_down,
+				self.key_bindings.move_up_step,
+				self.key_bindings.move_down_step,
+				self.key_bindings.move_right,
+				self.key_bindings.move_left,
+				self.key_bindings.show_diff,
+				self.key_bindings.help,
+			)
+		}
+		else {
+			format!(
+				" {}, {}, {}, {}, {}, {}, {}, {}, Any to close",
+				get_input_short_name(self.key_bindings.move_up.as_str()),
+				get_input_short_name(self.key_bindings.move_down.as_str()),
+				get_input_short_name(self.key_bindings.move_up_step.as_str()),
+				get_input_short_name(self.key_bindings.move_down_step.as_str()),
+				get_input_short_name(self.key_bindings.move_right.as_str()),
+				get_input_short_name(self.key_bindings.move_left.as_str()),
+				get_input_short_name(self.key_bindings.show_diff.as_str()),
+				get_input_short_name(self.key_bindings.help.as_str()),
+			)
+		}
+	}
+
+	fn get_diff_footer(&self, is_full_width: bool) -> String {
 		if is_full_width {
 			format!(
 				" {}, {}, {}, {}, {}, {}, {}, Any other key to close",
@@ -41,6 +114,17 @@ impl<'d> ViewBuilder<'d> {
 				get_input_short_name(self.key_bindings.help.as_str()),
 			)
 		}
+	}
+
+	fn replace_whitespace(&self, s: &str, visible: bool) -> String {
+		let s = if visible {
+			s.replace(" ", self.visible_space_string.as_str())
+				.replace("\t", self.visible_tab_string.as_str())
+		}
+		else {
+			s.replace("\t", self.invisible_tab_string.as_str())
+		};
+		s.replace("\n", "")
 	}
 
 	pub(super) fn build_view_data_for_overview(&self, view_data: &mut ViewData, commit: &Commit, is_full_width: bool) {
@@ -92,6 +176,140 @@ impl<'d> ViewBuilder<'d> {
 
 		view_data.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new(
 			self.get_overview_footer(is_full_width).as_str(),
+		)]));
+	}
+
+	fn get_diff_line_segments(
+		&self,
+		diff_line: &DiffLine,
+		old_largest_line_number_length: usize,
+		new_largest_line_number_length: usize,
+	) -> Vec<LineSegment>
+	{
+		let mut line_segments = vec![];
+		line_segments.push(match diff_line.old_line_number() {
+			Some(line_number) => {
+				LineSegment::new(format!("{:<width$}", line_number, width = old_largest_line_number_length).as_str())
+			},
+			None => LineSegment::new(" ".repeat(old_largest_line_number_length).as_str()),
+		});
+		line_segments.push(LineSegment::new(" "));
+
+		line_segments.push(match diff_line.new_line_number() {
+			Some(line_number) => {
+				LineSegment::new(format!("{:<width$}", line_number, width = new_largest_line_number_length).as_str())
+			},
+			None => LineSegment::new(" ".repeat(new_largest_line_number_length).as_str()),
+		});
+		line_segments.push(LineSegment::new("| "));
+
+		if self.show_leading_whitespace || self.show_trailing_whitespace {
+			let line = diff_line.line();
+			let (start, end) = get_partition_index_on_whitespace_for_line(line);
+			let leading = self.replace_whitespace(&line[0..start], self.show_leading_whitespace);
+			let content = self.replace_whitespace(&line[start..end], false);
+			let trailing = self.replace_whitespace(&line[end..], self.show_trailing_whitespace);
+
+			line_segments.push(LineSegment::new_with_color(
+				leading.as_str(),
+				DisplayColor::DiffWhitespaceColor,
+			));
+			line_segments.push(LineSegment::new_with_color(
+				content.as_str(),
+				match diff_line.origin() {
+					Origin::Addition => DisplayColor::DiffAddColor,
+					Origin::Deletion => DisplayColor::DiffRemoveColor,
+					Origin::Context => DisplayColor::DiffContextColor,
+				},
+			));
+			line_segments.push(LineSegment::new_with_color(
+				trailing.as_str(),
+				DisplayColor::DiffWhitespaceColor,
+			));
+		}
+		else {
+			line_segments.push(LineSegment::new_with_color(
+				self.replace_whitespace(diff_line.line(), false).as_str(),
+				match diff_line.origin() {
+					Origin::Addition => DisplayColor::DiffAddColor,
+					Origin::Deletion => DisplayColor::DiffRemoveColor,
+					Origin::Context => DisplayColor::DiffContextColor,
+				},
+			));
+		}
+
+		line_segments
+	}
+
+	pub(super) fn build_view_data_diff(&self, view_data: &mut ViewData, commit: &Commit, is_full_width: bool) {
+		view_data.push_leading_line(get_files_changed_summary(commit, is_full_width));
+		view_data.push_line(ViewLine::new_empty_line().set_padding_character("―"));
+		for stat in commit.get_file_stats() {
+			view_data.push_line(ViewLine::new(get_stat_item_segments(
+				stat.get_status(),
+				stat.get_to_name().as_str(),
+				stat.get_from_name().as_str(),
+				true,
+			)));
+
+			view_data.push_line(ViewLine::new_empty_line());
+			let old_largest_line_number_length = stat.largest_old_line_number().to_string().len();
+			let new_largest_line_number_length = stat.largest_new_line_number().to_string().len();
+			for delta in stat.deltas() {
+				view_data.push_line(ViewLine::new(vec![
+					LineSegment::new_with_color_and_style("@@", DisplayColor::Normal, true, false, false),
+					LineSegment::new_with_color(
+						format!(
+							" -{},{} +{},{} ",
+							delta.old_start(),
+							delta.old_lines(),
+							delta.new_start(),
+							delta.new_lines(),
+						)
+						.as_str(),
+						DisplayColor::DiffContextColor,
+					),
+					LineSegment::new_with_color_and_style("@@", DisplayColor::Normal, true, false, false),
+					LineSegment::new_with_color(
+						format!(" {}", delta.context()).as_str(),
+						DisplayColor::DiffContextColor,
+					),
+				]));
+				view_data.push_line(
+					ViewLine::new_pinned(vec![])
+						.set_padding_color_and_style(DisplayColor::Normal, true, false, false)
+						.set_padding_character("┈"),
+				);
+
+				for line in delta.lines() {
+					if line.end_of_file() && line.line() != "\n" {
+						view_data.push_line(ViewLine::new(vec![
+							LineSegment::new(
+								" ".repeat(old_largest_line_number_length + new_largest_line_number_length + 3)
+									.as_str(),
+							),
+							LineSegment::new_with_color(
+								"\\ No newline at end of file ",
+								DisplayColor::DiffContextColor,
+							),
+						]));
+						continue;
+					}
+
+					view_data.push_line(ViewLine::new(self.get_diff_line_segments(
+						line,
+						old_largest_line_number_length,
+						new_largest_line_number_length,
+					)));
+				}
+
+				view_data.push_line(ViewLine::new_empty_line());
+			}
+			view_data.push_line(ViewLine::new_empty_line().set_padding_character("―"));
+		}
+
+		view_data.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new(
+			self.get_diff_footer(is_full_width).as_str(),
 		)]));
 	}
 }

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -449,7 +449,7 @@ impl ViewData {
 				}
 
 				if start < window_width {
-					let padding = " ".repeat(window_width - start);
+					let padding = line.padding_character().repeat(window_width - start);
 
 					segments.push(LineSegment::new_with_color_and_style(
 						padding.as_str(),

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -9,9 +9,14 @@ pub(crate) struct ViewLine {
 	padding_dim: bool,
 	padding_reverse: bool,
 	padding_underline: bool,
+	padding_character: String,
 }
 
 impl ViewLine {
+	pub(crate) fn new_empty_line() -> Self {
+		Self::new_with_pinned_segments(vec![], 1)
+	}
+
 	pub(crate) fn new(segments: Vec<LineSegment>) -> Self {
 		Self::new_with_pinned_segments(segments, 0)
 	}
@@ -30,11 +35,17 @@ impl ViewLine {
 			padding_dim: false,
 			padding_reverse: false,
 			padding_underline: false,
+			padding_character: String::from(" "),
 		}
 	}
 
 	pub(crate) fn set_selected(mut self, selected: bool) -> Self {
 		self.selected = selected;
+		self
+	}
+
+	pub(crate) fn set_padding_character(mut self, character: &str) -> Self {
+		self.padding_character = String::from(character);
 		self
 	}
 
@@ -79,6 +90,10 @@ impl ViewLine {
 
 	pub(super) fn is_padding_reversed(&self) -> bool {
 		self.padding_reverse
+	}
+
+	pub(super) fn padding_character(&self) -> &str {
+		self.padding_character.as_str()
 	}
 }
 


### PR DESCRIPTION
# What

This change adds a diff view to the show commit that is similar to the `git show` command.

## Screenshots

#### General diff view
![Screenshot from 2020-07-26 21-28-35](https://user-images.githubusercontent.com/177427/88492672-fe76fe80-cf86-11ea-92da-e377e9ba6026.png)

#### Missing newline support
![Screenshot from 2020-07-26 21-24-38](https://user-images.githubusercontent.com/177427/88492634-a50ecf80-cf86-11ea-80a2-4640088c02dc.png)

#### Leading and trailing whitespace support
![Screenshot from 2020-07-26 21-27-45](https://user-images.githubusercontent.com/177427/88492663-ea330180-cf86-11ea-8941-774a152e6a3e.png)




closes #57 and #126