### PR TITLE
Ensure rebuild of ViewData

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -13,7 +13,10 @@ pub struct ConfirmAbort {
 }
 
 impl ProcessModule for ConfirmAbort {
-	fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (window_width, window_height) = view.get_view_size();
+		self.view_data.set_view_size(window_width, window_height);
+		self.view_data.rebuild();
 		&self.view_data
 	}
 

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -13,7 +13,10 @@ pub struct ConfirmRebase {
 }
 
 impl ProcessModule for ConfirmRebase {
-	fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (window_width, window_height) = view.get_view_size();
+		self.view_data.set_view_size(window_width, window_height);
+		self.view_data.rebuild();
 		&self.view_data
 	}
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -32,10 +32,12 @@ impl ProcessModule for Error {
 		let (view_width, view_height) = view.get_view_size();
 		if let Some(ref mut view_data) = self.view_data {
 			view_data.set_view_size(view_width, view_height);
+			view_data.rebuild();
 			view_data
 		}
 		else {
 			self.view_data_no_error.set_view_size(view_width, view_height);
+			self.view_data_no_error.rebuild();
 			&self.view_data_no_error
 		}
 	}

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -39,11 +39,16 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 		}
 	}
 
-	fn build_view_data(&mut self, _: &View<'_>, _: &GitInteractive) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (window_width, window_height) = view.get_view_size();
 		if let ExternalEditorState::Empty = self.state {
+			self.view_data_error.set_view_size(window_width, window_height);
+			self.view_data_error.rebuild();
 			&self.view_data_error
 		}
 		else {
+			self.view_data_external.set_view_size(window_width, window_height);
+			self.view_data_external.rebuild();
 			&self.view_data_external
 		}
 	}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -66,10 +66,10 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 	}
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
+		let (view_width, view_height) = view.get_view_size();
 		match &self.commit {
 			Some(commit) => {
 				if self.view_data.is_empty() {
-					let (view_width, view_height) = view.get_view_size();
 					let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
 
 					let commit = commit.as_ref().unwrap(); // if commit is error it will be caught in process
@@ -107,7 +107,11 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 				}
 				&self.view_data
 			},
-			None => &self.no_commit_view_data,
+			None => {
+				self.no_commit_view_data.set_view_size(view_width, view_height);
+				self.no_commit_view_data.rebuild();
+				&self.no_commit_view_data
+			},
 		}
 	}
 

--- a/src/window_size_error/mod.rs
+++ b/src/window_size_error/mod.rs
@@ -49,6 +49,7 @@ impl ProcessModule for WindowSizeError {
 		self.view_data.clear();
 		self.view_data.push_line(ViewLine::new(vec![LineSegment::new(message)]));
 		self.view_data.set_view_size(window_width, window_height);
+		self.view_data.rebuild();
 		&self.view_data
 	}
 


### PR DESCRIPTION
# Descripton

There were a few places where the ViewData was not rebuilt, causing some renders to display stale data. This ensures that the view data is rebuilt in all cases.