### PR TITLE
Rewrite Error module to use ViewData

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -152,7 +152,10 @@ impl<'r> Process<'r> {
 				self.view.draw_view_data(view_data);
 			},
 			State::Edit => self.edit.render(self.view, &self.git_interactive),
-			State::Error { .. } => self.error.render(self.view, &self.git_interactive),
+			State::Error { .. } => {
+				let view_data = self.error.build_view_data(self.view, &self.git_interactive);
+				self.view.draw_view_data(view_data);
+			},
 			State::Exiting => self.exiting.render(self.view, &self.git_interactive),
 			State::ExternalEditor => {
 				let view_data = self.external_editor.build_view_data(self.view, &self.git_interactive);

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -140,7 +140,7 @@ impl<'s> ShowCommit<'s> {
 		Self {
 			commit: None,
 			config,
-			no_commit_view_data: ViewData::new_error("Not commit data to show"),
+			no_commit_view_data: ViewData::new_error("No commit data to show"),
 			state: ShowCommitState::Overview,
 			view_builder: ViewBuilder::new(view_builder_options, &config.key_bindings),
 			view_data,

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -45,16 +45,6 @@ impl<'v> View<'v> {
 		!(window_width <= MINIMUM_COMPACT_WINDOW_WIDTH || window_height <= MINIMUM_WINDOW_HEIGHT)
 	}
 
-	pub(crate) fn draw_error(&self, message: &str) {
-		self.draw_title(false);
-		self.display.color(DisplayColor::Normal, false);
-		self.display.set_style(false, false, false);
-		self.display.draw_str(message);
-		self.display.draw_str("\n");
-		self.display.color(DisplayColor::IndicatorColor, false);
-		self.display.draw_str("Press any key to continue");
-	}
-
 	pub(crate) fn clear(&self) {
 		self.display.clear();
 	}


### PR DESCRIPTION
# Description

The Error module was manually rendering the view with a render function. This change converts the module to use the ViewData struct and remove the need for a custom render function.