### PR TITLE
Move Window Size Error module to use ViewData

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,10 +4,7 @@ pub const TITLE_SHORT: &str = "Git Rebase";
 pub const TITLE_SHORT_LENGTH: usize = 10;
 pub const TITLE_HELP_INDICATOR_LENGTH: usize = 6;
 
-pub const HEIGHT_ERROR_MESSAGE: &str = "Window too small, increase height to continue\n";
 pub const MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH: usize = 45;
-pub const SHORT_ERROR_MESSAGE: &str = "Window too small\n";
-pub const SHORT_ERROR_MESSAGE_WIDTH: usize = 16;
 
 pub const MINIMUM_WINDOW_HEIGHT: usize = 5; // title + pad top + line + pad bottom + help
 pub const MINIMUM_COMPACT_WINDOW_WIDTH: usize = 20; // ">s ccc mmmmmmmmmmmmm".len()

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -173,7 +173,10 @@ impl<'r> Process<'r> {
 				self.view
 					.draw_view_data(self.show_commit.build_view_data(self.view, &self.git_interactive))
 			},
-			State::WindowSizeError(_) => self.window_size_error.render(self.view, &self.git_interactive),
+			State::WindowSizeError(_) => {
+				self.view
+					.draw_view_data(self.window_size_error.build_view_data(self.view, &self.git_interactive))
+			},
 		};
 		self.view.refresh()
 	}

--- a/src/window_size_error/mod.rs
+++ b/src/window_size_error/mod.rs
@@ -1,19 +1,21 @@
-use crate::constants::{
-	HEIGHT_ERROR_MESSAGE,
-	MINIMUM_COMPACT_WINDOW_WIDTH,
-	MINIMUM_WINDOW_HEIGHT,
-	MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH,
-	SHORT_ERROR_MESSAGE,
-	SHORT_ERROR_MESSAGE_WIDTH,
-};
-use crate::display::display_color::DisplayColor;
+use crate::constants::{MINIMUM_COMPACT_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH};
 use crate::git_interactive::GitInteractive;
 use crate::input::input_handler::{InputHandler, InputMode};
 use crate::process::handle_input_result::HandleInputResult;
 use crate::process::process_module::ProcessModule;
+use crate::view::line_segment::LineSegment;
+use crate::view::view_data::ViewData;
+use crate::view::view_line::ViewLine;
 use crate::view::View;
 
-pub struct WindowSizeError {}
+pub struct WindowSizeError {
+	view_data: ViewData,
+}
+
+const HEIGHT_ERROR_MESSAGE: &str = "Window too small, increase height to continue";
+const SHORT_ERROR_MESSAGE: &str = "Window too small";
+const SIZE_ERROR_MESSAGE: &str = "Size!";
+const BUG_WINDOW_SIZE_MESSAGE: &str = "Bug: window size is not invalid!";
 
 impl ProcessModule for WindowSizeError {
 	fn handle_input(
@@ -26,38 +28,47 @@ impl ProcessModule for WindowSizeError {
 		HandleInputResult::new(input_handler.get_input(InputMode::Default))
 	}
 
-	fn render(&self, view: &View<'_>, _git_interactive: &GitInteractive) {
-		let (window_width, window_height) = view.get_view_size();
-
-		view.set_color(DisplayColor::Normal, false);
-		if window_width <= MINIMUM_COMPACT_WINDOW_WIDTH {
-			if window_width >= SHORT_ERROR_MESSAGE_WIDTH {
-				view.draw_str(SHORT_ERROR_MESSAGE);
-			}
-			else {
-				// not much to do if the window gets too narrow
-				view.draw_str("Size!\n");
-			}
-			return;
-		}
-
-		if window_height <= MINIMUM_WINDOW_HEIGHT {
-			if window_width >= MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH {
-				view.draw_str(HEIGHT_ERROR_MESSAGE);
-			}
-			else if window_width >= SHORT_ERROR_MESSAGE_WIDTH {
-				view.draw_str(SHORT_ERROR_MESSAGE);
-			}
-			else {
-				// not much to do if the window gets too narrow
-				view.draw_str("Size!\n");
-			}
-		}
-	}
+	fn render(&self, _: &View<'_>, _: &GitInteractive) {}
 }
 
 impl WindowSizeError {
 	pub const fn new() -> Self {
-		Self {}
+		Self {
+			view_data: ViewData::new(),
+		}
+	}
+
+	pub(crate) fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (window_width, window_height) = view.get_view_size();
+
+		let message = if window_width <= MINIMUM_COMPACT_WINDOW_WIDTH {
+			if window_width >= SHORT_ERROR_MESSAGE.len() {
+				SHORT_ERROR_MESSAGE
+			}
+			else {
+				// not much to do if the window gets too narrow
+				SIZE_ERROR_MESSAGE
+			}
+		}
+		else if window_height <= MINIMUM_WINDOW_HEIGHT {
+			if window_width >= MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH {
+				HEIGHT_ERROR_MESSAGE
+			}
+			else if window_width >= SHORT_ERROR_MESSAGE.len() {
+				SHORT_ERROR_MESSAGE
+			}
+			else {
+				// not much to do if the window gets too narrow
+				SIZE_ERROR_MESSAGE
+			}
+		}
+		else {
+			BUG_WINDOW_SIZE_MESSAGE
+		};
+
+		self.view_data.clear();
+		self.view_data.push_line(ViewLine::new(vec![LineSegment::new(message)]));
+		self.view_data.set_view_size(window_width, window_height);
+		&self.view_data
 	}
 }


### PR DESCRIPTION
# Description

This updates the Window Size Error module to use the ViewData struct over a direct view render.