### PR TITLE
Refactor Edit module to use ViewData

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -6,6 +6,9 @@ use crate::process::handle_input_result::HandleInputResult;
 use crate::process::process_module::ProcessModule;
 use crate::process::process_result::{ProcessResult, ProcessResultBuilder};
 use crate::process::state::State;
+use crate::view::line_segment::LineSegment;
+use crate::view::view_data::ViewData;
+use crate::view::view_line::ViewLine;
 use crate::view::View;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -19,6 +22,7 @@ pub struct Edit {
 	content: String,
 	cursor_position: usize,
 	state: EditState,
+	view_data: ViewData,
 }
 
 impl ProcessModule for Edit {
@@ -48,8 +52,8 @@ impl ProcessModule for Edit {
 	fn handle_input(
 		&mut self,
 		input_handler: &InputHandler<'_>,
-		_git_interactive: &mut GitInteractive,
-		_view: &View<'_>,
+		_: &mut GitInteractive,
+		view: &View<'_>,
 	) -> HandleInputResult
 	{
 		if self.state == EditState::Finish {
@@ -107,6 +111,10 @@ impl ProcessModule for Edit {
 					}
 				},
 				Input::Enter => self.state = EditState::Finish,
+				Input::Resize => {
+					let (view_width, view_height) = view.get_view_size();
+					self.view_data.set_view_size(view_width, view_height);
+				},
 				_ => {
 					continue;
 				},
@@ -116,45 +124,56 @@ impl ProcessModule for Edit {
 		HandleInputResult::new(input)
 	}
 
-	fn render(&self, view: &View<'_>, _git_interactive: &GitInteractive) {
-		let line = self.content.as_str();
-		let pointer = self.cursor_position;
-
-		view.draw_title(false);
-		view.set_style(false, true, false);
-		view.set_color(DisplayColor::Normal, false);
-
-		// this could probably be made way more efficient
-		let graphemes = UnicodeSegmentation::graphemes(line, true);
-		let segment_length = graphemes.clone().count();
-		for (counter, c) in graphemes.enumerate() {
-			if counter == pointer {
-				view.set_style(false, true, false);
-				view.draw_str(c);
-				view.set_style(false, false, false);
-			}
-			else {
-				view.draw_str(c);
-			}
-		}
-		if pointer >= segment_length {
-			view.set_style(false, true, false);
-			view.draw_str(" ");
-			view.set_style(false, false, false);
-		}
-
-		view.draw_str("\n\n");
-		view.set_color(DisplayColor::IndicatorColor, false);
-		view.draw_str("Enter to finish");
-	}
+	fn render(&self, _: &View<'_>, _: &GitInteractive) {}
 }
 
 impl Edit {
 	pub(crate) fn new() -> Self {
+		let mut view_data = ViewData::new();
+		view_data.set_show_title(true);
 		Self {
 			content: String::from(""),
 			cursor_position: 0,
 			state: EditState::Active,
+			view_data,
 		}
+	}
+
+	pub(crate) fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (view_width, view_height) = view.get_view_size();
+
+		let line = self.content.as_str();
+		let pointer = self.cursor_position;
+
+		let graphemes = UnicodeSegmentation::graphemes(line, true);
+
+		let start = graphemes.clone().take(pointer).collect::<String>();
+		let indicator = graphemes.clone().skip(pointer).take(1).collect::<String>();
+		let end = graphemes.skip(pointer + 1).collect::<String>();
+
+		let mut segments = vec![
+			LineSegment::new(start.as_str()),
+			LineSegment::new_with_color_and_style(indicator.as_str(), DisplayColor::Normal, false, true, false),
+			LineSegment::new(end.as_str()),
+		];
+		if end.is_empty() {
+			segments.push(LineSegment::new_with_color_and_style(
+				" ",
+				DisplayColor::Normal,
+				false,
+				true,
+				false,
+			));
+		}
+		self.view_data.clear();
+		self.view_data.set_content(ViewLine::new(segments));
+		self.view_data
+			.push_trailing_line(ViewLine::new(vec![LineSegment::new_with_color(
+				"Enter to finish",
+				DisplayColor::IndicatorColor,
+			)]));
+		self.view_data.set_view_size(view_width, view_height);
+		self.view_data.rebuild();
+		&self.view_data
 	}
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -151,7 +151,10 @@ impl<'r> Process<'r> {
 				let view_data = self.confirm_rebase.build_view_data(self.view, &self.git_interactive);
 				self.view.draw_view_data(view_data);
 			},
-			State::Edit => self.edit.render(self.view, &self.git_interactive),
+			State::Edit => {
+				self.view
+					.draw_view_data(self.edit.build_view_data(self.view, &self.git_interactive));
+			},
 			State::Error { .. } => {
 				let view_data = self.error.build_view_data(self.view, &self.git_interactive);
 				self.view.draw_view_data(view_data);

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -36,6 +36,7 @@ impl SegmentPartial {
 	}
 }
 
+#[derive(Clone, Debug)]
 pub struct LineSegment {
 	color: DisplayColor,
 	dim: bool,

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -28,18 +28,6 @@ impl<'v> View<'v> {
 		Self { display, config }
 	}
 
-	pub(crate) fn draw_str(&self, s: &str) {
-		self.display.draw_str(s);
-	}
-
-	pub(crate) fn set_color(&self, color: DisplayColor, selected: bool) {
-		self.display.color(color, selected);
-	}
-
-	pub(crate) fn set_style(&self, dim: bool, underline: bool, reverse: bool) {
-		self.display.set_style(dim, underline, reverse);
-	}
-
 	pub(crate) fn check_window_size(&self) -> bool {
 		let (window_width, window_height) = self.get_view_size();
 		!(window_width <= MINIMUM_COMPACT_WINDOW_WIDTH || window_height <= MINIMUM_WINDOW_HEIGHT)

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -16,6 +16,7 @@ pub struct ViewData {
 	trailing_lines_cache: Option<Vec<ViewLine>>,
 	show_title: bool,
 	show_help: bool,
+	content: Option<ViewLine>,
 	prompt: Option<String>,
 	max_leading_line_length: usize,
 	max_line_length: usize,
@@ -38,6 +39,7 @@ impl ViewData {
 			scroll_position: ScrollPosition::new(),
 			show_help: false,
 			show_title: false,
+			content: None,
 			trailing_lines: vec![],
 			trailing_lines_cache: None,
 			width: 0,
@@ -167,6 +169,12 @@ impl ViewData {
 		self.show_help = show;
 	}
 
+	pub(crate) fn set_content(&mut self, content: ViewLine) {
+		self.lines.clear();
+		self.lines_cache = None;
+		self.content = Some(content);
+	}
+
 	pub(crate) fn push_leading_line(&mut self, view_line: ViewLine) {
 		self.leading_lines_cache = None;
 		self.lines_cache = None;
@@ -289,6 +297,7 @@ impl ViewData {
 		}
 	}
 
+	#[allow(clippy::cognitive_complexity)]
 	pub(crate) fn rebuild(&mut self) {
 		if self.leading_lines_cache.is_none() {
 			self.leading_lines_cache = Some(
@@ -351,7 +360,64 @@ impl ViewData {
 
 		if self.lines_cache.is_none() {
 			self.lines_cache = Some(
-				if self.lines.is_empty() {
+				if let Some(content) = &self.content {
+					let mut view_lines = vec![];
+					let mut segments = vec![];
+					let mut remaining_width = self.width;
+					for segment in content.get_segments().iter() {
+						// ignore empty segments
+						if segment.get_length() == 0 {
+							continue;
+						}
+						// push segments that completely fit
+						if segment.get_length() <= remaining_width {
+							remaining_width -= segment.get_length();
+							segments.push(segment.clone());
+
+							if remaining_width == 0 {
+								view_lines.push(ViewLine::new(segments.to_vec()));
+								segments.clear();
+								remaining_width = self.width;
+							}
+						}
+						else {
+							let mut used_segment_length = 0;
+							loop {
+								let partial = segment.get_partial_segment(used_segment_length, remaining_width);
+								used_segment_length += partial.get_length();
+								remaining_width -= partial.get_length();
+								if partial.get_length() > 0 {
+									segments.push(LineSegment::new_with_color_and_style(
+										partial.get_content(),
+										segment.get_color(),
+										segment.is_dimmed(),
+										segment.is_underlined(),
+										segment.is_reversed(),
+									));
+
+									if remaining_width == 0 {
+										view_lines.push(ViewLine::new(segments.to_vec()));
+										segments.clear();
+										remaining_width = self.width;
+									}
+								}
+								else {
+									break;
+								}
+							}
+						}
+					}
+					if !segments.is_empty() {
+						view_lines.push(ViewLine::new(segments.to_vec()));
+					}
+
+					self.max_line_length = self.width;
+
+					self.scroll_position
+						.set_line_maximums(self.get_max_line_length(), self.lines.len());
+					view_lines
+				}
+				else if self.lines.is_empty() {
 					self.max_line_length = Self::calculate_max_line_length(&self.lines, 0, self.lines.len());
 					self.build_lines(&self.lines, 0, self.lines.len(), self.should_show_scroll_bar())
 				}


### PR DESCRIPTION
# Description

The Edit module is the final module that is not using the ViewData. This adds a raw content value to the ViewData that will generated wrapped content lines. The Edit module uses this new functionality to remove the raw renders from the module.