### PR TITLE
Fix multiple width characters breaking render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,8 @@ dependencies = [
  "pancurses 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-unicode 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -445,6 +447,11 @@ dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xi-unicode"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
@@ -502,3 +509,4 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+"checksum xi-unicode 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e71b85d8b1b8bfaf4b5c834187554d201a8cd621c2bbfa33efd41a3ecabd48b2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ chrono = "0.4"
 clap = "2.32.0"
 num-format = "0.4.0"
 unicode-segmentation = "1.1.0"
+xi-unicode = "0.2.1"
+unicode-width = "0.1.5"
 
 [dependencies.pancurses]
 version = "0.16"

--- a/src/display/curses.rs
+++ b/src/display/curses.rs
@@ -234,6 +234,10 @@ impl Curses {
 		self.window.getch()
 	}
 
+	pub(crate) fn get_cur_y(&self) -> i32 {
+		self.window.get_cur_y()
+	}
+
 	pub(super) fn get_max_y(&self) -> i32 {
 		self.window.get_max_y()
 	}
@@ -250,6 +254,14 @@ impl Curses {
 	#[allow(clippy::unused_self)]
 	pub(super) fn reset_prog_mode(&self) {
 		pancurses::reset_prog_mode();
+	}
+
+	pub(crate) fn hline(&self, ch: char, width: i32) {
+		self.window.hline(ch, width);
+	}
+
+	pub(crate) fn mv(&self, y: i32, x: i32) {
+		self.window.mv(y, x);
 	}
 
 	#[allow(clippy::unused_self)]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -99,6 +99,18 @@ impl<'d> Display<'d> {
 		(*self.width.borrow(), *self.height.borrow())
 	}
 
+	pub(crate) fn fill_end_of_line(&self) {
+		self.curses.hline(' ', self.curses.get_max_x());
+	}
+
+	pub(crate) fn ensure_at_line_start(&self, y: i32) {
+		self.curses.mv(y, 0);
+	}
+
+	pub(crate) fn move_from_end_of_line(&self, right: i32) {
+		self.curses.mv(self.curses.get_cur_y(), self.curses.get_max_x() - right);
+	}
+
 	/// Leaves curses mode, runs the specified callback, and re-enables curses.
 	pub(crate) fn leave_temporarily<F, T>(&self, callback: F) -> T
 	where F: FnOnce() -> T {


### PR DESCRIPTION
# Description

Multiple width characters were rendered as a single character which would cause the line render to overflow breaking the line below.

closes #259 