### PR TITLE
Refactor process module input tests

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -57,7 +57,6 @@ mod tests {
 	use crate::build_render_output;
 	use crate::config::Config;
 	use crate::confirm_abort::ConfirmAbort;
-	use crate::display::curses::Input as CursesInput;
 	use crate::display::Display;
 	use crate::git_interactive::GitInteractive;
 	use crate::input::input_handler::InputHandler;
@@ -79,7 +78,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_yes,
 		vec!["pick aaa comment"],
-		CursesInput::Character('y'),
+		Input::Yes,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -96,7 +95,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_no,
 		vec!["pick aaa comment"],
-		CursesInput::Character('n'),
+		Input::No,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -107,7 +106,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_any_key,
 		vec!["pick aaa comment"],
-		CursesInput::Character('x'),
+		Input::Character('x'),
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -118,7 +117,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_resize,
 		vec!["pick aaa comment"],
-		CursesInput::KeyResize,
+		Input::Resize,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -56,7 +56,6 @@ mod tests {
 	use crate::build_render_output;
 	use crate::config::Config;
 	use crate::confirm_rebase::ConfirmRebase;
-	use crate::display::curses::Input as CursesInput;
 	use crate::display::Display;
 	use crate::git_interactive::GitInteractive;
 	use crate::input::input_handler::InputHandler;
@@ -78,7 +77,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_yes,
 		vec!["pick aaa comment"],
-		CursesInput::Character('y'),
+		Input::Yes,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -96,7 +95,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_no,
 		vec!["pick aaa comment"],
-		CursesInput::Character('n'),
+		Input::No,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -108,7 +107,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_any_key,
 		vec!["pick aaa comment"],
-		CursesInput::Character('x'),
+		Input::Character('x'),
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -119,7 +118,7 @@ mod tests {
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_resize,
 		vec!["pick aaa comment"],
-		CursesInput::KeyResize,
+		Input::Resize,
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -1,3 +1,4 @@
+use crate::config::key_bindings::KeyBindings;
 use crate::config::Config;
 use crate::display::curses::{Curses, Input as PancursesInput};
 use crate::display::Display;
@@ -90,7 +91,89 @@ macro_rules! process_module_test {
 	};
 }
 
-pub fn _process_module_handle_input_test<F>(lines: Vec<&str>, input: PancursesInput, callback: F)
+fn map_input_str_to_curses(input: &str) -> PancursesInput {
+	match input {
+		"Backspace" => PancursesInput::KeyBackspace,
+		"Delete" => PancursesInput::KeyDC,
+		"Down" => PancursesInput::KeyDown,
+		"End" => PancursesInput::KeyEnd,
+		"Enter" => PancursesInput::KeyEnter,
+		"F0" => PancursesInput::KeyF0,
+		"F1" => PancursesInput::KeyF1,
+		"F2" => PancursesInput::KeyF2,
+		"F3" => PancursesInput::KeyF3,
+		"F4" => PancursesInput::KeyF4,
+		"F5" => PancursesInput::KeyF5,
+		"F6" => PancursesInput::KeyF6,
+		"F7" => PancursesInput::KeyF7,
+		"F8" => PancursesInput::KeyF8,
+		"F9" => PancursesInput::KeyF9,
+		"F10" => PancursesInput::KeyF10,
+		"F11" => PancursesInput::KeyF11,
+		"F12" => PancursesInput::KeyF12,
+		"F13" => PancursesInput::KeyF13,
+		"F14" => PancursesInput::KeyF14,
+		"F15" => PancursesInput::KeyF15,
+		"Home" => PancursesInput::KeyHome,
+		"Insert" => PancursesInput::KeyIC,
+		"Left" => PancursesInput::KeyLeft,
+		"PageDown" => PancursesInput::KeyNPage,
+		"PageUp" => PancursesInput::KeyPPage,
+		"Resize" => PancursesInput::KeyResize,
+		"Right" => PancursesInput::KeyRight,
+		"ShiftDelete" => PancursesInput::KeySDC,
+		"ShiftDown" => PancursesInput::KeySF,
+		"ShiftEnd" => PancursesInput::KeySEnd,
+		"ShiftHome" => PancursesInput::KeySHome,
+		"ShiftLeft" => PancursesInput::KeySLeft,
+		"ShiftRight" => PancursesInput::KeySRight,
+		"ShiftTab" => PancursesInput::KeySTab,
+		"ShiftUp" => PancursesInput::KeySR,
+		"Tab" => PancursesInput::Character('\t'),
+		"Up" => PancursesInput::KeyUp,
+		_ => PancursesInput::Character(input.chars().next().unwrap()),
+	}
+}
+
+fn map_input_to_curses(key_bindings: &KeyBindings, input: Input) -> PancursesInput {
+	match input {
+		Input::Abort => map_input_str_to_curses(key_bindings.abort.as_str()),
+		Input::ActionBreak => map_input_str_to_curses(key_bindings.action_break.as_str()),
+		Input::ActionDrop => map_input_str_to_curses(key_bindings.action_drop.as_str()),
+		Input::ActionEdit => map_input_str_to_curses(key_bindings.action_edit.as_str()),
+		Input::ActionFixup => map_input_str_to_curses(key_bindings.action_fixup.as_str()),
+		Input::ActionPick => map_input_str_to_curses(key_bindings.action_pick.as_str()),
+		Input::ActionReword => map_input_str_to_curses(key_bindings.action_reword.as_str()),
+		Input::ActionSquash => map_input_str_to_curses(key_bindings.action_squash.as_str()),
+		Input::Backspace => map_input_str_to_curses("Backspace"),
+		Input::Character(c) => map_input_str_to_curses(c.to_string().as_str()),
+		Input::Delete => map_input_str_to_curses("Delete"),
+		Input::Edit => map_input_str_to_curses("Edit"),
+		Input::Enter => map_input_str_to_curses("Enter"),
+		Input::ForceAbort => map_input_str_to_curses(key_bindings.force_abort.as_str()),
+		Input::ForceRebase => map_input_str_to_curses(key_bindings.force_rebase.as_str()),
+		Input::Help => map_input_str_to_curses(key_bindings.help.as_str()),
+		Input::MoveCursorDown => map_input_str_to_curses(key_bindings.move_down.as_str()),
+		Input::MoveCursorLeft => map_input_str_to_curses(key_bindings.move_left.as_str()),
+		Input::MoveCursorPageDown => map_input_str_to_curses(key_bindings.move_down_step.as_str()),
+		Input::MoveCursorPageUp => map_input_str_to_curses(key_bindings.move_up_step.as_str()),
+		Input::MoveCursorRight => map_input_str_to_curses(key_bindings.move_right.as_str()),
+		Input::MoveCursorUp => map_input_str_to_curses(key_bindings.move_up.as_str()),
+		Input::No => map_input_str_to_curses(key_bindings.confirm_no.as_str()),
+		Input::OpenInEditor => map_input_str_to_curses(key_bindings.open_in_external_editor.as_str()),
+		Input::Other => map_input_str_to_curses("Other"),
+		Input::Rebase => map_input_str_to_curses(key_bindings.rebase.as_str()),
+		Input::Resize => map_input_str_to_curses("Resize"),
+		Input::ShowCommit => map_input_str_to_curses(key_bindings.show_commit.as_str()),
+		Input::ShowDiff => map_input_str_to_curses(key_bindings.show_diff.as_str()),
+		Input::SwapSelectedDown => map_input_str_to_curses(key_bindings.move_selection_down.as_str()),
+		Input::SwapSelectedUp => map_input_str_to_curses(key_bindings.move_selection_up.as_str()),
+		Input::ToggleVisualMode => map_input_str_to_curses(key_bindings.toggle_visual_mode.as_str()),
+		Input::Yes => map_input_str_to_curses(key_bindings.confirm_yes.as_str()),
+	}
+}
+
+pub fn _process_module_handle_input_test<F>(lines: Vec<&str>, input: Input, callback: F)
 where F: FnOnce(&InputHandler<'_>, &mut GitInteractive, &View<'_>) {
 	set_var(
 		"GIT_DIR",
@@ -103,7 +186,7 @@ where F: FnOnce(&InputHandler<'_>, &mut GitInteractive, &View<'_>) {
 	);
 	let config = Config::new().unwrap();
 	let mut curses = Curses::new();
-	curses.push_input(input);
+	curses.push_input(map_input_to_curses(&config.key_bindings, input));
 	let display = Display::new(&mut curses, &config.theme);
 	let input_handler = InputHandler::new(&display, &config.key_bindings);
 	let view = View::new(&display, &config);


### PR DESCRIPTION
The input module tests required knowledge of how Curses parses and converts the raw inputs into the internal representation of inputs. This resulted in fragile tests that would break if the key bindings change or the usages of Curses changed. This updates those tests to take the internal inputs instead of the Curses equivalent.