### PR TITLE
Fix new linting errors due to Rust update

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,8 +9,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt-get install build-essential libncursesw5-dev pkg-config liblzma-dev
+      - name: Update Rust
+        run: rustup update stable
       - name: Test
-        run: cargo test --
+        run: cargo test
       - name: Build
         run: cargo build --release
       - name: Test Run
@@ -24,11 +26,8 @@ jobs:
     runs-on: [macos-latest]
     steps:
       - uses: actions/checkout@v2
-      # Install Rust until actions/virtual-environments#6 is resolved
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Update Rust
+        run: rustup update stable
       - name: Test
         run: cargo test --
       - name: Build
@@ -40,6 +39,8 @@ jobs:
     runs-on: [windows-latest]
     steps:
       - uses: actions/checkout@v2
+      - name: Update Rust
+        run: rustup update stable
       - name: Test
         run: cargo test --target x86_64-pc-windows-msvc --release --
       - name: Build

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -4,4 +4,5 @@ set -e
 set -u
 set -o pipefail
 
-cargo test --
+rustup update stable
+cargo test

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -102,7 +102,7 @@ impl ColorManager {
 		}
 	}
 
-	pub(super) fn get_color(&self, color: DisplayColor, selected: bool) -> chtype {
+	pub(super) const fn get_color(&self, color: DisplayColor, selected: bool) -> chtype {
 		if selected {
 			match color {
 				DisplayColor::ActionBreak => self.action_break.1,

--- a/src/display/color_mode.rs
+++ b/src/display/color_mode.rs
@@ -1,6 +1,6 @@
 use crate::display::color_mode::ColorMode::{EightBit, FourBit, TrueColor};
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(super) enum ColorMode {
 	TwoTone,
 	ThreeBit,
@@ -10,12 +10,12 @@ pub(super) enum ColorMode {
 }
 
 impl ColorMode {
-	pub(super) fn has_minimum_four_bit_color(&self) -> bool {
-		*self == FourBit || *self == EightBit || *self == TrueColor
+	pub(super) fn has_minimum_four_bit_color(self) -> bool {
+		self == FourBit || self == EightBit || self == TrueColor
 	}
 
-	pub(super) fn has_true_color(&self) -> bool {
-		*self == TrueColor
+	pub(super) fn has_true_color(self) -> bool {
+		self == TrueColor
 	}
 }
 

--- a/src/list/line.rs
+++ b/src/list/line.rs
@@ -84,7 +84,7 @@ impl Line {
 		}
 	}
 
-	pub(crate) fn get_edit_content(&self) -> &String {
+	pub(crate) const fn get_edit_content(&self) -> &String {
 		match self.action {
 			Action::Exec => &self.command,
 			_ => &self.comment,

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -7,7 +7,7 @@ use crate::list::line::Line;
 use crate::view::line_segment::LineSegment;
 use std::cmp;
 
-fn get_action_color(action: Action) -> DisplayColor {
+const fn get_action_color(action: Action) -> DisplayColor {
 	match action {
 		Action::Break => DisplayColor::ActionBreak,
 		Action::Drop => DisplayColor::ActionDrop,

--- a/src/process/exit_status.rs
+++ b/src/process/exit_status.rs
@@ -8,7 +8,7 @@ pub enum ExitStatus {
 }
 
 impl ExitStatus {
-	pub fn to_code(self) -> i32 {
+	pub const fn to_code(self) -> i32 {
 		match self {
 			Self::ConfigError => 1,
 			Self::FileReadError => 2,

--- a/src/show_commit/status.rs
+++ b/src/show_commit/status.rs
@@ -19,7 +19,7 @@ pub enum Status {
 }
 
 impl Status {
-	pub(super) fn new_from_git_delta(delta: Delta) -> Self {
+	pub(super) const fn new_from_git_delta(delta: Delta) -> Self {
 		match delta {
 			Delta::Added => Self::Added,
 			Delta::Copied => Self::Copied,

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -276,21 +276,21 @@ impl ViewData {
 		&self.prompt
 	}
 
-	pub(super) fn get_leading_lines(&self) -> &Vec<ViewLine> {
+	pub(super) const fn get_leading_lines(&self) -> &Vec<ViewLine> {
 		match &self.leading_lines_cache {
 			Some(lines) => lines,
 			None => &self.empty_lines,
 		}
 	}
 
-	pub(super) fn get_lines(&self) -> &Vec<ViewLine> {
+	pub(super) const fn get_lines(&self) -> &Vec<ViewLine> {
 		match &self.lines_cache {
 			Some(lines) => lines,
 			None => &self.empty_lines,
 		}
 	}
 
-	pub(super) fn get_trailing_lines(&self) -> &Vec<ViewLine> {
+	pub(super) const fn get_trailing_lines(&self) -> &Vec<ViewLine> {
 		match &self.trailing_lines_cache {
 			Some(lines) => lines,
 			None => &self.empty_lines,


### PR DESCRIPTION
# What

The latest version of Rust allowed more function to be declared as `const fn`. This change ensures that those new cases are converted over to `const fn` and fixes the broken build.