### PR TITLE
Fix series of linting issues

### DIFF
--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -6,4 +6,11 @@ set -o pipefail
 
 rustup update stable
 rustup component add clippy --toolchain stable
-cargo +stable clippy --all-features
+cargo +stable clippy --all-targets --all-features
+
+# try to run the nightly version, if it exists, but do not fail
+(
+	rustup update nightly && \
+	rustup component add clippy --toolchain nightly && \
+	cargo +nightly clippy --all-targets --all-features
+) || true

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,1262 +1,1259 @@
-#[cfg(test)]
-mod tests {
-	use crate::config::diff_ignore_whitespace_setting::DiffIgnoreWhitespaceSetting;
-	use crate::config::diff_show_whitespace_setting::DiffShowWhitespaceSetting;
-	use crate::config::Config;
-	use crate::display::color::Color;
-	use serial_test::serial;
-	use std::env::{remove_var, set_var};
-	use std::path::Path;
+use crate::config::diff_ignore_whitespace_setting::DiffIgnoreWhitespaceSetting;
+use crate::config::diff_show_whitespace_setting::DiffShowWhitespaceSetting;
+use crate::config::Config;
+use crate::display::color::Color;
+use serial_test::serial;
+use std::env::{remove_var, set_var};
+use std::path::Path;
 
-	fn load_with_config_file(case: &str, test: &str) -> Config {
-		Config::new_from_config(
-			&git2::Config::open(
-				Path::new(env!("CARGO_MANIFEST_DIR"))
-					.join("test")
-					.join("fixtures")
-					.join("config")
-					.join(case)
-					.join(test)
-					.as_path(),
-			)
-			.unwrap(),
-		)
-		.unwrap()
-	}
-
-	fn load_error_with_config_file(case: &str, test: &str) -> String {
-		Config::new_from_config(
-			&git2::Config::open(
-				Path::new(env!("CARGO_MANIFEST_DIR"))
-					.join("test")
-					.join("fixtures")
-					.join("config")
-					.join(case)
-					.join(test)
-					.as_path(),
-			)
-			.unwrap(),
-		)
-		.err()
-		.unwrap()
-	}
-	fn set_git_dir(fixture: &str) {
-		set_var(
-			"GIT_DIR",
+fn load_with_config_file(case: &str, test: &str) -> Config {
+	Config::new_from_config(
+		&git2::Config::open(
 			Path::new(env!("CARGO_MANIFEST_DIR"))
 				.join("test")
 				.join("fixtures")
-				.join(fixture)
-				.to_str()
-				.unwrap(),
-		);
-	}
-
-	#[test]
-	#[serial]
-	fn config_new() {
-		set_git_dir("simple");
-		Config::new().unwrap();
-	}
-
-	#[test]
-	#[serial]
-	fn config_new_invalid_repo() {
-		set_git_dir("does-not-exist");
-		assert!(Config::new()
-			.err()
-			.unwrap()
-			.starts_with("Error reading git config: failed to resolve path"));
-	}
-
-	#[test]
-	fn config_auto_select_next_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert!(!config.auto_select_next);
-	}
-
-	#[test]
-	fn config_auto_select_next_true() {
-		let config = load_with_config_file("auto-select-next", "true.gitconfig");
-		assert!(config.auto_select_next);
-	}
-
-	#[test]
-	fn config_auto_select_next_false() {
-		let config = load_with_config_file("auto-select-next", "false.gitconfig");
-		assert!(!config.auto_select_next);
-	}
-
-	#[test]
-	fn config_auto_select_next_invalid() {
-		assert_eq!(
-			load_error_with_config_file("auto-select-next", "invalid.gitconfig"),
-			"Error reading git config: \"interactive-rebase-tool.autoSelectNext\" is not valid",
-		);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_true() {
-		let config = load_with_config_file("diff-ignore-whitespace", "true.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_on() {
-		let config = load_with_config_file("diff-ignore-whitespace", "on.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_all() {
-		let config = load_with_config_file("diff-ignore-whitespace", "all.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_change() {
-		let config = load_with_config_file("diff-ignore-whitespace", "change.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_false() {
-		let config = load_with_config_file("diff-ignore-whitespace", "false.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_off() {
-		let config = load_with_config_file("diff-ignore-whitespace", "off.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_none() {
-		let config = load_with_config_file("diff-ignore-whitespace", "none.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_mixed_case() {
-		let config = load_with_config_file("diff-ignore-whitespace", "mixed-case.gitconfig");
-		assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
-	}
-
-	#[test]
-	fn config_diff_ignore_whitespace_invalid() {
-		assert_eq!(
-			load_error_with_config_file("diff-ignore-whitespace", "invalid.gitconfig"),
-			"Error reading git config: \"invalid\" is invalid for \"interactive-rebase-tool.diffIgnoreWhitespace\"",
-		);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_true() {
-		let config = load_with_config_file("diff-show-whitespace", "true.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_on() {
-		let config = load_with_config_file("diff-show-whitespace", "on.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_both() {
-		let config = load_with_config_file("diff-show-whitespace", "both.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_trailing() {
-		let config = load_with_config_file("diff-show-whitespace", "trailing.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_leading() {
-		let config = load_with_config_file("diff-show-whitespace", "leading.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Leading);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_false() {
-		let config = load_with_config_file("diff-show-whitespace", "false.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_off() {
-		let config = load_with_config_file("diff-show-whitespace", "off.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_none() {
-		let config = load_with_config_file("diff-show-whitespace", "none.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_mixed_case() {
-		let config = load_with_config_file("diff-show-whitespace", "mixed-case.gitconfig");
-		assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
-	}
-
-	#[test]
-	fn config_diff_show_whitespace_invalid() {
-		assert_eq!(
-			load_error_with_config_file("diff-show-whitespace", "invalid.gitconfig"),
-			"Error reading git config: \"invalid\" is invalid for \"interactive-rebase-tool.diffShowWhitespace\"",
-		);
-	}
-
-	#[test]
-	fn config_diff_tab_width_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.diff_tab_width, 4);
-	}
-
-	#[test]
-	fn config_diff_tab_width() {
-		let config = load_with_config_file("diff-tab-width", ".gitconfig");
-		assert_eq!(config.diff_tab_width, 14);
-	}
-
-	#[test]
-	fn config_diff_tab_invalid() {
-		assert_eq!(
-			load_error_with_config_file("diff-tab-width", "invalid.gitconfig"),
-			"Error reading git config: \"interactive-rebase-tool.diffTabWidth\" is not valid",
-		);
-	}
-
-	#[test]
-	fn config_diff_tab_invalid_range() {
-		assert_eq!(
-			load_error_with_config_file("diff-tab-width", "invalid-range.gitconfig"),
-			"Error reading git config: \"-100\" is outside of value range for \"interactive-rebase-tool.diffTabWidth\"",
-		);
-	}
-
-	#[test]
-	fn config_diff_tab_symbol_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.diff_tab_symbol, "→");
-	}
-
-	#[test]
-	fn config_diff_tab_symbol() {
-		let config = load_with_config_file("diff-tab-symbol", ".gitconfig");
-		assert_eq!(config.diff_tab_symbol, "|");
-	}
-
-	#[test]
-	fn config_diff_tab_symbol_invalid_utf8() {
-		assert_eq!(
-			load_error_with_config_file("diff-tab-symbol", "invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_diff_space_symbol_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.diff_space_symbol, "·");
-	}
-
-	#[test]
-	fn config_diff_space_symbol() {
-		let config = load_with_config_file("diff-space-symbol", ".gitconfig");
-		assert_eq!(config.diff_space_symbol, "-");
-	}
-
-	#[test]
-	fn config_diff_space_symbol_invalid_utf8() {
-		assert_eq!(
-			load_error_with_config_file("diff-space-symbol", "invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_git_comment_char_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.comment_char, "#");
-	}
-
-	#[test]
-	fn config_git_comment_char_auto() {
-		let config = load_with_config_file("comment-char", "auto.gitconfig");
-		assert_eq!(config.git.comment_char, "#");
-	}
-
-	#[test]
-	fn config_git_comment_char() {
-		let config = load_with_config_file("comment-char", ".gitconfig");
-		assert_eq!(config.git.comment_char, ";");
-	}
-
-	#[test]
-	fn config_git_comment_char_invalid() {
-		assert_eq!(
-			load_error_with_config_file("comment-char", "invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_git_diff_context_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.diff_context, 3);
-	}
-
-	#[test]
-	fn config_git_diff_context() {
-		let config = load_with_config_file("diff-context", ".gitconfig");
-		assert_eq!(config.git.diff_context, 5);
-	}
-
-	#[test]
-	fn config_git_diff_context_invalid() {
-		assert_eq!(
-			load_error_with_config_file("diff-context", "invalid.gitconfig"),
-			"Error reading git config: \"diff.context\" is not valid"
-		);
-	}
-
-	#[test]
-	fn config_git_diff_context_invalid_range() {
-		assert_eq!(
-			load_error_with_config_file("diff-context", "invalid-range.gitconfig"),
-			"Error reading git config: \"-100\" is outside of value range for \"diff.context\""
-		);
-	}
-
-	#[test]
-	fn config_git_diff_renames_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.diff_renames, true);
-		assert_eq!(config.git.diff_copies, false);
-	}
-
-	#[test]
-	fn config_git_diff_renames_true() {
-		let config = load_with_config_file("diff-renames", "true.gitconfig");
-		assert_eq!(config.git.diff_renames, true);
-		assert_eq!(config.git.diff_copies, false);
-	}
-
-	#[test]
-	fn config_git_diff_renames_false() {
-		let config = load_with_config_file("diff-renames", "false.gitconfig");
-		assert_eq!(config.git.diff_renames, false);
-		assert_eq!(config.git.diff_copies, false);
-	}
-
-	#[test]
-	fn config_git_diff_renames_copy() {
-		let config = load_with_config_file("diff-renames", "copy.gitconfig");
-		assert_eq!(config.git.diff_renames, true);
-		assert_eq!(config.git.diff_copies, true);
-	}
-
-	#[test]
-	fn config_git_diff_renames_copies() {
-		let config = load_with_config_file("diff-renames", "copies.gitconfig");
-		assert_eq!(config.git.diff_renames, true);
-		assert_eq!(config.git.diff_copies, true);
-	}
-
-	#[test]
-	fn config_git_diff_renames_mixed_case() {
-		let config = load_with_config_file("diff-renames", "mixed-case.gitconfig");
-		assert_eq!(config.git.diff_renames, true);
-		assert_eq!(config.git.diff_copies, true);
-	}
-
-	#[test]
-	fn config_git_diff_renames_invalid() {
-		assert_eq!(
-			load_error_with_config_file("diff-renames", "invalid.gitconfig"),
-			"Error reading git config: \"invalid\" is not valid for \"diff.renames\""
-		);
-	}
-
-	#[test]
-	#[serial]
-	fn config_git_editor_default_no_env() {
-		remove_var("VISUAL");
-		remove_var("EDITOR");
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.editor, "vi");
-	}
-
-	#[test]
-	#[serial]
-	fn config_git_editor_default_visual_env() {
-		remove_var("EDITOR");
-		set_var("VISUAL", "visual-editor");
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.editor, "visual-editor");
-	}
-
-	#[test]
-	#[serial]
-	fn config_git_editor_default_editor_env() {
-		remove_var("VISUAL");
-		set_var("EDITOR", "editor");
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.git.editor, "editor");
-	}
-
-	#[test]
-	#[serial]
-	fn config_git_editor() {
-		remove_var("VISUAL");
-		remove_var("EDITOR");
-		let config = load_with_config_file("editor", ".gitconfig");
-		assert_eq!(config.git.editor, "custom");
-	}
-
-	#[test]
-	#[serial]
-	fn config_git_editor_invalid() {
-		remove_var("VISUAL");
-		remove_var("EDITOR");
-		assert_eq!(
-			load_error_with_config_file("editor", "invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_key_bindings_key_mixed_case() {
-		let config = load_with_config_file("key-bindings", "key-mixed-case.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Backspace");
-	}
-
-	#[test]
-	fn config_key_bindings_key_backspace() {
-		let config = load_with_config_file("key-bindings", "key-backspace.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Backspace");
-	}
-
-	#[test]
-	fn config_key_bindings_key_delete() {
-		let config = load_with_config_file("key-bindings", "key-delete.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Delete");
-	}
-
-	#[test]
-	fn config_key_bindings_key_down() {
-		let config = load_with_config_file("key-bindings", "key-down.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Down");
-	}
-
-	#[test]
-	fn config_key_bindings_key_end() {
-		let config = load_with_config_file("key-bindings", "key-end.gitconfig");
-		assert_eq!(config.key_bindings.abort, "End");
-	}
-
-	#[test]
-	fn config_key_bindings_key_enter() {
-		let config = load_with_config_file("key-bindings", "key-enter.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Enter");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f0() {
-		let config = load_with_config_file("key-bindings", "key-f0.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F0");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f1() {
-		let config = load_with_config_file("key-bindings", "key-f1.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F1");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f2() {
-		let config = load_with_config_file("key-bindings", "key-f2.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F2");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f3() {
-		let config = load_with_config_file("key-bindings", "key-f3.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F3");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f4() {
-		let config = load_with_config_file("key-bindings", "key-f4.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F4");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f5() {
-		let config = load_with_config_file("key-bindings", "key-f5.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F5");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f6() {
-		let config = load_with_config_file("key-bindings", "key-f6.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F6");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f7() {
-		let config = load_with_config_file("key-bindings", "key-f7.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F7");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f8() {
-		let config = load_with_config_file("key-bindings", "key-f8.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F8");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f9() {
-		let config = load_with_config_file("key-bindings", "key-f9.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F9");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f10() {
-		let config = load_with_config_file("key-bindings", "key-f10.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F10");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f11() {
-		let config = load_with_config_file("key-bindings", "key-f11.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F11");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f12() {
-		let config = load_with_config_file("key-bindings", "key-f12.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F12");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f13() {
-		let config = load_with_config_file("key-bindings", "key-f13.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F13");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f14() {
-		let config = load_with_config_file("key-bindings", "key-f14.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F14");
-	}
-
-	#[test]
-	fn config_key_bindings_key_f15() {
-		let config = load_with_config_file("key-bindings", "key-f15.gitconfig");
-		assert_eq!(config.key_bindings.abort, "F15");
-	}
-
-	#[test]
-	fn config_key_bindings_key_home() {
-		let config = load_with_config_file("key-bindings", "key-home.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Home");
-	}
-
-	#[test]
-	fn config_key_bindings_key_insert() {
-		let config = load_with_config_file("key-bindings", "key-insert.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Insert");
-	}
-
-	#[test]
-	fn config_key_bindings_key_left() {
-		let config = load_with_config_file("key-bindings", "key-left.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Left");
-	}
-
-	#[test]
-	fn config_key_bindings_key_pagedown() {
-		let config = load_with_config_file("key-bindings", "key-pagedown.gitconfig");
-		assert_eq!(config.key_bindings.abort, "PageDown");
-	}
-
-	#[test]
-	fn config_key_bindings_key_pageup() {
-		let config = load_with_config_file("key-bindings", "key-pageup.gitconfig");
-		assert_eq!(config.key_bindings.abort, "PageUp");
-	}
-
-	#[test]
-	fn config_key_bindings_key_right() {
-		let config = load_with_config_file("key-bindings", "key-right.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Right");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_delete() {
-		let config = load_with_config_file("key-bindings", "key-shift-delete.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftDelete");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_down() {
-		let config = load_with_config_file("key-bindings", "key-shift-down.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftDown");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_end() {
-		let config = load_with_config_file("key-bindings", "key-shift-end.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftEnd");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_home() {
-		let config = load_with_config_file("key-bindings", "key-shift-home.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftHome");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_left() {
-		let config = load_with_config_file("key-bindings", "key-shift-left.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftLeft");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_right() {
-		let config = load_with_config_file("key-bindings", "key-shift-right.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftRight");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_tab() {
-		let config = load_with_config_file("key-bindings", "key-shift-tab.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftTab");
-	}
-
-	#[test]
-	fn config_key_bindings_key_shift_up() {
-		let config = load_with_config_file("key-bindings", "key-shift-up.gitconfig");
-		assert_eq!(config.key_bindings.abort, "ShiftUp");
-	}
-
-	#[test]
-	fn config_key_bindings_key_tab() {
-		let config = load_with_config_file("key-bindings", "key-tab.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Tab");
-	}
-
-	#[test]
-	fn config_key_bindings_key_up() {
-		let config = load_with_config_file("key-bindings", "key-up.gitconfig");
-		assert_eq!(config.key_bindings.abort, "Up");
-	}
-
-	#[test]
-	fn config_key_bindings_invalid() {
-		assert_eq!(
-			load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_key_bindings_key_multiple_characters() {
-		assert_eq!(
-			load_error_with_config_file("key-bindings", "key-multiple-characters.gitconfig"),
-			"Error reading git config: interactive-rebase-tool.inputAbort must contain only one character"
-		);
-	}
-
-	#[test]
-	fn config_key_bindings_key_invalid() {
-		assert_eq!(
-			load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
-			"Error reading git config: configuration value is not valid utf8"
-		);
-	}
-
-	#[test]
-	fn config_key_bindings_abort_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.abort, "q");
-	}
-
-	#[test]
-	fn config_key_bindings_abort() {
-		let config = load_with_config_file("key-bindings", "abort.gitconfig");
-		assert_eq!(config.key_bindings.abort, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_break_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_break, "b");
-	}
-
-	#[test]
-	fn config_key_bindings_action_break() {
-		let config = load_with_config_file("key-bindings", "action-break.gitconfig");
-		assert_eq!(config.key_bindings.action_break, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_drop_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_drop, "d");
-	}
-
-	#[test]
-	fn config_key_bindings_action_drop() {
-		let config = load_with_config_file("key-bindings", "action-drop.gitconfig");
-		assert_eq!(config.key_bindings.action_drop, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_edit_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_edit, "e");
-	}
-
-	#[test]
-	fn config_key_bindings_action_edit() {
-		let config = load_with_config_file("key-bindings", "action-edit.gitconfig");
-		assert_eq!(config.key_bindings.action_edit, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_fixup_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_fixup, "f");
-	}
-
-	#[test]
-	fn config_key_bindings_action_fixup() {
-		let config = load_with_config_file("key-bindings", "action-fixup.gitconfig");
-		assert_eq!(config.key_bindings.action_fixup, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_pick_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_pick, "p");
-	}
-
-	#[test]
-	fn config_key_bindings_action_pick() {
-		let config = load_with_config_file("key-bindings", "action-pick.gitconfig");
-		assert_eq!(config.key_bindings.action_pick, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_reword_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_reword, "r");
-	}
-
-	#[test]
-	fn config_key_bindings_action_reword() {
-		let config = load_with_config_file("key-bindings", "action-reword.gitconfig");
-		assert_eq!(config.key_bindings.action_reword, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_action_squash_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.action_squash, "s");
-	}
-
-	#[test]
-	fn config_key_bindings_action_squash() {
-		let config = load_with_config_file("key-bindings", "action-squash.gitconfig");
-		assert_eq!(config.key_bindings.action_squash, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_confirm_no_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.confirm_no, "n");
-	}
-
-	#[test]
-	fn config_key_bindings_confirm_no() {
-		let config = load_with_config_file("key-bindings", "confirm-no.gitconfig");
-		assert_eq!(config.key_bindings.confirm_no, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_confirm_yes_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.confirm_yes, "y");
-	}
-
-	#[test]
-	fn config_key_bindings_confirm_yes() {
-		let config = load_with_config_file("key-bindings", "confirm-yes.gitconfig");
-		assert_eq!(config.key_bindings.confirm_yes, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_edit_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.edit, "E");
-	}
-
-	#[test]
-	fn config_key_bindings_confirm_edit() {
-		let config = load_with_config_file("key-bindings", "edit.gitconfig");
-		assert_eq!(config.key_bindings.edit, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_force_abort_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.force_abort, "Q");
-	}
-
-	#[test]
-	fn config_key_bindings_force_abort() {
-		let config = load_with_config_file("key-bindings", "force-abort.gitconfig");
-		assert_eq!(config.key_bindings.force_abort, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_force_rebase_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.force_rebase, "W");
-	}
-
-	#[test]
-	fn config_key_bindings_force_rebase() {
-		let config = load_with_config_file("key-bindings", "force-rebase.gitconfig");
-		assert_eq!(config.key_bindings.force_rebase, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_help_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.help, "?");
-	}
-
-	#[test]
-	fn config_key_bindings_help() {
-		let config = load_with_config_file("key-bindings", "help.gitconfig");
-		assert_eq!(config.key_bindings.help, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_down_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_down, "Down");
-	}
-
-	#[test]
-	fn config_key_bindings_move_down() {
-		let config = load_with_config_file("key-bindings", "move-down.gitconfig");
-		assert_eq!(config.key_bindings.move_down, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_left_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_left, "Left");
-	}
-
-	#[test]
-	fn config_key_bindings_move_left() {
-		let config = load_with_config_file("key-bindings", "move-left.gitconfig");
-		assert_eq!(config.key_bindings.move_left, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_right_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_right, "Right");
-	}
-
-	#[test]
-	fn config_key_bindings_move_right() {
-		let config = load_with_config_file("key-bindings", "move-right.gitconfig");
-		assert_eq!(config.key_bindings.move_right, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_step_up_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_up_step, "PageUp");
-	}
-
-	#[test]
-	fn config_key_bindings_move_step_up() {
-		let config = load_with_config_file("key-bindings", "move-step-up.gitconfig");
-		assert_eq!(config.key_bindings.move_up_step, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_step_down_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_down_step, "PageDown");
-	}
-
-	#[test]
-	fn config_key_bindings_move_step_down() {
-		let config = load_with_config_file("key-bindings", "move-step-down.gitconfig");
-		assert_eq!(config.key_bindings.move_down_step, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_selection_down_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_selection_down, "j");
-	}
-
-	#[test]
-	fn config_key_bindings_move_selection_down() {
-		let config = load_with_config_file("key-bindings", "move-selection-down.gitconfig");
-		assert_eq!(config.key_bindings.move_selection_down, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_selection_up_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_selection_up, "k");
-	}
-
-	#[test]
-	fn config_key_bindings_move_selection_up() {
-		let config = load_with_config_file("key-bindings", "move-selection-up.gitconfig");
-		assert_eq!(config.key_bindings.move_selection_up, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_move_up_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.move_up, "Up");
-	}
-
-	#[test]
-	fn config_key_bindings_move_up() {
-		let config = load_with_config_file("key-bindings", "move-up.gitconfig");
-		assert_eq!(config.key_bindings.move_up, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_open_in_external_editor_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.open_in_external_editor, "!");
-	}
-
-	#[test]
-	fn config_key_bindings_open_in_external_editor() {
-		let config = load_with_config_file("key-bindings", "open-in-external-editor.gitconfig");
-		assert_eq!(config.key_bindings.open_in_external_editor, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_rebase_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.rebase, "w");
-	}
-
-	#[test]
-	fn config_key_bindings_rebase() {
-		let config = load_with_config_file("key-bindings", "rebase.gitconfig");
-		assert_eq!(config.key_bindings.rebase, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_show_commit_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.show_commit, "c");
-	}
-
-	#[test]
-	fn config_key_bindings_show_commit() {
-		let config = load_with_config_file("key-bindings", "show-commit.gitconfig");
-		assert_eq!(config.key_bindings.show_commit, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_show_diff_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.show_diff, "d");
-	}
-
-	#[test]
-	fn config_key_bindings_show_diff() {
-		let config = load_with_config_file("key-bindings", "show-diff.gitconfig");
-		assert_eq!(config.key_bindings.show_diff, "X");
-	}
-
-	#[test]
-	fn config_key_bindings_toggle_visual_mode_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.key_bindings.toggle_visual_mode, "v");
-	}
-
-	#[test]
-	fn config_key_bindings_toggle_visual_mode() {
-		let config = load_with_config_file("key-bindings", "toggle-visual-mode.gitconfig");
-		assert_eq!(config.key_bindings.toggle_visual_mode, "X");
-	}
-
-	#[test]
-	fn config_theme_character_vertical_spacing_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.character_vertical_spacing, "~");
-	}
-
-	#[test]
-	fn config_theme_character_vertical_spacing() {
-		let config = load_with_config_file("theme", "character-vertical-spacing.gitconfig");
-		assert_eq!(config.theme.character_vertical_spacing, "X");
-	}
-
-	#[test]
-	fn config_theme_color_action_break_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_break, Color::LightWhite);
-	}
-
-	#[test]
-	fn config_theme_color_action_break() {
-		let config = load_with_config_file("theme", "color-action-break.gitconfig");
-		assert_eq!(config.theme.color_action_break, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_drop_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_drop, Color::LightRed);
-	}
-
-	#[test]
-	fn config_theme_color_action_drop() {
-		let config = load_with_config_file("theme", "color-action-drop.gitconfig");
-		assert_eq!(config.theme.color_action_drop, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_edit_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_edit, Color::LightBlue);
-	}
-
-	#[test]
-	fn config_theme_color_action_edit() {
-		let config = load_with_config_file("theme", "color-action-edit.gitconfig");
-		assert_eq!(config.theme.color_action_edit, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_exec_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_exec, Color::LightWhite);
-	}
-
-	#[test]
-	fn config_theme_color_action_exec() {
-		let config = load_with_config_file("theme", "color-action-exec.gitconfig");
-		assert_eq!(config.theme.color_action_exec, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_fixup_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_fixup, Color::LightMagenta);
-	}
-
-	#[test]
-	fn config_theme_color_action_fixup() {
-		let config = load_with_config_file("theme", "color-action-fixup.gitconfig");
-		assert_eq!(config.theme.color_action_fixup, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_pick_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_pick, Color::LightGreen);
-	}
-
-	#[test]
-	fn config_theme_color_action_pick() {
-		let config = load_with_config_file("theme", "color-action-pick.gitconfig");
-		assert_eq!(config.theme.color_action_pick, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_reword_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_reword, Color::LightYellow);
-	}
-
-	#[test]
-	fn config_theme_color_action_reword() {
-		let config = load_with_config_file("theme", "color-action-reword.gitconfig");
-		assert_eq!(config.theme.color_action_reword, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_action_squash_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_action_squash, Color::LightCyan);
-	}
-
-	#[test]
-	fn config_theme_color_action_squash() {
-		let config = load_with_config_file("theme", "color-action-squash.gitconfig");
-		assert_eq!(config.theme.color_action_squash, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_background_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_background, Color::Default);
-	}
-
-	#[test]
-	fn config_theme_color_background() {
-		let config = load_with_config_file("theme", "color-background.gitconfig");
-		assert_eq!(config.theme.color_background, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_diff_add_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_diff_add, Color::LightGreen);
-	}
-
-	#[test]
-	fn config_theme_color_diff_add() {
-		let config = load_with_config_file("theme", "color-diff-add.gitconfig");
-		assert_eq!(config.theme.color_diff_add, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_diff_change_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_diff_change, Color::LightYellow);
-	}
-
-	#[test]
-	fn config_theme_color_diff_change() {
-		let config = load_with_config_file("theme", "color-diff-change.gitconfig");
-		assert_eq!(config.theme.color_diff_change, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_diff_context_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_diff_context, Color::LightWhite);
-	}
-
-	#[test]
-	fn config_theme_color_diff_context() {
-		let config = load_with_config_file("theme", "color-diff-context.gitconfig");
-		assert_eq!(config.theme.color_diff_context, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_diff_remove_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_diff_remove, Color::LightRed);
-	}
-
-	#[test]
-	fn config_theme_color_diff_remove() {
-		let config = load_with_config_file("theme", "color-diff-remove.gitconfig");
-		assert_eq!(config.theme.color_diff_remove, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_diff_whitespace_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_diff_whitespace, Color::LightBlack);
-	}
-
-	#[test]
-	fn config_theme_color_diff_whitespace() {
-		let config = load_with_config_file("theme", "color-diff-whitespace.gitconfig");
-		assert_eq!(config.theme.color_diff_whitespace, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_foreground_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_foreground, Color::Default);
-	}
-
-	#[test]
-	fn config_theme_color_foreground() {
-		let config = load_with_config_file("theme", "color-foreground.gitconfig");
-		assert_eq!(config.theme.color_foreground, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_indicator_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_indicator, Color::LightCyan);
-	}
-
-	#[test]
-	fn config_theme_color_indicator() {
-		let config = load_with_config_file("theme", "color-indicator.gitconfig");
-		assert_eq!(config.theme.color_indicator, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_selected_background_default() {
-		let config = load_with_config_file("empty", ".gitconfig");
-		assert_eq!(config.theme.color_selected_background, Color::Index(237));
-	}
-
-	#[test]
-	fn config_theme_color_selected() {
-		let config = load_with_config_file("theme", "color-selected-background.gitconfig");
-		assert_eq!(config.theme.color_selected_background, Color::Index(10));
-	}
-
-	#[test]
-	fn config_theme_color_invalid() {
-		assert_eq!(
-			load_error_with_config_file("theme", "color-invalid.gitconfig"),
-			"Error reading git config: \"interactive-rebase-tool.breakColor\" is not valid"
-		);
-	}
-
-	#[test]
-	fn config_theme_color_invalid_range_under() {
-		assert_eq!(
-			load_error_with_config_file("theme", "color-invalid-range-under.gitconfig"),
-			"Invalid color value: -2"
-		);
-	}
-
-	#[test]
-	fn config_theme_color_invalid_range_above() {
-		assert_eq!(
-			load_error_with_config_file("theme", "color-invalid-range-above.gitconfig"),
-			"Invalid color value: 256"
-		);
-	}
+				.join("config")
+				.join(case)
+				.join(test)
+				.as_path(),
+		)
+		.unwrap(),
+	)
+	.unwrap()
+}
+
+fn load_error_with_config_file(case: &str, test: &str) -> String {
+	Config::new_from_config(
+		&git2::Config::open(
+			Path::new(env!("CARGO_MANIFEST_DIR"))
+				.join("test")
+				.join("fixtures")
+				.join("config")
+				.join(case)
+				.join(test)
+				.as_path(),
+		)
+		.unwrap(),
+	)
+	.err()
+	.unwrap()
+}
+fn set_git_dir(fixture: &str) {
+	set_var(
+		"GIT_DIR",
+		Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("test")
+			.join("fixtures")
+			.join(fixture)
+			.to_str()
+			.unwrap(),
+	);
+}
+
+#[test]
+#[serial]
+fn config_new() {
+	set_git_dir("simple");
+	Config::new().unwrap();
+}
+
+#[test]
+#[serial]
+fn config_new_invalid_repo() {
+	set_git_dir("does-not-exist");
+	assert!(Config::new()
+		.err()
+		.unwrap()
+		.starts_with("Error reading git config: failed to resolve path"));
+}
+
+#[test]
+fn config_auto_select_next_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert!(!config.auto_select_next);
+}
+
+#[test]
+fn config_auto_select_next_true() {
+	let config = load_with_config_file("auto-select-next", "true.gitconfig");
+	assert!(config.auto_select_next);
+}
+
+#[test]
+fn config_auto_select_next_false() {
+	let config = load_with_config_file("auto-select-next", "false.gitconfig");
+	assert!(!config.auto_select_next);
+}
+
+#[test]
+fn config_auto_select_next_invalid() {
+	assert_eq!(
+		load_error_with_config_file("auto-select-next", "invalid.gitconfig"),
+		"Error reading git config: \"interactive-rebase-tool.autoSelectNext\" is not valid",
+	);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_true() {
+	let config = load_with_config_file("diff-ignore-whitespace", "true.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_on() {
+	let config = load_with_config_file("diff-ignore-whitespace", "on.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_all() {
+	let config = load_with_config_file("diff-ignore-whitespace", "all.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_change() {
+	let config = load_with_config_file("diff-ignore-whitespace", "change.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_false() {
+	let config = load_with_config_file("diff-ignore-whitespace", "false.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_off() {
+	let config = load_with_config_file("diff-ignore-whitespace", "off.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_none() {
+	let config = load_with_config_file("diff-ignore-whitespace", "none.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_mixed_case() {
+	let config = load_with_config_file("diff-ignore-whitespace", "mixed-case.gitconfig");
+	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
+}
+
+#[test]
+fn config_diff_ignore_whitespace_invalid() {
+	assert_eq!(
+		load_error_with_config_file("diff-ignore-whitespace", "invalid.gitconfig"),
+		"Error reading git config: \"invalid\" is invalid for \"interactive-rebase-tool.diffIgnoreWhitespace\"",
+	);
+}
+
+#[test]
+fn config_diff_show_whitespace_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
+}
+
+#[test]
+fn config_diff_show_whitespace_true() {
+	let config = load_with_config_file("diff-show-whitespace", "true.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
+}
+
+#[test]
+fn config_diff_show_whitespace_on() {
+	let config = load_with_config_file("diff-show-whitespace", "on.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
+}
+
+#[test]
+fn config_diff_show_whitespace_both() {
+	let config = load_with_config_file("diff-show-whitespace", "both.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
+}
+
+#[test]
+fn config_diff_show_whitespace_trailing() {
+	let config = load_with_config_file("diff-show-whitespace", "trailing.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
+}
+
+#[test]
+fn config_diff_show_whitespace_leading() {
+	let config = load_with_config_file("diff-show-whitespace", "leading.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Leading);
+}
+
+#[test]
+fn config_diff_show_whitespace_false() {
+	let config = load_with_config_file("diff-show-whitespace", "false.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_show_whitespace_off() {
+	let config = load_with_config_file("diff-show-whitespace", "off.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_show_whitespace_none() {
+	let config = load_with_config_file("diff-show-whitespace", "none.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
+}
+
+#[test]
+fn config_diff_show_whitespace_mixed_case() {
+	let config = load_with_config_file("diff-show-whitespace", "mixed-case.gitconfig");
+	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
+}
+
+#[test]
+fn config_diff_show_whitespace_invalid() {
+	assert_eq!(
+		load_error_with_config_file("diff-show-whitespace", "invalid.gitconfig"),
+		"Error reading git config: \"invalid\" is invalid for \"interactive-rebase-tool.diffShowWhitespace\"",
+	);
+}
+
+#[test]
+fn config_diff_tab_width_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.diff_tab_width, 4);
+}
+
+#[test]
+fn config_diff_tab_width() {
+	let config = load_with_config_file("diff-tab-width", ".gitconfig");
+	assert_eq!(config.diff_tab_width, 14);
+}
+
+#[test]
+fn config_diff_tab_invalid() {
+	assert_eq!(
+		load_error_with_config_file("diff-tab-width", "invalid.gitconfig"),
+		"Error reading git config: \"interactive-rebase-tool.diffTabWidth\" is not valid",
+	);
+}
+
+#[test]
+fn config_diff_tab_invalid_range() {
+	assert_eq!(
+		load_error_with_config_file("diff-tab-width", "invalid-range.gitconfig"),
+		"Error reading git config: \"-100\" is outside of value range for \"interactive-rebase-tool.diffTabWidth\"",
+	);
+}
+
+#[test]
+fn config_diff_tab_symbol_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.diff_tab_symbol, "→");
+}
+
+#[test]
+fn config_diff_tab_symbol() {
+	let config = load_with_config_file("diff-tab-symbol", ".gitconfig");
+	assert_eq!(config.diff_tab_symbol, "|");
+}
+
+#[test]
+fn config_diff_tab_symbol_invalid_utf8() {
+	assert_eq!(
+		load_error_with_config_file("diff-tab-symbol", "invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_diff_space_symbol_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.diff_space_symbol, "·");
+}
+
+#[test]
+fn config_diff_space_symbol() {
+	let config = load_with_config_file("diff-space-symbol", ".gitconfig");
+	assert_eq!(config.diff_space_symbol, "-");
+}
+
+#[test]
+fn config_diff_space_symbol_invalid_utf8() {
+	assert_eq!(
+		load_error_with_config_file("diff-space-symbol", "invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_git_comment_char_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.comment_char, "#");
+}
+
+#[test]
+fn config_git_comment_char_auto() {
+	let config = load_with_config_file("comment-char", "auto.gitconfig");
+	assert_eq!(config.git.comment_char, "#");
+}
+
+#[test]
+fn config_git_comment_char() {
+	let config = load_with_config_file("comment-char", ".gitconfig");
+	assert_eq!(config.git.comment_char, ";");
+}
+
+#[test]
+fn config_git_comment_char_invalid() {
+	assert_eq!(
+		load_error_with_config_file("comment-char", "invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_git_diff_context_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.diff_context, 3);
+}
+
+#[test]
+fn config_git_diff_context() {
+	let config = load_with_config_file("diff-context", ".gitconfig");
+	assert_eq!(config.git.diff_context, 5);
+}
+
+#[test]
+fn config_git_diff_context_invalid() {
+	assert_eq!(
+		load_error_with_config_file("diff-context", "invalid.gitconfig"),
+		"Error reading git config: \"diff.context\" is not valid"
+	);
+}
+
+#[test]
+fn config_git_diff_context_invalid_range() {
+	assert_eq!(
+		load_error_with_config_file("diff-context", "invalid-range.gitconfig"),
+		"Error reading git config: \"-100\" is outside of value range for \"diff.context\""
+	);
+}
+
+#[test]
+fn config_git_diff_renames_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.diff_renames, true);
+	assert_eq!(config.git.diff_copies, false);
+}
+
+#[test]
+fn config_git_diff_renames_true() {
+	let config = load_with_config_file("diff-renames", "true.gitconfig");
+	assert_eq!(config.git.diff_renames, true);
+	assert_eq!(config.git.diff_copies, false);
+}
+
+#[test]
+fn config_git_diff_renames_false() {
+	let config = load_with_config_file("diff-renames", "false.gitconfig");
+	assert_eq!(config.git.diff_renames, false);
+	assert_eq!(config.git.diff_copies, false);
+}
+
+#[test]
+fn config_git_diff_renames_copy() {
+	let config = load_with_config_file("diff-renames", "copy.gitconfig");
+	assert_eq!(config.git.diff_renames, true);
+	assert_eq!(config.git.diff_copies, true);
+}
+
+#[test]
+fn config_git_diff_renames_copies() {
+	let config = load_with_config_file("diff-renames", "copies.gitconfig");
+	assert_eq!(config.git.diff_renames, true);
+	assert_eq!(config.git.diff_copies, true);
+}
+
+#[test]
+fn config_git_diff_renames_mixed_case() {
+	let config = load_with_config_file("diff-renames", "mixed-case.gitconfig");
+	assert_eq!(config.git.diff_renames, true);
+	assert_eq!(config.git.diff_copies, true);
+}
+
+#[test]
+fn config_git_diff_renames_invalid() {
+	assert_eq!(
+		load_error_with_config_file("diff-renames", "invalid.gitconfig"),
+		"Error reading git config: \"invalid\" is not valid for \"diff.renames\""
+	);
+}
+
+#[test]
+#[serial]
+fn config_git_editor_default_no_env() {
+	remove_var("VISUAL");
+	remove_var("EDITOR");
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.editor, "vi");
+}
+
+#[test]
+#[serial]
+fn config_git_editor_default_visual_env() {
+	remove_var("EDITOR");
+	set_var("VISUAL", "visual-editor");
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.editor, "visual-editor");
+}
+
+#[test]
+#[serial]
+fn config_git_editor_default_editor_env() {
+	remove_var("VISUAL");
+	set_var("EDITOR", "editor");
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.git.editor, "editor");
+}
+
+#[test]
+#[serial]
+fn config_git_editor() {
+	remove_var("VISUAL");
+	remove_var("EDITOR");
+	let config = load_with_config_file("editor", ".gitconfig");
+	assert_eq!(config.git.editor, "custom");
+}
+
+#[test]
+#[serial]
+fn config_git_editor_invalid() {
+	remove_var("VISUAL");
+	remove_var("EDITOR");
+	assert_eq!(
+		load_error_with_config_file("editor", "invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_key_bindings_key_mixed_case() {
+	let config = load_with_config_file("key-bindings", "key-mixed-case.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Backspace");
+}
+
+#[test]
+fn config_key_bindings_key_backspace() {
+	let config = load_with_config_file("key-bindings", "key-backspace.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Backspace");
+}
+
+#[test]
+fn config_key_bindings_key_delete() {
+	let config = load_with_config_file("key-bindings", "key-delete.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Delete");
+}
+
+#[test]
+fn config_key_bindings_key_down() {
+	let config = load_with_config_file("key-bindings", "key-down.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Down");
+}
+
+#[test]
+fn config_key_bindings_key_end() {
+	let config = load_with_config_file("key-bindings", "key-end.gitconfig");
+	assert_eq!(config.key_bindings.abort, "End");
+}
+
+#[test]
+fn config_key_bindings_key_enter() {
+	let config = load_with_config_file("key-bindings", "key-enter.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Enter");
+}
+
+#[test]
+fn config_key_bindings_key_f0() {
+	let config = load_with_config_file("key-bindings", "key-f0.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F0");
+}
+
+#[test]
+fn config_key_bindings_key_f1() {
+	let config = load_with_config_file("key-bindings", "key-f1.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F1");
+}
+
+#[test]
+fn config_key_bindings_key_f2() {
+	let config = load_with_config_file("key-bindings", "key-f2.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F2");
+}
+
+#[test]
+fn config_key_bindings_key_f3() {
+	let config = load_with_config_file("key-bindings", "key-f3.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F3");
+}
+
+#[test]
+fn config_key_bindings_key_f4() {
+	let config = load_with_config_file("key-bindings", "key-f4.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F4");
+}
+
+#[test]
+fn config_key_bindings_key_f5() {
+	let config = load_with_config_file("key-bindings", "key-f5.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F5");
+}
+
+#[test]
+fn config_key_bindings_key_f6() {
+	let config = load_with_config_file("key-bindings", "key-f6.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F6");
+}
+
+#[test]
+fn config_key_bindings_key_f7() {
+	let config = load_with_config_file("key-bindings", "key-f7.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F7");
+}
+
+#[test]
+fn config_key_bindings_key_f8() {
+	let config = load_with_config_file("key-bindings", "key-f8.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F8");
+}
+
+#[test]
+fn config_key_bindings_key_f9() {
+	let config = load_with_config_file("key-bindings", "key-f9.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F9");
+}
+
+#[test]
+fn config_key_bindings_key_f10() {
+	let config = load_with_config_file("key-bindings", "key-f10.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F10");
+}
+
+#[test]
+fn config_key_bindings_key_f11() {
+	let config = load_with_config_file("key-bindings", "key-f11.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F11");
+}
+
+#[test]
+fn config_key_bindings_key_f12() {
+	let config = load_with_config_file("key-bindings", "key-f12.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F12");
+}
+
+#[test]
+fn config_key_bindings_key_f13() {
+	let config = load_with_config_file("key-bindings", "key-f13.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F13");
+}
+
+#[test]
+fn config_key_bindings_key_f14() {
+	let config = load_with_config_file("key-bindings", "key-f14.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F14");
+}
+
+#[test]
+fn config_key_bindings_key_f15() {
+	let config = load_with_config_file("key-bindings", "key-f15.gitconfig");
+	assert_eq!(config.key_bindings.abort, "F15");
+}
+
+#[test]
+fn config_key_bindings_key_home() {
+	let config = load_with_config_file("key-bindings", "key-home.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Home");
+}
+
+#[test]
+fn config_key_bindings_key_insert() {
+	let config = load_with_config_file("key-bindings", "key-insert.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Insert");
+}
+
+#[test]
+fn config_key_bindings_key_left() {
+	let config = load_with_config_file("key-bindings", "key-left.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Left");
+}
+
+#[test]
+fn config_key_bindings_key_pagedown() {
+	let config = load_with_config_file("key-bindings", "key-pagedown.gitconfig");
+	assert_eq!(config.key_bindings.abort, "PageDown");
+}
+
+#[test]
+fn config_key_bindings_key_pageup() {
+	let config = load_with_config_file("key-bindings", "key-pageup.gitconfig");
+	assert_eq!(config.key_bindings.abort, "PageUp");
+}
+
+#[test]
+fn config_key_bindings_key_right() {
+	let config = load_with_config_file("key-bindings", "key-right.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Right");
+}
+
+#[test]
+fn config_key_bindings_key_shift_delete() {
+	let config = load_with_config_file("key-bindings", "key-shift-delete.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftDelete");
+}
+
+#[test]
+fn config_key_bindings_key_shift_down() {
+	let config = load_with_config_file("key-bindings", "key-shift-down.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftDown");
+}
+
+#[test]
+fn config_key_bindings_key_shift_end() {
+	let config = load_with_config_file("key-bindings", "key-shift-end.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftEnd");
+}
+
+#[test]
+fn config_key_bindings_key_shift_home() {
+	let config = load_with_config_file("key-bindings", "key-shift-home.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftHome");
+}
+
+#[test]
+fn config_key_bindings_key_shift_left() {
+	let config = load_with_config_file("key-bindings", "key-shift-left.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftLeft");
+}
+
+#[test]
+fn config_key_bindings_key_shift_right() {
+	let config = load_with_config_file("key-bindings", "key-shift-right.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftRight");
+}
+
+#[test]
+fn config_key_bindings_key_shift_tab() {
+	let config = load_with_config_file("key-bindings", "key-shift-tab.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftTab");
+}
+
+#[test]
+fn config_key_bindings_key_shift_up() {
+	let config = load_with_config_file("key-bindings", "key-shift-up.gitconfig");
+	assert_eq!(config.key_bindings.abort, "ShiftUp");
+}
+
+#[test]
+fn config_key_bindings_key_tab() {
+	let config = load_with_config_file("key-bindings", "key-tab.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Tab");
+}
+
+#[test]
+fn config_key_bindings_key_up() {
+	let config = load_with_config_file("key-bindings", "key-up.gitconfig");
+	assert_eq!(config.key_bindings.abort, "Up");
+}
+
+#[test]
+fn config_key_bindings_invalid() {
+	assert_eq!(
+		load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_key_bindings_key_multiple_characters() {
+	assert_eq!(
+		load_error_with_config_file("key-bindings", "key-multiple-characters.gitconfig"),
+		"Error reading git config: interactive-rebase-tool.inputAbort must contain only one character"
+	);
+}
+
+#[test]
+fn config_key_bindings_key_invalid() {
+	assert_eq!(
+		load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
+		"Error reading git config: configuration value is not valid utf8"
+	);
+}
+
+#[test]
+fn config_key_bindings_abort_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.abort, "q");
+}
+
+#[test]
+fn config_key_bindings_abort() {
+	let config = load_with_config_file("key-bindings", "abort.gitconfig");
+	assert_eq!(config.key_bindings.abort, "X");
+}
+
+#[test]
+fn config_key_bindings_action_break_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_break, "b");
+}
+
+#[test]
+fn config_key_bindings_action_break() {
+	let config = load_with_config_file("key-bindings", "action-break.gitconfig");
+	assert_eq!(config.key_bindings.action_break, "X");
+}
+
+#[test]
+fn config_key_bindings_action_drop_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_drop, "d");
+}
+
+#[test]
+fn config_key_bindings_action_drop() {
+	let config = load_with_config_file("key-bindings", "action-drop.gitconfig");
+	assert_eq!(config.key_bindings.action_drop, "X");
+}
+
+#[test]
+fn config_key_bindings_action_edit_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_edit, "e");
+}
+
+#[test]
+fn config_key_bindings_action_edit() {
+	let config = load_with_config_file("key-bindings", "action-edit.gitconfig");
+	assert_eq!(config.key_bindings.action_edit, "X");
+}
+
+#[test]
+fn config_key_bindings_action_fixup_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_fixup, "f");
+}
+
+#[test]
+fn config_key_bindings_action_fixup() {
+	let config = load_with_config_file("key-bindings", "action-fixup.gitconfig");
+	assert_eq!(config.key_bindings.action_fixup, "X");
+}
+
+#[test]
+fn config_key_bindings_action_pick_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_pick, "p");
+}
+
+#[test]
+fn config_key_bindings_action_pick() {
+	let config = load_with_config_file("key-bindings", "action-pick.gitconfig");
+	assert_eq!(config.key_bindings.action_pick, "X");
+}
+
+#[test]
+fn config_key_bindings_action_reword_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_reword, "r");
+}
+
+#[test]
+fn config_key_bindings_action_reword() {
+	let config = load_with_config_file("key-bindings", "action-reword.gitconfig");
+	assert_eq!(config.key_bindings.action_reword, "X");
+}
+
+#[test]
+fn config_key_bindings_action_squash_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.action_squash, "s");
+}
+
+#[test]
+fn config_key_bindings_action_squash() {
+	let config = load_with_config_file("key-bindings", "action-squash.gitconfig");
+	assert_eq!(config.key_bindings.action_squash, "X");
+}
+
+#[test]
+fn config_key_bindings_confirm_no_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.confirm_no, "n");
+}
+
+#[test]
+fn config_key_bindings_confirm_no() {
+	let config = load_with_config_file("key-bindings", "confirm-no.gitconfig");
+	assert_eq!(config.key_bindings.confirm_no, "X");
+}
+
+#[test]
+fn config_key_bindings_confirm_yes_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.confirm_yes, "y");
+}
+
+#[test]
+fn config_key_bindings_confirm_yes() {
+	let config = load_with_config_file("key-bindings", "confirm-yes.gitconfig");
+	assert_eq!(config.key_bindings.confirm_yes, "X");
+}
+
+#[test]
+fn config_key_bindings_edit_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.edit, "E");
+}
+
+#[test]
+fn config_key_bindings_confirm_edit() {
+	let config = load_with_config_file("key-bindings", "edit.gitconfig");
+	assert_eq!(config.key_bindings.edit, "X");
+}
+
+#[test]
+fn config_key_bindings_force_abort_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.force_abort, "Q");
+}
+
+#[test]
+fn config_key_bindings_force_abort() {
+	let config = load_with_config_file("key-bindings", "force-abort.gitconfig");
+	assert_eq!(config.key_bindings.force_abort, "X");
+}
+
+#[test]
+fn config_key_bindings_force_rebase_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.force_rebase, "W");
+}
+
+#[test]
+fn config_key_bindings_force_rebase() {
+	let config = load_with_config_file("key-bindings", "force-rebase.gitconfig");
+	assert_eq!(config.key_bindings.force_rebase, "X");
+}
+
+#[test]
+fn config_key_bindings_help_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.help, "?");
+}
+
+#[test]
+fn config_key_bindings_help() {
+	let config = load_with_config_file("key-bindings", "help.gitconfig");
+	assert_eq!(config.key_bindings.help, "X");
+}
+
+#[test]
+fn config_key_bindings_move_down_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_down, "Down");
+}
+
+#[test]
+fn config_key_bindings_move_down() {
+	let config = load_with_config_file("key-bindings", "move-down.gitconfig");
+	assert_eq!(config.key_bindings.move_down, "X");
+}
+
+#[test]
+fn config_key_bindings_move_left_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_left, "Left");
+}
+
+#[test]
+fn config_key_bindings_move_left() {
+	let config = load_with_config_file("key-bindings", "move-left.gitconfig");
+	assert_eq!(config.key_bindings.move_left, "X");
+}
+
+#[test]
+fn config_key_bindings_move_right_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_right, "Right");
+}
+
+#[test]
+fn config_key_bindings_move_right() {
+	let config = load_with_config_file("key-bindings", "move-right.gitconfig");
+	assert_eq!(config.key_bindings.move_right, "X");
+}
+
+#[test]
+fn config_key_bindings_move_step_up_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_up_step, "PageUp");
+}
+
+#[test]
+fn config_key_bindings_move_step_up() {
+	let config = load_with_config_file("key-bindings", "move-step-up.gitconfig");
+	assert_eq!(config.key_bindings.move_up_step, "X");
+}
+
+#[test]
+fn config_key_bindings_move_step_down_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_down_step, "PageDown");
+}
+
+#[test]
+fn config_key_bindings_move_step_down() {
+	let config = load_with_config_file("key-bindings", "move-step-down.gitconfig");
+	assert_eq!(config.key_bindings.move_down_step, "X");
+}
+
+#[test]
+fn config_key_bindings_move_selection_down_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_selection_down, "j");
+}
+
+#[test]
+fn config_key_bindings_move_selection_down() {
+	let config = load_with_config_file("key-bindings", "move-selection-down.gitconfig");
+	assert_eq!(config.key_bindings.move_selection_down, "X");
+}
+
+#[test]
+fn config_key_bindings_move_selection_up_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_selection_up, "k");
+}
+
+#[test]
+fn config_key_bindings_move_selection_up() {
+	let config = load_with_config_file("key-bindings", "move-selection-up.gitconfig");
+	assert_eq!(config.key_bindings.move_selection_up, "X");
+}
+
+#[test]
+fn config_key_bindings_move_up_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.move_up, "Up");
+}
+
+#[test]
+fn config_key_bindings_move_up() {
+	let config = load_with_config_file("key-bindings", "move-up.gitconfig");
+	assert_eq!(config.key_bindings.move_up, "X");
+}
+
+#[test]
+fn config_key_bindings_open_in_external_editor_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.open_in_external_editor, "!");
+}
+
+#[test]
+fn config_key_bindings_open_in_external_editor() {
+	let config = load_with_config_file("key-bindings", "open-in-external-editor.gitconfig");
+	assert_eq!(config.key_bindings.open_in_external_editor, "X");
+}
+
+#[test]
+fn config_key_bindings_rebase_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.rebase, "w");
+}
+
+#[test]
+fn config_key_bindings_rebase() {
+	let config = load_with_config_file("key-bindings", "rebase.gitconfig");
+	assert_eq!(config.key_bindings.rebase, "X");
+}
+
+#[test]
+fn config_key_bindings_show_commit_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.show_commit, "c");
+}
+
+#[test]
+fn config_key_bindings_show_commit() {
+	let config = load_with_config_file("key-bindings", "show-commit.gitconfig");
+	assert_eq!(config.key_bindings.show_commit, "X");
+}
+
+#[test]
+fn config_key_bindings_show_diff_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.show_diff, "d");
+}
+
+#[test]
+fn config_key_bindings_show_diff() {
+	let config = load_with_config_file("key-bindings", "show-diff.gitconfig");
+	assert_eq!(config.key_bindings.show_diff, "X");
+}
+
+#[test]
+fn config_key_bindings_toggle_visual_mode_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.key_bindings.toggle_visual_mode, "v");
+}
+
+#[test]
+fn config_key_bindings_toggle_visual_mode() {
+	let config = load_with_config_file("key-bindings", "toggle-visual-mode.gitconfig");
+	assert_eq!(config.key_bindings.toggle_visual_mode, "X");
+}
+
+#[test]
+fn config_theme_character_vertical_spacing_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.character_vertical_spacing, "~");
+}
+
+#[test]
+fn config_theme_character_vertical_spacing() {
+	let config = load_with_config_file("theme", "character-vertical-spacing.gitconfig");
+	assert_eq!(config.theme.character_vertical_spacing, "X");
+}
+
+#[test]
+fn config_theme_color_action_break_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_break, Color::LightWhite);
+}
+
+#[test]
+fn config_theme_color_action_break() {
+	let config = load_with_config_file("theme", "color-action-break.gitconfig");
+	assert_eq!(config.theme.color_action_break, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_drop_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_drop, Color::LightRed);
+}
+
+#[test]
+fn config_theme_color_action_drop() {
+	let config = load_with_config_file("theme", "color-action-drop.gitconfig");
+	assert_eq!(config.theme.color_action_drop, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_edit_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_edit, Color::LightBlue);
+}
+
+#[test]
+fn config_theme_color_action_edit() {
+	let config = load_with_config_file("theme", "color-action-edit.gitconfig");
+	assert_eq!(config.theme.color_action_edit, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_exec_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_exec, Color::LightWhite);
+}
+
+#[test]
+fn config_theme_color_action_exec() {
+	let config = load_with_config_file("theme", "color-action-exec.gitconfig");
+	assert_eq!(config.theme.color_action_exec, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_fixup_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_fixup, Color::LightMagenta);
+}
+
+#[test]
+fn config_theme_color_action_fixup() {
+	let config = load_with_config_file("theme", "color-action-fixup.gitconfig");
+	assert_eq!(config.theme.color_action_fixup, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_pick_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_pick, Color::LightGreen);
+}
+
+#[test]
+fn config_theme_color_action_pick() {
+	let config = load_with_config_file("theme", "color-action-pick.gitconfig");
+	assert_eq!(config.theme.color_action_pick, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_reword_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_reword, Color::LightYellow);
+}
+
+#[test]
+fn config_theme_color_action_reword() {
+	let config = load_with_config_file("theme", "color-action-reword.gitconfig");
+	assert_eq!(config.theme.color_action_reword, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_action_squash_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_action_squash, Color::LightCyan);
+}
+
+#[test]
+fn config_theme_color_action_squash() {
+	let config = load_with_config_file("theme", "color-action-squash.gitconfig");
+	assert_eq!(config.theme.color_action_squash, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_background_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_background, Color::Default);
+}
+
+#[test]
+fn config_theme_color_background() {
+	let config = load_with_config_file("theme", "color-background.gitconfig");
+	assert_eq!(config.theme.color_background, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_diff_add_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_diff_add, Color::LightGreen);
+}
+
+#[test]
+fn config_theme_color_diff_add() {
+	let config = load_with_config_file("theme", "color-diff-add.gitconfig");
+	assert_eq!(config.theme.color_diff_add, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_diff_change_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_diff_change, Color::LightYellow);
+}
+
+#[test]
+fn config_theme_color_diff_change() {
+	let config = load_with_config_file("theme", "color-diff-change.gitconfig");
+	assert_eq!(config.theme.color_diff_change, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_diff_context_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_diff_context, Color::LightWhite);
+}
+
+#[test]
+fn config_theme_color_diff_context() {
+	let config = load_with_config_file("theme", "color-diff-context.gitconfig");
+	assert_eq!(config.theme.color_diff_context, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_diff_remove_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_diff_remove, Color::LightRed);
+}
+
+#[test]
+fn config_theme_color_diff_remove() {
+	let config = load_with_config_file("theme", "color-diff-remove.gitconfig");
+	assert_eq!(config.theme.color_diff_remove, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_diff_whitespace_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_diff_whitespace, Color::LightBlack);
+}
+
+#[test]
+fn config_theme_color_diff_whitespace() {
+	let config = load_with_config_file("theme", "color-diff-whitespace.gitconfig");
+	assert_eq!(config.theme.color_diff_whitespace, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_foreground_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_foreground, Color::Default);
+}
+
+#[test]
+fn config_theme_color_foreground() {
+	let config = load_with_config_file("theme", "color-foreground.gitconfig");
+	assert_eq!(config.theme.color_foreground, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_indicator_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_indicator, Color::LightCyan);
+}
+
+#[test]
+fn config_theme_color_indicator() {
+	let config = load_with_config_file("theme", "color-indicator.gitconfig");
+	assert_eq!(config.theme.color_indicator, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_selected_background_default() {
+	let config = load_with_config_file("empty", ".gitconfig");
+	assert_eq!(config.theme.color_selected_background, Color::Index(237));
+}
+
+#[test]
+fn config_theme_color_selected() {
+	let config = load_with_config_file("theme", "color-selected-background.gitconfig");
+	assert_eq!(config.theme.color_selected_background, Color::Index(10));
+}
+
+#[test]
+fn config_theme_color_invalid() {
+	assert_eq!(
+		load_error_with_config_file("theme", "color-invalid.gitconfig"),
+		"Error reading git config: \"interactive-rebase-tool.breakColor\" is not valid"
+	);
+}
+
+#[test]
+fn config_theme_color_invalid_range_under() {
+	assert_eq!(
+		load_error_with_config_file("theme", "color-invalid-range-under.gitconfig"),
+		"Invalid color value: -2"
+	);
+}
+
+#[test]
+fn config_theme_color_invalid_range_above() {
+	assert_eq!(
+		load_error_with_config_file("theme", "color-invalid-range-above.gitconfig"),
+		"Invalid color value: 256"
+	);
 }

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -70,15 +70,15 @@ mod tests {
 
 	process_module_test!(
 		confirm_abort_build_view_data,
-		vec!["pick aaa comment"],
+		["pick aaa comment"],
 		build_render_output!("{TITLE}", "{PROMPT}", "Are you sure you want to abort"),
 		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(ConfirmAbort::new()) }
 	);
 
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_yes,
-		vec!["pick aaa comment"],
-		vec![Input::Yes],
+		["pick aaa comment"],
+		[Input::Yes],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -94,8 +94,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_no,
-		vec!["pick aaa comment"],
-		vec![Input::No],
+		["pick aaa comment"],
+		[Input::No],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -105,8 +105,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_any_key,
-		vec!["pick aaa comment"],
-		vec![Input::Character('x')],
+		["pick aaa comment"],
+		[Input::Character('x')],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
@@ -116,8 +116,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_abort_handle_input_resize,
-		vec!["pick aaa comment"],
-		vec![Input::Resize],
+		["pick aaa comment"],
+		[Input::Resize],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_abort = ConfirmAbort::new();
 			let result = confirm_abort.handle_input(input_handler, git_interactive, view);

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -69,15 +69,15 @@ mod tests {
 
 	process_module_test!(
 		confirm_rebase_build_view_data,
-		vec!["pick aaa comment"],
+		["pick aaa comment"],
 		build_render_output!("{TITLE}", "{PROMPT}", "Are you sure you want to rebase"),
 		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(ConfirmRebase::new()) }
 	);
 
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_yes,
-		vec!["pick aaa comment"],
-		vec![Input::Yes],
+		["pick aaa comment"],
+		[Input::Yes],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -94,8 +94,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_no,
-		vec!["pick aaa comment"],
-		vec![Input::No],
+		["pick aaa comment"],
+		[Input::No],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -106,8 +106,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_any_key,
-		vec!["pick aaa comment"],
-		vec![Input::Character('x')],
+		["pick aaa comment"],
+		[Input::Character('x')],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
@@ -117,8 +117,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		confirm_rebase_handle_input_resize,
-		vec!["pick aaa comment"],
-		vec![Input::Resize],
+		["pick aaa comment"],
+		[Input::Resize],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut confirm_rebase = ConfirmRebase::new();
 			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);

--- a/src/display/color_mode.rs
+++ b/src/display/color_mode.rs
@@ -74,6 +74,6 @@ mod tests {
 
 	#[test]
 	fn color_mode_equals_other_color_mode() {
-		assert!(ColorMode::TrueColor == ColorMode::TrueColor);
+		assert_eq!(ColorMode::TrueColor, ColorMode::TrueColor);
 	}
 }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -298,7 +298,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_underline_disabled,
-		vec![
+		[
 			build_trace!("attron", "64"),
 			build_trace!("attroff", "256"),
 			build_trace!("attron", "128")
@@ -317,13 +317,13 @@ mod tests {
 
 	display_module_test!(
 		draw_str,
-		vec![build_trace!("addstr", "Test string")],
+		[build_trace!("addstr", "Test string")],
 		|display: &mut Display<'_>| display.draw_str("Test string")
 	);
 
 	display_module_test!(
 		clear,
-		vec![
+		[
 			build_trace!("attrset", "16"),
 			build_trace!("attroff", "64"),
 			build_trace!("attroff", "256"),
@@ -333,193 +333,193 @@ mod tests {
 		|display: &mut Display<'_>| display.clear()
 	);
 
-	display_module_test!(refresh, vec![build_trace!("refresh")], |display: &mut Display<'_>| {
+	display_module_test!(refresh, [build_trace!("refresh")], |display: &mut Display<'_>| {
 		display.refresh()
 	});
 
 	display_module_test!(
 		color_action_break_not_selected,
-		vec![build_trace!("attrset", "20")],
+		[build_trace!("attrset", "20")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionBreak, false)
 	);
 
 	display_module_test!(
 		color_action_break_selected,
-		vec![build_trace!("attrset", "21")],
+		[build_trace!("attrset", "21")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionBreak, true)
 	);
 
 	display_module_test!(
 		color_action_drop_not_selected,
-		vec![build_trace!("attrset", "22")],
+		[build_trace!("attrset", "22")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionDrop, false)
 	);
 
 	display_module_test!(
 		color_action_drop_selected,
-		vec![build_trace!("attrset", "23")],
+		[build_trace!("attrset", "23")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionDrop, true)
 	);
 
 	display_module_test!(
 		color_action_edit_not_selected,
-		vec![build_trace!("attrset", "24")],
+		[build_trace!("attrset", "24")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionEdit, false)
 	);
 
 	display_module_test!(
 		color_action_edit_selected,
-		vec![build_trace!("attrset", "25")],
+		[build_trace!("attrset", "25")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionEdit, true)
 	);
 
 	display_module_test!(
 		color_action_exec_not_selected,
-		vec![build_trace!("attrset", "26")],
+		[build_trace!("attrset", "26")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionExec, false)
 	);
 
 	display_module_test!(
 		color_action_exec_selected,
-		vec![build_trace!("attrset", "27")],
+		[build_trace!("attrset", "27")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionExec, true)
 	);
 
 	display_module_test!(
 		color_action_fixup_not_selected,
-		vec![build_trace!("attrset", "28")],
+		[build_trace!("attrset", "28")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionFixup, false)
 	);
 
 	display_module_test!(
 		color_action_fixup_selected,
-		vec![build_trace!("attrset", "29")],
+		[build_trace!("attrset", "29")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionFixup, true)
 	);
 
 	display_module_test!(
 		color_action_pick_not_selected,
-		vec![build_trace!("attrset", "30")],
+		[build_trace!("attrset", "30")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionPick, false)
 	);
 
 	display_module_test!(
 		color_action_pick_selected,
-		vec![build_trace!("attrset", "31")],
+		[build_trace!("attrset", "31")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionPick, true)
 	);
 
 	display_module_test!(
 		color_action_reword_not_selected,
-		vec![build_trace!("attrset", "32")],
+		[build_trace!("attrset", "32")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionReword, false)
 	);
 
 	display_module_test!(
 		color_action_reword_selected,
-		vec![build_trace!("attrset", "33")],
+		[build_trace!("attrset", "33")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionReword, true)
 	);
 
 	display_module_test!(
 		color_action_squash_not_selected,
-		vec![build_trace!("attrset", "34")],
+		[build_trace!("attrset", "34")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionSquash, false)
 	);
 
 	display_module_test!(
 		color_action_squash_selected,
-		vec![build_trace!("attrset", "35")],
+		[build_trace!("attrset", "35")],
 		|display: &mut Display<'_>| display.color(DisplayColor::ActionSquash, true)
 	);
 
 	display_module_test!(
 		color_normal_not_selected,
-		vec![build_trace!("attrset", "16")],
+		[build_trace!("attrset", "16")],
 		|display: &mut Display<'_>| display.color(DisplayColor::Normal, false)
 	);
 
 	display_module_test!(
 		color_normal_selected,
-		vec![build_trace!("attrset", "17")],
+		[build_trace!("attrset", "17")],
 		|display: &mut Display<'_>| display.color(DisplayColor::Normal, true)
 	);
 
 	display_module_test!(
 		color_indicator_color_not_selected,
-		vec![build_trace!("attrset", "18")],
+		[build_trace!("attrset", "18")],
 		|display: &mut Display<'_>| display.color(DisplayColor::IndicatorColor, false)
 	);
 
 	display_module_test!(
 		color_indiciator_color_selected,
-		vec![build_trace!("attrset", "19")],
+		[build_trace!("attrset", "19")],
 		|display: &mut Display<'_>| display.color(DisplayColor::IndicatorColor, true)
 	);
 
 	display_module_test!(
 		color_diff_add_color_not_selected,
-		vec![build_trace!("attrset", "36")],
+		[build_trace!("attrset", "36")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffAddColor, false)
 	);
 
 	display_module_test!(
 		color_diff_add_color_selected,
-		vec![build_trace!("attrset", "37")],
+		[build_trace!("attrset", "37")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffAddColor, true)
 	);
 
 	display_module_test!(
 		color_diff_remove_color_not_selected,
-		vec![build_trace!("attrset", "40")],
+		[build_trace!("attrset", "40")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffRemoveColor, false)
 	);
 
 	display_module_test!(
 		color_diff_remove_color_selected,
-		vec![build_trace!("attrset", "41")],
+		[build_trace!("attrset", "41")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffRemoveColor, true)
 	);
 
 	display_module_test!(
 		color_diff_change_color_not_selected,
-		vec![build_trace!("attrset", "38")],
+		[build_trace!("attrset", "38")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffChangeColor, false)
 	);
 
 	display_module_test!(
 		color_diff_change_color_selected,
-		vec![build_trace!("attrset", "39")],
+		[build_trace!("attrset", "39")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffChangeColor, true)
 	);
 
 	display_module_test!(
 		color_diff_context_color_not_selected,
-		vec![build_trace!("attrset", "42")],
+		[build_trace!("attrset", "42")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffContextColor, false)
 	);
 
 	display_module_test!(
 		color_diff_context_color_selected,
-		vec![build_trace!("attrset", "43")],
+		[build_trace!("attrset", "43")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffContextColor, true)
 	);
 
 	display_module_test!(
 		color_diff_whitespace_color_not_selected,
-		vec![build_trace!("attrset", "44")],
+		[build_trace!("attrset", "44")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffWhitespaceColor, false)
 	);
 
 	display_module_test!(
 		color_diff_whitespace_color_selected,
-		vec![build_trace!("attrset", "45")],
+		[build_trace!("attrset", "45")],
 		|display: &mut Display<'_>| display.color(DisplayColor::DiffWhitespaceColor, true)
 	);
 
 	display_module_test!(
 		set_style_dim_off_underline_off_reverse_off,
-		vec![
+		[
 			build_trace!("attroff", "64"),
 			build_trace!("attroff", "256"),
 			build_trace!("attroff", "128")
@@ -529,7 +529,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_on_underline_off_reverse_off,
-		vec![
+		[
 			build_trace!("attron", "64"),
 			build_trace!("attroff", "256"),
 			build_trace!("attroff", "128")
@@ -539,7 +539,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_on_underline_off_reverse_on,
-		vec![
+		[
 			build_trace!("attron", "64"),
 			build_trace!("attroff", "256"),
 			build_trace!("attron", "128")
@@ -549,7 +549,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_on_underline_on_reverse_off,
-		vec![
+		[
 			build_trace!("attron", "64"),
 			build_trace!("attron", "256"),
 			build_trace!("attroff", "128")
@@ -559,7 +559,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_on_underline_on_reverse_on,
-		vec![
+		[
 			build_trace!("attron", "64"),
 			build_trace!("attron", "256"),
 			build_trace!("attron", "128")
@@ -569,7 +569,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_off_underline_on_reverse_off,
-		vec![
+		[
 			build_trace!("attroff", "64"),
 			build_trace!("attron", "256"),
 			build_trace!("attroff", "128")
@@ -579,7 +579,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_off_underline_on_reverse_on,
-		vec![
+		[
 			build_trace!("attroff", "64"),
 			build_trace!("attron", "256"),
 			build_trace!("attron", "128")
@@ -589,7 +589,7 @@ mod tests {
 
 	display_module_test!(
 		set_style_dim_off_underline_off_reverse_on,
-		vec![
+		[
 			build_trace!("attroff", "64"),
 			build_trace!("attroff", "256"),
 			build_trace!("attron", "128")
@@ -600,14 +600,14 @@ mod tests {
 	display_module_test!(
 		getch_normal_input,
 		Input::Character('z'),
-		vec![],
+		[],
 		|display: &mut Display<'_>| assert_eq!(display.getch().unwrap(), Input::Character('z'))
 	);
 
 	display_module_test!(
 		getch_resize,
 		Input::KeyResize,
-		vec![
+		[
 			build_trace!("resize_term", "0", "0"),
 			build_trace!("get_max_y"),
 			build_trace!("get_max_x")
@@ -615,19 +615,19 @@ mod tests {
 		|display: &mut Display<'_>| { assert_eq!(display.getch().unwrap(), Input::KeyResize) }
 	);
 
-	display_module_test!(get_window_size, vec![], |display: &mut Display<'_>| {
+	display_module_test!(get_window_size, [], |display: &mut Display<'_>| {
 		assert_eq!(display.get_window_size(), (77, 66));
 	});
 
 	display_module_test!(
 		fill_end_of_line,
-		vec![build_trace!("hline", " ", "77")],
+		[build_trace!("hline", " ", "77")],
 		|display: &mut Display<'_>| display.fill_end_of_line()
 	);
 
 	display_module_test!(
 		move_from_end_of_line,
-		vec![
+		[
 			build_trace!("get_cur_y"),
 			build_trace!("get_max_x"),
 			build_trace!("mv", "13", "65")
@@ -637,7 +637,7 @@ mod tests {
 
 	display_module_test!(
 		leave_temporarily,
-		vec![
+		[
 			build_trace!("def_prog_mode"),
 			build_trace!("endwin"),
 			build_trace!("reset_prog_mode")
@@ -648,7 +648,7 @@ mod tests {
 		}
 	);
 
-	display_module_test!(end, vec![build_trace!("endwin")], |display: &mut Display<'_>| {
+	display_module_test!(end, [build_trace!("endwin")], |display: &mut Display<'_>| {
 		display.end()
 	});
 }

--- a/src/display/testutil.rs
+++ b/src/display/testutil.rs
@@ -7,7 +7,7 @@ use crate::testutil::compare_trace;
 use std::env::set_var;
 use std::path::Path;
 
-pub fn _display_module_test<F>(expected_trace: Vec<(String, Vec<String>)>, input: Option<Input>, callback: F)
+pub fn _display_module_test<F>(expected_trace: &[(String, Vec<String>)], input: Option<Input>, callback: F)
 where F: FnOnce(&mut Display<'_>) {
 	set_var(
 		"GIT_DIR",
@@ -29,7 +29,7 @@ where F: FnOnce(&mut Display<'_>) {
 	let mut display = Display::new(&mut curses, &config.theme);
 	callback(&mut display);
 	let trace = curses.get_function_trace();
-	compare_trace(&trace, &expected_trace);
+	compare_trace(&trace, &expected_trace.to_vec());
 }
 
 // a lot of the testing here is just ensuring that the correct curses function are called
@@ -40,7 +40,7 @@ macro_rules! display_module_test {
 				#[test]
 				#[serial_test::serial]
 				fn test_name() {
-					crate::display::testutil::_display_module_test($expected_trace, None, $fun);
+					crate::display::testutil::_display_module_test(&$expected_trace, None, $fun);
 				}
 			});
 		};
@@ -49,7 +49,7 @@ macro_rules! display_module_test {
 				#[test]
 				#[serial_test::serial]
 				fn test_name() {
-					crate::display::testutil::_display_module_test($expected_trace, Some($input), $fun);
+					crate::display::testutil::_display_module_test(&$expected_trace, Some($input), $fun);
 				}
 			});
 		};

--- a/src/display/virtual_curses.rs
+++ b/src/display/virtual_curses.rs
@@ -94,29 +94,27 @@ impl Curses {
 	}
 
 	pub(super) fn attrset<T: Into<chtype>>(&self, attributes: T) {
-		let attributes = attributes.into();
+		let attrs = attributes.into();
 		self.function_call_trace
 			.borrow_mut()
-			.push(build_trace!("attrset", attributes));
-		self.attributes.replace(attributes);
+			.push(build_trace!("attrset", attrs));
+		self.attributes.replace(attrs);
 	}
 
-	pub(super) fn attron<T: Into<chtype>>(&self, attributes: T) {
-		let attributes = attributes.into();
-		self.function_call_trace
-			.borrow_mut()
-			.push(build_trace!("attron", attributes));
-		let attr = *self.attributes.borrow();
-		self.attributes.replace(attr | attributes);
+	pub(super) fn attron<T: Into<chtype>>(&self, attribute: T) {
+		let attr = attribute.into();
+		let old_attr = *self.attributes.borrow();
+		self.function_call_trace.borrow_mut().push(build_trace!("attron", attr));
+		self.attributes.replace(old_attr | attr);
 	}
 
-	pub(super) fn attroff<T: Into<chtype>>(&self, attributes: T) {
-		let attributes = attributes.into();
+	pub(super) fn attroff<T: Into<chtype>>(&self, attribute: T) {
+		let attr = attribute.into();
+		let old_attr = *self.attributes.borrow();
 		self.function_call_trace
 			.borrow_mut()
-			.push(build_trace!("attroff", attributes));
-		let attr = *self.attributes.borrow();
-		self.attributes.replace(attr & !attributes);
+			.push(build_trace!("attroff", attr));
+		self.attributes.replace(old_attr & !attr);
 	}
 
 	pub(super) fn getch(&self) -> Option<Input> {

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -172,7 +172,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_end,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![],
 		build_render_output!(
@@ -187,7 +187,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_1_left,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft],
 		build_render_output!(
@@ -202,7 +202,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_2_left,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
@@ -217,7 +217,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_1_right,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 5],
 		build_render_output!(
@@ -232,7 +232,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_right,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 6],
 		build_render_output!(
@@ -247,7 +247,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_attempt_past_start,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 10],
 		build_render_output!(
@@ -262,7 +262,7 @@ mod tests {
 
 	process_module_test!(
 		edit_move_cursor_attempt_past_end,
-		vec!["exec foobar"],
+		["exec foobar"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorRight; 5],
 		build_render_output!(
@@ -277,7 +277,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_multiple_width_unicode_single_width,
-		vec!["exec a🗳b"],
+		["exec a🗳b"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
@@ -292,7 +292,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_multiple_width_unicode_emoji,
-		vec!["exec a😀b"],
+		["exec a😀b"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
@@ -307,7 +307,7 @@ mod tests {
 
 	process_module_test!(
 		edit_add_character_end,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::Character('x')],
 		build_render_output!(
@@ -322,7 +322,7 @@ mod tests {
 
 	process_module_test!(
 		edit_add_character_one_from_end,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft, Input::Character('x')],
 		build_render_output!(
@@ -337,7 +337,7 @@ mod tests {
 
 	process_module_test!(
 		edit_add_character_one_from_start,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -357,7 +357,7 @@ mod tests {
 
 	process_module_test!(
 		edit_add_character_at_start,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -378,7 +378,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_backspace_at_end,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::Backspace],
 		build_render_output!(
@@ -393,7 +393,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_backspace_one_from_end,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft, Input::Backspace],
 		build_render_output!(
@@ -408,7 +408,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_backspace_one_from_start,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -428,7 +428,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_backspace_at_start,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -449,7 +449,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_delete_at_end,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::Delete],
 		build_render_output!(
@@ -464,7 +464,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_delete_last_character,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![Input::MoveCursorLeft, Input::Delete],
 		build_render_output!(
@@ -479,7 +479,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_delete_second_character,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -499,7 +499,7 @@ mod tests {
 
 	process_module_test!(
 		edit_cursor_delete_first_character,
-		vec!["exec abcd"],
+		["exec abcd"],
 		process_module_state!(state = State::Edit),
 		vec![
 			Input::MoveCursorLeft,
@@ -520,8 +520,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		edit_resize,
-		vec!["exec foobar"],
-		vec![Input::Resize],
+		["exec foobar"],
+		[Input::Resize],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
 			edit.activate(&State::Edit, git_interactive);
@@ -532,8 +532,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		edit_finish_edit_no_change,
-		vec!["exec foobar"],
-		vec![Input::Enter],
+		["exec foobar"],
+		[Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
 			edit.activate(&State::Edit, git_interactive);
@@ -545,8 +545,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		edit_finish_edit_with_change,
-		vec!["exec foobar"],
-		vec![Input::Character('x'), Input::Enter],
+		["exec foobar"],
+		[Input::Character('x'), Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
 			edit.activate(&State::Edit, git_interactive);
@@ -559,8 +559,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		edit_ignore_other_input,
-		vec!["exec foobar"],
-		vec![Input::Other, Input::Enter],
+		["exec foobar"],
+		[Input::Other, Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
 			edit.activate(&State::Edit, git_interactive);
@@ -571,8 +571,8 @@ mod tests {
 
 	process_module_handle_input_test!(
 		edit_deactivate,
-		vec!["exec foobar"],
-		vec![Input::MoveCursorLeft],
+		["exec foobar"],
+		[Input::MoveCursorLeft],
 		|_: &InputHandler<'_>, git_interactive: &mut GitInteractive, _: &View<'_>| {
 			let mut edit = Edit::new();
 			edit.activate(&State::Edit, git_interactive);

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,7 +15,11 @@ pub struct Error {
 
 impl ProcessModule for Error {
 	fn activate(&mut self, state: &State, _git_interactive: &GitInteractive) {
-		if let State::Error { message, return_state } = state {
+		if let State::Error {
+			ref message,
+			ref return_state,
+		} = *state
+		{
 			self.view_data = Some(ViewData::new_error(message.as_str()));
 			self.return_state = *return_state.clone();
 		}

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -37,7 +37,7 @@ impl<'i> InputHandler<'i> {
 		}
 	}
 
-	fn get_default_input(self: &Self, input: &str) -> Input {
+	fn get_default_input(&self, input: &str) -> Input {
 		match input {
 			i if i == self.key_bindings.move_up.as_str() => Input::MoveCursorUp,
 			i if i == self.key_bindings.move_down.as_str() => Input::MoveCursorDown,
@@ -50,7 +50,7 @@ impl<'i> InputHandler<'i> {
 		}
 	}
 
-	fn get_show_commit_input(self: &Self, input: &str) -> Input {
+	fn get_show_commit_input(&self, input: &str) -> Input {
 		match input {
 			i if i == self.key_bindings.help.as_str() => Input::Help,
 			i if i == self.key_bindings.move_up.as_str() => Input::MoveCursorUp,
@@ -66,7 +66,7 @@ impl<'i> InputHandler<'i> {
 	}
 
 	#[allow(clippy::cognitive_complexity)]
-	fn get_list_input(self: &Self, input: &str) -> Input {
+	fn get_list_input(&self, input: &str) -> Input {
 		match input {
 			i if i == self.key_bindings.abort.as_str() => Input::Abort,
 			i if i == self.key_bindings.rebase.as_str() => Input::Rebase,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,8 @@ struct Exit {
 	status: ExitStatus,
 }
 
+// TODO use the termination trait once rust-lang/rust#43301 is stable
+#[allow(clippy::exit)]
 fn main() {
 	match try_main() {
 		Ok(code) => std::process::exit(code.to_code()),

--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -14,8 +14,8 @@ pub struct Help {
 
 fn get_max_help_key_length(lines: &[(&str, &str)]) -> usize {
 	let mut max_length = 0;
-	for (key, _) in lines {
-		let len = UnicodeSegmentation::graphemes(*key, true).count();
+	for &(key, _) in lines {
+		let len = UnicodeSegmentation::graphemes(key, true).count();
 		if len > max_length {
 			max_length = len;
 		}

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -263,7 +263,7 @@ impl<'r> Process<'r> {
 	fn check_window_size(&mut self) {
 		let (window_width, window_height) = self.view.get_view_size();
 		let check = !(window_width <= MINIMUM_COMPACT_WINDOW_WIDTH || window_height <= MINIMUM_WINDOW_HEIGHT);
-		if let State::WindowSizeError(return_state) = &self.state {
+		if let State::WindowSizeError(ref return_state) = self.state {
 			if check {
 				self.state = *return_state.clone();
 			}

--- a/src/show_commit/commit.rs
+++ b/src/show_commit/commit.rs
@@ -271,7 +271,7 @@ mod tests {
 	fn commit_utils_load_commit_state_load_date() {
 		set_git_dir("simple");
 		let commit = load_commit_state("18d82dcc4c36cade807d7cf79700b6bbad8080b9").unwrap();
-		assert_eq!(commit.get_date().timestamp(), 1580172067);
+		assert_eq!(commit.get_date().timestamp(), 1_580_172_067);
 	}
 
 	#[test]

--- a/src/show_commit/file_stats_builder.rs
+++ b/src/show_commit/file_stats_builder.rs
@@ -20,16 +20,16 @@ impl FileStatsBuilder {
 	}
 
 	fn close_delta(&mut self) {
-		if let Some(d) = &self.delta {
-			match &mut self.file_stat {
-				Some(fs) => fs.add_delta(d.clone()),
+		if let Some(ref d) = self.delta {
+			match self.file_stat {
+				Some(ref mut fs) => fs.add_delta(d.clone()),
 				None => panic!("add_file_stat must be called once before adding a delta"),
 			}
 		}
 	}
 
 	fn close_file_stat(&mut self) {
-		if let Some(fs) = &self.file_stat {
+		if let Some(ref fs) = self.file_stat {
 			self.file_stats.push(fs.clone());
 		}
 	}
@@ -47,8 +47,8 @@ impl FileStatsBuilder {
 	}
 
 	pub(crate) fn add_diff_line(&mut self, diff_line: DiffLine) {
-		match &mut self.delta {
-			Some(d) => d.add_line(diff_line),
+		match self.delta {
+			Some(ref mut d) => d.add_line(diff_line),
 			None => panic!("add_delta must be called once before adding a diff line"),
 		}
 	}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -69,51 +69,49 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
 		let (view_width, view_height) = view.get_view_size();
-		match self.commit {
-			Some(ref commit) => {
-				if self.view_data.is_empty() {
-					let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
+		if let Some(ref commit) = self.commit {
+			if self.view_data.is_empty() {
+				let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
 
-					let commit = commit.as_ref().unwrap(); // if commit is error it will be caught in process
+				let commit = commit.as_ref().unwrap(); // if commit is error it will be caught in process
 
-					self.view_data.push_leading_line(ViewLine::new(vec![
-						LineSegment::new_with_color(
-							if is_full_width { "Commit: " } else { "" },
-							DisplayColor::IndicatorColor,
-						),
-						LineSegment::new(
-							if is_full_width {
-								commit.get_hash().to_string()
-							}
-							else {
-								let hash = commit.get_hash();
-								let max_index = hash.len().min(8);
-								format!("{:8} ", hash[0..max_index].to_string())
-							}
-							.as_str(),
-						),
-					]));
+				self.view_data.push_leading_line(ViewLine::new(vec![
+					LineSegment::new_with_color(
+						if is_full_width { "Commit: " } else { "" },
+						DisplayColor::IndicatorColor,
+					),
+					LineSegment::new(
+						if is_full_width {
+							commit.get_hash().to_string()
+						}
+						else {
+							let hash = commit.get_hash();
+							let max_index = hash.len().min(8);
+							format!("{:8} ", hash[0..max_index].to_string())
+						}
+						.as_str(),
+					),
+				]));
 
-					match self.state {
-						ShowCommitState::Overview => {
-							self.view_builder
-								.build_view_data_for_overview(&mut self.view_data, commit, is_full_width);
-						},
-						ShowCommitState::Diff => {
-							self.view_builder
-								.build_view_data_diff(&mut self.view_data, commit, is_full_width)
-						},
-					}
-					self.view_data.set_view_size(view_width, view_height);
-					self.view_data.rebuild();
+				match self.state {
+					ShowCommitState::Overview => {
+						self.view_builder
+							.build_view_data_for_overview(&mut self.view_data, commit, is_full_width);
+					},
+					ShowCommitState::Diff => {
+						self.view_builder
+							.build_view_data_diff(&mut self.view_data, commit, is_full_width)
+					},
 				}
-				&self.view_data
-			},
-			None => {
-				self.no_commit_view_data.set_view_size(view_width, view_height);
-				self.no_commit_view_data.rebuild();
-				&self.no_commit_view_data
-			},
+				self.view_data.set_view_size(view_width, view_height);
+				self.view_data.rebuild();
+			}
+			&self.view_data
+		}
+		else {
+			self.no_commit_view_data.set_view_size(view_width, view_height);
+			self.no_commit_view_data.rebuild();
+			&self.no_commit_view_data
 		}
 	}
 

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -44,8 +44,8 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 	fn activate(&mut self, _state: &State, git_interactive: &GitInteractive) {
 		// skip loading commit data if the currently loaded commit has not changed, this retains
 		// position after returning to the list view or help
-		if let Some(commit) = &self.commit {
-			if let Ok(commit) = commit {
+		if let Some(ref commit) = self.commit {
+			if let Ok(ref commit) = *commit {
 				if commit.get_hash() == git_interactive.get_selected_line_hash() {
 					return;
 				}
@@ -69,8 +69,8 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
 		let (view_width, view_height) = view.get_view_size();
-		match &self.commit {
-			Some(commit) => {
+		match self.commit {
+			Some(ref commit) => {
 				if self.view_data.is_empty() {
 					let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
 
@@ -120,8 +120,8 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 	fn process(&mut self, _git_interactive: &mut GitInteractive, _: &View<'_>) -> ProcessResult {
 		let mut result = ProcessResultBuilder::new();
 
-		if let Some(commit) = &self.commit {
-			if let Err(e) = commit {
+		if let Some(ref commit) = self.commit {
+			if let Err(ref e) = *commit {
 				result = result.error(e.as_str(), State::List);
 			}
 		}

--- a/src/show_commit/user.rs
+++ b/src/show_commit/user.rs
@@ -21,16 +21,16 @@ impl User {
 	pub(super) fn to_string(&self) -> Option<String> {
 		let name = &self.name;
 		let email = &self.email;
-		match name {
-			Some(n) => {
-				match email {
-					Some(e) => Some(format!("{} <{}>", *n, *e)),
+		match *name {
+			Some(ref n) => {
+				match *email {
+					Some(ref e) => Some(format!("{} <{}>", *n, *e)),
 					None => Some(n.to_string()),
 				}
 			},
 			None => {
-				match email {
-					Some(e) => Some(format!("<{}>", *e)),
+				match *email {
+					Some(ref e) => Some(format!("<{}>", *e)),
 					None => None,
 				}
 			},

--- a/src/show_commit/util.rs
+++ b/src/show_commit/util.rs
@@ -28,7 +28,7 @@ pub(super) fn get_stat_item_segments(
 ) -> Vec<LineSegment>
 {
 	let status_name = if is_full_width {
-		match status {
+		match *status {
 			Status::Added => format!("{:>8}: ", "added"),
 			Status::Copied => format!("{:>8}: ", "copied"),
 			Status::Deleted => format!("{:>8}: ", "deleted"),
@@ -40,7 +40,7 @@ pub(super) fn get_stat_item_segments(
 		}
 	}
 	else {
-		match status {
+		match *status {
 			Status::Added => String::from("A "),
 			Status::Copied => String::from("C "),
 			Status::Deleted => String::from("D "),
@@ -52,7 +52,7 @@ pub(super) fn get_stat_item_segments(
 		}
 	};
 
-	let color = match status {
+	let color = match *status {
 		Status::Added | Status::Copied => DisplayColor::DiffAddColor,
 		Status::Deleted => DisplayColor::DiffRemoveColor,
 		Status::Modified | Status::Renamed | Status::Typechange => DisplayColor::DiffChangeColor,
@@ -62,7 +62,7 @@ pub(super) fn get_stat_item_segments(
 
 	let to_file_indicator = if is_full_width { " → " } else { "→" };
 
-	match status {
+	match *status {
 		Status::Copied => {
 			vec![
 				LineSegment::new_with_color(status_name.as_str(), color),

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -156,7 +156,7 @@ impl<'d> ViewBuilder<'d> {
 			]));
 		}
 
-		if let Some(body) = commit.get_body() {
+		if let Some(ref body) = *commit.get_body() {
 			for line in body.lines() {
 				view_data.push_line(ViewLine::new(vec![LineSegment::new(line)]));
 			}
@@ -216,7 +216,7 @@ impl<'d> ViewBuilder<'d> {
 			));
 			line_segments.push(LineSegment::new_with_color(
 				content.as_str(),
-				match diff_line.origin() {
+				match *diff_line.origin() {
 					Origin::Addition => DisplayColor::DiffAddColor,
 					Origin::Deletion => DisplayColor::DiffRemoveColor,
 					Origin::Context => DisplayColor::DiffContextColor,
@@ -230,7 +230,7 @@ impl<'d> ViewBuilder<'d> {
 		else {
 			line_segments.push(LineSegment::new_with_color(
 				self.replace_whitespace(diff_line.line(), false).as_str(),
-				match diff_line.origin() {
+				match *diff_line.origin() {
 					Origin::Addition => DisplayColor::DiffAddColor,
 					Origin::Deletion => DisplayColor::DiffRemoveColor,
 					Origin::Context => DisplayColor::DiffContextColor,

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -38,7 +38,7 @@ impl<'v> View<'v> {
 			self.draw_title(view_data.show_help());
 		}
 
-		if let Some(prompt) = view_data.get_prompt() {
+		if let Some(ref prompt) = *view_data.get_prompt() {
 			self.display.set_style(false, false, false);
 			self.display.draw_str("\n");
 			self.display.draw_str(&format!(

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -118,5 +118,5 @@ pub(crate) fn render_view_data(view_data: &ViewData) -> String {
 		}
 	}
 
-	return lines.join("\n");
+	lines.join("\n")
 }

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -77,7 +77,7 @@ fn render_view_line(view_line: &ViewLine) -> String {
 	line
 }
 
-pub(crate) fn render_view_data(view_data: &ViewData) -> String {
+pub fn render_view_data(view_data: &ViewData) -> String {
 	let mut lines = vec![];
 	if view_data.show_title() {
 		if view_data.show_help() {
@@ -88,9 +88,9 @@ pub(crate) fn render_view_data(view_data: &ViewData) -> String {
 		}
 	}
 
-	if let Some(prompt) = view_data.get_prompt() {
+	if let Some(ref prompt) = *view_data.get_prompt() {
 		lines.push("{PROMPT}".to_string());
-		lines.push(format!("{}", prompt));
+		lines.push(prompt.to_string());
 		return lines.join("\n");
 	}
 

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -2,6 +2,8 @@ use crate::display::display_color::DisplayColor;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 
+// TODO change how style is passed to use a Struct
+#[allow(clippy::fn_params_excessive_bools)]
 fn render_style(color: DisplayColor, selected: bool, dimmed: bool, underline: bool, reversed: bool) -> String {
 	let mut color_string = match color {
 		DisplayColor::ActionBreak => String::from("ActionBreak"),

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -636,9 +636,7 @@ mod tests {
 
 	fn get_segment_content_for_view_line(view_lines: &[ViewLine], line_index: usize, segment_index: usize) -> String {
 		String::from(
-			view_lines
-				.get(line_index)
-				.unwrap()
+			view_lines[line_index]
 				.get_segments()
 				.get(segment_index)
 				.unwrap()

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -278,22 +278,22 @@ impl ViewData {
 	}
 
 	pub(super) const fn get_leading_lines(&self) -> &Vec<ViewLine> {
-		match &self.leading_lines_cache {
-			Some(lines) => lines,
+		match self.leading_lines_cache {
+			Some(ref lines) => lines,
 			None => &self.empty_lines,
 		}
 	}
 
 	pub(super) const fn get_lines(&self) -> &Vec<ViewLine> {
-		match &self.lines_cache {
-			Some(lines) => lines,
+		match self.lines_cache {
+			Some(ref lines) => lines,
 			None => &self.empty_lines,
 		}
 	}
 
 	pub(super) const fn get_trailing_lines(&self) -> &Vec<ViewLine> {
-		match &self.trailing_lines_cache {
-			Some(lines) => lines,
+		match self.trailing_lines_cache {
+			Some(ref lines) => lines,
 			None => &self.empty_lines,
 		}
 	}
@@ -361,7 +361,7 @@ impl ViewData {
 
 		if self.lines_cache.is_none() {
 			self.lines_cache = Some(
-				if let Some(content) = &self.content {
+				if let Some(ref content) = self.content {
 					let mut view_lines = vec![];
 					let mut segments = vec![];
 					let mut remaining_width = self.width;


### PR DESCRIPTION
# Description

The linting was not correctly running against the tests in stable. So, this enables the linting to run against the nightly Clippy build, but allow failures. It also fixes many of the issues found in the nightly Clippy build.