### PR TITLE
Add module test utilities and confirm abort tests

### DIFF
--- a/src/display/color_mode.rs
+++ b/src/display/color_mode.rs
@@ -1,7 +1,7 @@
 use crate::display::color_mode::ColorMode::{EightBit, FourBit, TrueColor};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub(super) enum ColorMode {
+pub enum ColorMode {
 	TwoTone,
 	ThreeBit,
 	FourBit,

--- a/src/display/curses.rs
+++ b/src/display/curses.rs
@@ -1,4 +1,7 @@
+#[cfg(not(test))]
 pub use super::ncurses::Curses;
+#[cfg(test)]
+pub use super::virtual_curses::Curses;
 
 pub use pancurses::{
 	chtype,

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,4 +1,7 @@
+#[cfg(not(test))]
 mod ncurses;
+#[cfg(test)]
+mod virtual_curses;
 
 pub mod color;
 mod color_manager;

--- a/src/display/ncurses.rs
+++ b/src/display/ncurses.rs
@@ -1,6 +1,6 @@
 use crate::display::color_mode::ColorMode;
+use crate::display::curses::{chtype, Input};
 use crate::display::utils::detect_color_mode;
-use pancurses::{chtype, Input};
 
 pub struct Curses {
 	color_mode: ColorMode,

--- a/src/display/virtual_curses.rs
+++ b/src/display/virtual_curses.rs
@@ -1,0 +1,159 @@
+#![allow(non_camel_case_types)]
+
+use crate::build_trace;
+use crate::display::color_mode::ColorMode;
+use crate::display::utils::detect_color_mode;
+use crate::display::{chtype, Input};
+use std::cell::RefCell;
+
+pub struct Curses {
+	attributes: RefCell<chtype>,
+	color_mode: ColorMode,
+	color_pairs: [(i16, i16); 255],
+	colors: [(i16, i16, i16); 255],
+	function_call_trace: RefCell<Vec<(String, Vec<String>)>>,
+	output: RefCell<Vec<String>>,
+	input: RefCell<Vec<Input>>,
+	position: RefCell<(i32, i32)>,
+	size: RefCell<(i32, i32)>,
+}
+
+impl Curses {
+	pub(crate) fn new() -> Self {
+		Self {
+			attributes: RefCell::new(0),
+			color_mode: detect_color_mode(16),
+			color_pairs: [(0, 0); 255],
+			colors: [(0, 0, 0); 255],
+			function_call_trace: RefCell::new(vec![build_trace!("new")]),
+			output: RefCell::new(vec![]),
+			input: RefCell::new(vec![]),
+			position: RefCell::new((0, 0)),
+			size: RefCell::new((10, 10)),
+		}
+	}
+
+	pub(crate) fn get_function_trace(&self) -> Vec<(String, Vec<String>)> {
+		self.function_call_trace.borrow().clone()
+	}
+
+	pub(crate) fn push_input(&mut self, input: Input) {
+		self.input.borrow_mut().push(input);
+	}
+
+	pub(super) fn init_color(&mut self, index: i16, red: i16, green: i16, blue: i16) {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("init_color", index, red, green, blue));
+		self.colors[index as usize] = (red, green, blue);
+	}
+
+	pub(super) fn init_color_pair(&mut self, index: i16, foreground: i16, background: i16) -> chtype {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("init_color_pair", index, foreground, background));
+		self.color_pairs[index as usize] = (foreground, background);
+		index as chtype
+	}
+
+	pub(super) fn get_color_mode(&self) -> &ColorMode {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("get_color_mode"));
+		&self.color_mode
+	}
+
+	pub(super) fn erase(&self) {
+		self.function_call_trace.borrow_mut().push(build_trace!("erase"));
+		self.output.borrow_mut().clear();
+	}
+
+	pub(super) fn refresh(&self) {
+		self.function_call_trace.borrow_mut().push(build_trace!("refresh"));
+	}
+
+	pub(super) fn addstr(&self, s: &str) {
+		self.function_call_trace.borrow_mut().push(build_trace!("addstr", s));
+		self.output.borrow_mut().push(String::from(s));
+	}
+
+	pub(super) fn attrset<T: Into<chtype>>(&self, attributes: T) {
+		let attributes = attributes.into();
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("attrset", attributes));
+		self.attributes.replace(attributes);
+	}
+
+	pub(super) fn attron<T: Into<chtype>>(&self, attributes: T) {
+		let attributes = attributes.into();
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("attron", attributes));
+		let attr = *self.attributes.borrow();
+		self.attributes.replace(attr | attributes);
+	}
+
+	pub(super) fn attroff<T: Into<chtype>>(&self, attributes: T) {
+		let attributes = attributes.into();
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("attroff", attributes));
+		let attr = *self.attributes.borrow();
+		self.attributes.replace(attr & !attributes);
+	}
+
+	pub(super) fn getch(&self) -> Option<Input> {
+		self.function_call_trace.borrow_mut().push(build_trace!("getch"));
+		self.input.borrow_mut().pop()
+	}
+
+	pub(crate) fn get_cur_y(&self) -> i32 {
+		self.function_call_trace.borrow_mut().push(build_trace!("get_cur_y"));
+		(*self.position.borrow()).1
+	}
+
+	pub(super) fn get_max_x(&self) -> i32 {
+		self.function_call_trace.borrow_mut().push(build_trace!("get_max_x"));
+		(*self.size.borrow()).0
+	}
+
+	pub(super) fn get_max_y(&self) -> i32 {
+		self.function_call_trace.borrow_mut().push(build_trace!("get_max_y"));
+		(*self.size.borrow()).1
+	}
+
+	pub(crate) fn hline(&self, ch: char, width: i32) {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("hline", ch, width));
+	}
+
+	pub(crate) fn mv(&self, y: i32, x: i32) {
+		self.function_call_trace.borrow_mut().push(build_trace!("mv", y, x));
+		self.position.replace((x, y));
+	}
+
+	pub(crate) fn resize_term(&self, nlines: i32, ncols: i32) {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("resize_term", nlines, ncols));
+		self.size.replace((ncols, nlines));
+	}
+
+	pub(super) fn def_prog_mode(&self) {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("def_prog_mode"));
+	}
+
+	pub(super) fn reset_prog_mode(&self) {
+		self.function_call_trace
+			.borrow_mut()
+			.push(build_trace!("reset_prog_mode"));
+	}
+
+	pub(super) fn endwin(&self) {
+		self.function_call_trace.borrow_mut().push(build_trace!("endwin"));
+	}
+}

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -29,10 +29,7 @@ pub struct GitInteractive {
 }
 
 impl GitInteractive {
-	pub(crate) fn new_from_filepath(filepath: &str, comment_char: &str) -> Result<Self, String> {
-		let path = PathBuf::from(filepath);
-		let lines = load_filepath(&path, comment_char)?;
-
+	pub(crate) fn new(lines: Vec<Line>, path: PathBuf, comment_char: &str) -> Result<Self, String> {
 		Ok(Self {
 			filepath: path,
 			lines,
@@ -40,6 +37,12 @@ impl GitInteractive {
 			visual_index_start: 1,
 			comment_char: String::from(comment_char),
 		})
+	}
+
+	pub(crate) fn new_from_filepath(filepath: &str, comment_char: &str) -> Result<Self, String> {
+		let path = PathBuf::from(filepath);
+		let lines = load_filepath(&path, comment_char)?;
+		Self::new(lines, path, comment_char)
 	}
 
 	pub(crate) fn write_file(&self) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ mod input;
 mod list;
 mod process;
 mod show_commit;
+#[cfg(test)]
+#[macro_use]
+mod testutil;
 mod view;
 mod window_size_error;
 

--- a/src/process/exit_status.rs
+++ b/src/process/exit_status.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExitStatus {
 	ConfigError,
 	FileReadError,

--- a/src/process/handle_input_result.rs
+++ b/src/process/handle_input_result.rs
@@ -2,6 +2,7 @@ use crate::input::Input;
 use crate::process::exit_status::ExitStatus;
 use crate::process::state::State;
 
+#[derive(Debug, PartialEq)]
 pub struct HandleInputResult {
 	pub(super) exit_status: Option<ExitStatus>,
 	pub(super) input: Input,

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,212 @@
+use crate::config::Config;
+use crate::display::curses::{Curses, Input as PancursesInput};
+use crate::display::Display;
+use crate::git_interactive::GitInteractive;
+use crate::input::input_handler::InputHandler;
+use crate::input::Input;
+use crate::list::line::Line;
+use crate::process::exit_status::ExitStatus;
+use crate::process::handle_input_result::{HandleInputResult, HandleInputResultBuilder};
+use crate::process::process_module::ProcessModule;
+use crate::process::state::State;
+use crate::view::View;
+use std::env::set_var;
+use std::path::Path;
+
+#[macro_export]
+macro_rules! build_trace {
+	($name:expr) => {{
+		let args: Vec<String> = vec![];
+		(String::from($name), args)
+	}};
+	($name:expr, $($arg:expr),*) => {{
+		let mut args = vec![];
+		$( args.push(format!("{}", $arg)); )*
+		(String::from($name), args)
+	}};
+}
+
+pub fn panic_trace_error(e: &(String, Vec<String>), trace: &Vec<(String, Vec<String>)>) {
+	panic!(vec![
+		"\n==========",
+		"Missing function call in trace",
+		format!("Call: {}({})", e.0, e.1.join(", ")).as_str(),
+		"Trace:",
+		trace
+			.clone()
+			.iter()
+			.map(|(f, args)| {
+				format!(
+					"\t{}({})",
+					f,
+					args.iter()
+						.map(|v| v.replace("\n", "\\n"))
+						.collect::<Vec<String>>()
+						.join(", ")
+				)
+			})
+			.collect::<Vec<String>>()
+			.join("\n")
+			.as_str(),
+		"==========\n"
+	]
+	.join("\n"));
+}
+
+pub fn compare_trace(actual: &Vec<(String, Vec<String>)>, expected: &Vec<(String, Vec<String>)>) {
+	let mut e_iter = expected.iter();
+	let mut a_iter = actual.iter();
+	'trace: loop {
+		if let Some(e) = e_iter.next() {
+			loop {
+				if let Some(a) = a_iter.next() {
+					// function name and argument length must match
+					if !a.0.eq(&e.0) || a.1.len() != e.1.len() {
+						continue;
+					}
+					if a.1.iter().zip(&e.1).all(|(a, e)| e.eq("*") || a.eq(e)) {
+						continue 'trace;
+					}
+				}
+				else {
+					panic_trace_error(&e, &actual);
+				}
+			}
+		}
+		else {
+			break;
+		}
+	}
+
+	if let Some(e) = e_iter.next() {
+		panic_trace_error(&e, &actual);
+	}
+}
+
+pub fn _process_module_build_view_data_test<F>(
+	lines: Vec<&str>,
+	view_size: (i32, i32),
+	position: (i32, i32),
+	expected_trace: Vec<(String, Vec<String>)>,
+	get_module: F,
+) where
+	F: FnOnce(&Config, &Display<'_>) -> Box<dyn ProcessModule>,
+{
+	set_var(
+		"GIT_DIR",
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("test")
+			.join("fixtures")
+			.join("simple")
+			.to_str()
+			.unwrap(),
+	);
+	let config = Config::new().unwrap();
+	let mut curses = Curses::new();
+	curses.mv(position.1, position.0);
+	curses.resize_term(view_size.1, view_size.0);
+	let display = Display::new(&mut curses, &config.theme);
+	let view = View::new(&display, &config);
+	let git_interactive = GitInteractive::new(
+		lines.iter().map(|l| Line::new(l).unwrap()).collect(),
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("test")
+			.join("git-rebase-todo-short"),
+		"#",
+	)
+	.unwrap();
+	let mut module = get_module(&config, &display);
+	let view_data = module.build_view_data(&view, &git_interactive);
+	view.render(view_data);
+	let trace = curses.get_function_trace();
+	compare_trace(&trace, &expected_trace);
+}
+
+#[macro_export]
+macro_rules! process_module_build_view_data_test {
+	($name:ident, $lines:expr, $view_size:expr, $position:expr, $expected_trace:expr, $get_module:expr) => {
+		#[test]
+		#[serial_test::serial]
+		fn $name() {
+			crate::testutil::_process_module_build_view_data_test(
+				$lines,
+				$view_size,
+				$position,
+				$expected_trace,
+				$get_module,
+			);
+		}
+	};
+}
+
+pub fn _process_module_handle_input_test<F>(lines: Vec<&str>, input: PancursesInput, callback: F)
+where F: FnOnce(&InputHandler<'_>, &mut GitInteractive, &View<'_>) {
+	set_var(
+		"GIT_DIR",
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("test")
+			.join("fixtures")
+			.join("simple")
+			.to_str()
+			.unwrap(),
+	);
+	let config = Config::new().unwrap();
+	let mut curses = Curses::new();
+	curses.push_input(input);
+	let display = Display::new(&mut curses, &config.theme);
+	let input_handler = InputHandler::new(&display, &config.key_bindings);
+	let view = View::new(&display, &config);
+	let mut git_interactive = GitInteractive::new(
+		lines.iter().map(|l| Line::new(l).unwrap()).collect(),
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("test")
+			.join("git-rebase-todo-short"),
+		"#",
+	)
+	.unwrap();
+	callback(&input_handler, &mut git_interactive, &view);
+}
+
+#[macro_export]
+macro_rules! process_module_handle_input_test {
+	($name:ident, $lines:expr, $input:expr, $fun:expr) => {
+		#[test]
+		#[serial_test::serial]
+		fn $name() {
+			crate::testutil::_process_module_handle_input_test($lines, $input, $fun);
+		}
+	};
+}
+
+pub fn _assert_handle_input_result(
+	actual: HandleInputResult,
+	input: Input,
+	state: Option<State>,
+	exit_status: Option<ExitStatus>,
+)
+{
+	let mut expected = HandleInputResultBuilder::new(input);
+	if let Some(state) = state {
+		expected = expected.state(state);
+	}
+	if let Some(exit_status) = exit_status {
+		expected = expected.exit_status(exit_status);
+	}
+	assert_eq!(actual, expected.build());
+}
+
+#[macro_export]
+macro_rules! assert_handle_input_result {
+	($actual:expr,input = $input:expr) => {
+		crate::testutil::_assert_handle_input_result($actual, $input, None, None);
+	};
+	($actual:expr,input = $input:expr,state = $state:expr) => {
+		crate::testutil::_assert_handle_input_result($actual, $input, Some($state), None);
+	};
+	($actual:expr,input = $input:expr,exit_status = $exit_status:expr) => {
+		crate::testutil::_assert_handle_input_result($actual, $input, None, Some($exit_status));
+	};
+	($actual:expr,input = $input:expr,state = $state:expr,exit_status = $exit_status:expr) => {
+		crate::testutil::_assert_handle_input_result($actual, $input, Some($state), Some($exit_status));
+	};
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -38,10 +38,12 @@ impl<'v> View<'v> {
 
 		if let Some(prompt) = view_data.get_prompt() {
 			self.display.set_style(false, false, false);
+			self.display.draw_str("\n");
 			self.display.draw_str(&format!(
-				"\n{} ({}/{})? ",
+				"{} ({}/{})?",
 				prompt, self.config.key_bindings.confirm_yes, self.config.key_bindings.confirm_no
 			));
+			self.display.draw_str(" ");
 			return;
 		}
 


### PR DESCRIPTION
# Description

This adds a set of utility macros that assist in the testing of the process module trait functions. The test utilities are not complete but provide enough functionality to add tests for the rather simple confirm abort module.