### PR TITLE
Move prompt to ViewData

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -5,9 +5,12 @@ use crate::process::exit_status::ExitStatus;
 use crate::process::handle_input_result::{HandleInputResult, HandleInputResultBuilder};
 use crate::process::process_module::ProcessModule;
 use crate::process::state::State;
+use crate::view::view_data::ViewData;
 use crate::view::View;
 
-pub struct ConfirmAbort {}
+pub struct ConfirmAbort {
+	view_data: ViewData,
+}
 
 impl ProcessModule for ConfirmAbort {
 	fn handle_input(
@@ -32,13 +35,17 @@ impl ProcessModule for ConfirmAbort {
 		result.build()
 	}
 
-	fn render(&self, view: &View<'_>, _git_interactive: &GitInteractive) {
-		view.draw_confirm("Are you sure you want to abort");
-	}
+	fn render(&self, _view: &View<'_>, _git_interactive: &GitInteractive) {}
 }
 
 impl ConfirmAbort {
-	pub(crate) const fn new() -> Self {
-		Self {}
+	pub(crate) fn new() -> Self {
+		Self {
+			view_data: ViewData::new_confirm("Are you sure you want to abort"),
+		}
+	}
+
+	pub(crate) fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+		&self.view_data
 	}
 }

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -5,9 +5,12 @@ use crate::process::exit_status::ExitStatus;
 use crate::process::handle_input_result::{HandleInputResult, HandleInputResultBuilder};
 use crate::process::process_module::ProcessModule;
 use crate::process::state::State;
+use crate::view::view_data::ViewData;
 use crate::view::View;
 
-pub struct ConfirmRebase {}
+pub struct ConfirmRebase {
+	view_data: ViewData,
+}
 
 impl ProcessModule for ConfirmRebase {
 	fn handle_input(
@@ -31,13 +34,17 @@ impl ProcessModule for ConfirmRebase {
 		result.build()
 	}
 
-	fn render(&self, view: &View<'_>, _git_interactive: &GitInteractive) {
-		view.draw_confirm("Are you sure you want to rebase");
-	}
+	fn render(&self, _view: &View<'_>, _git_interactive: &GitInteractive) {}
 }
 
 impl ConfirmRebase {
-	pub(crate) const fn new() -> Self {
-		Self {}
+	pub(crate) fn new() -> Self {
+		Self {
+			view_data: ViewData::new_confirm("Are you sure you want to rebase"),
+		}
+	}
+
+	pub(crate) fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+		&self.view_data
 	}
 }

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -10,6 +10,7 @@ use crate::process::handle_input_result::{HandleInputResult, HandleInputResultBu
 use crate::process::process_module::ProcessModule;
 use crate::process::process_result::{ProcessResult, ProcessResultBuilder};
 use crate::process::state::State;
+use crate::view::view_data::ViewData;
 use crate::view::View;
 use std::ffi::OsString;
 use std::process::Command;
@@ -27,6 +28,8 @@ pub struct ExternalEditor<'e> {
 	editor: String,
 	display: &'e Display<'e>,
 	state: ExternalEditorState,
+	view_data_external: ViewData,
+	view_data_error: ViewData,
 }
 
 impl<'e> ProcessModule for ExternalEditor<'e> {
@@ -59,11 +62,7 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 		}
 	}
 
-	fn render(&self, view: &View<'_>, _git_interactive: &GitInteractive) {
-		if let ExternalEditorState::Empty = self.state {
-			view.draw_confirm("Empty rebase todo file. Do you wish to exit?");
-		}
-	}
+	fn render(&self, _view: &View<'_>, _git_interactive: &GitInteractive) {}
 }
 
 impl<'e> ExternalEditor<'e> {
@@ -72,6 +71,17 @@ impl<'e> ExternalEditor<'e> {
 			editor: String::from(editor),
 			display,
 			state: ExternalEditorState::Active,
+			view_data_external: ViewData::new(),
+			view_data_error: ViewData::new_confirm("Empty rebase todo file. Do you wish to exit"),
+		}
+	}
+
+	pub(crate) fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+		if let ExternalEditorState::Empty = self.state {
+			&self.view_data_error
+		}
+		else {
+			&self.view_data_external
 		}
 	}
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -143,12 +143,21 @@ impl<'r> Process<'r> {
 	fn render(&mut self) {
 		self.view.clear();
 		match self.get_state() {
-			State::ConfirmAbort => self.confirm_abort.render(self.view, &self.git_interactive),
-			State::ConfirmRebase => self.confirm_rebase.render(self.view, &self.git_interactive),
+			State::ConfirmAbort => {
+				let view_data = self.confirm_abort.build_view_data(self.view, &self.git_interactive);
+				self.view.draw_view_data(view_data);
+			},
+			State::ConfirmRebase => {
+				let view_data = self.confirm_rebase.build_view_data(self.view, &self.git_interactive);
+				self.view.draw_view_data(view_data);
+			},
 			State::Edit => self.edit.render(self.view, &self.git_interactive),
 			State::Error { .. } => self.error.render(self.view, &self.git_interactive),
 			State::Exiting => self.exiting.render(self.view, &self.git_interactive),
-			State::ExternalEditor => self.external_editor.render(self.view, &self.git_interactive),
+			State::ExternalEditor => {
+				let view_data = self.external_editor.build_view_data(self.view, &self.git_interactive);
+				self.view.draw_view_data(view_data);
+			},
 			State::Help(_) => {
 				let view_data = self.help.build_view_data(self.view, &self.git_interactive);
 				self.view.draw_view_data(view_data);

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -72,6 +72,21 @@ impl<'v> View<'v> {
 
 		let mut line_index = 0;
 
+		if view_data.show_title() {
+			self.display.ensure_at_line_start(line_index);
+			line_index += 1;
+			self.draw_title(view_data.show_help());
+		}
+
+		if let Some(prompt) = view_data.get_prompt() {
+			self.display.set_style(false, false, false);
+			self.display.draw_str(&format!(
+				"\n{} ({}/{})? ",
+				prompt, self.config.key_bindings.confirm_yes, self.config.key_bindings.confirm_no
+			));
+			return;
+		}
+
 		let leading_lines = view_data.get_leading_lines();
 		let lines = view_data.get_lines();
 		let trailing_lines = view_data.get_trailing_lines();
@@ -80,12 +95,6 @@ impl<'v> View<'v> {
 
 		let show_scroll_bar = view_data.should_show_scroll_bar();
 		let scroll_indicator_index = view_data.get_scroll_index();
-
-		if view_data.show_title() {
-			self.display.ensure_at_line_start(line_index);
-			line_index += 1;
-			self.draw_title(view_data.show_help());
-		}
 
 		for line in leading_lines {
 			self.display.ensure_at_line_start(line_index);
@@ -181,18 +190,5 @@ impl<'v> View<'v> {
 		// reset style
 		self.display.color(DisplayColor::Normal, false);
 		self.display.set_style(false, false, false);
-	}
-
-	fn draw_prompt(&self, message: &str) {
-		self.draw_title(false);
-		self.display.set_style(false, false, false);
-		self.display.draw_str(&format!("\n{} ", message));
-	}
-
-	pub(crate) fn draw_confirm(&self, message: &str) {
-		self.draw_prompt(&format!(
-			"{} ({}/{})? ",
-			message, self.config.key_bindings.confirm_yes, self.config.key_bindings.confirm_no
-		));
 	}
 }

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -16,6 +16,7 @@ pub struct ViewData {
 	trailing_lines_cache: Option<Vec<ViewLine>>,
 	show_title: bool,
 	show_help: bool,
+	prompt: Option<String>,
 	max_leading_line_length: usize,
 	max_line_length: usize,
 	max_trailing_line_length: usize,
@@ -24,21 +25,22 @@ pub struct ViewData {
 impl ViewData {
 	pub(crate) const fn new() -> Self {
 		Self {
-			scroll_position: ScrollPosition::new(),
-			height: 0,
-			width: 0,
 			empty_lines: vec![],
+			height: 0,
 			leading_lines: vec![],
 			leading_lines_cache: None,
 			lines: vec![],
 			lines_cache: None,
-			trailing_lines: vec![],
-			trailing_lines_cache: None,
-			show_title: false,
-			show_help: false,
 			max_leading_line_length: 0,
 			max_line_length: 0,
 			max_trailing_line_length: 0,
+			prompt: None,
+			scroll_position: ScrollPosition::new(),
+			show_help: false,
+			show_title: false,
+			trailing_lines: vec![],
+			trailing_lines_cache: None,
+			width: 0,
 		}
 	}
 
@@ -51,6 +53,13 @@ impl ViewData {
 			DisplayColor::IndicatorColor,
 		)]));
 		inst.rebuild();
+		inst
+	}
+
+	pub(crate) fn new_confirm(prompt: &str) -> Self {
+		let mut inst = Self::new();
+		inst.set_show_title(true);
+		inst.prompt = Some(String::from(prompt));
 		inst
 	}
 
@@ -253,6 +262,10 @@ impl ViewData {
 
 	pub(crate) fn is_empty(&self) -> bool {
 		self.lines.is_empty() && self.leading_lines.is_empty() && self.trailing_lines.is_empty()
+	}
+
+	pub(super) const fn get_prompt(&self) -> &Option<String> {
+		&self.prompt
 	}
 
 	pub(super) fn get_leading_lines(&self) -> &Vec<ViewLine> {


### PR DESCRIPTION
# Description

The confirm prompts were still using the raw view render function. This adds support for prompts for the ViewData and draw_view_data functions and updates the usage of the prompts to use the ViewData struct instead.