### PR TITLE
DRY up process module

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -18,14 +18,14 @@ pub struct Edit {
 }
 
 impl ProcessModule for Edit {
-	fn activate(&mut self, _state: &State, application: &GitInteractive) {
-		self.content = application.get_selected_line_edit_content().clone();
+	fn activate(&mut self, git_interactive: &GitInteractive, _: State) -> Result<(), String> {
+		self.content = git_interactive.get_selected_line_edit_content().clone();
 		self.cursor_position = UnicodeSegmentation::graphemes(self.content.as_str(), true).count();
+		Ok(())
 	}
 
 	fn deactivate(&mut self) {
 		self.content.clear();
-		self.cursor_position = 0;
 		self.view_data.clear();
 	}
 
@@ -173,7 +173,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_end,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![],
 		build_render_output!(
 			"{TITLE}",
@@ -188,7 +188,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_1_left,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft],
 		build_render_output!(
 			"{TITLE}",
@@ -203,7 +203,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_2_left,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
 			"{TITLE}",
@@ -218,7 +218,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_1_right,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 5],
 		build_render_output!(
 			"{TITLE}",
@@ -233,7 +233,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_right,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 6],
 		build_render_output!(
 			"{TITLE}",
@@ -248,7 +248,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_attempt_past_start,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 10],
 		build_render_output!(
 			"{TITLE}",
@@ -263,7 +263,7 @@ mod tests {
 	process_module_test!(
 		edit_move_cursor_attempt_past_end,
 		["exec foobar"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorRight; 5],
 		build_render_output!(
 			"{TITLE}",
@@ -278,7 +278,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_multiple_width_unicode_single_width,
 		["exec a🗳b"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
 			"{TITLE}",
@@ -293,7 +293,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_multiple_width_unicode_emoji,
 		["exec a😀b"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft; 2],
 		build_render_output!(
 			"{TITLE}",
@@ -308,7 +308,7 @@ mod tests {
 	process_module_test!(
 		edit_add_character_end,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::Character('x')],
 		build_render_output!(
 			"{TITLE}",
@@ -323,7 +323,7 @@ mod tests {
 	process_module_test!(
 		edit_add_character_one_from_end,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft, Input::Character('x')],
 		build_render_output!(
 			"{TITLE}",
@@ -338,7 +338,7 @@ mod tests {
 	process_module_test!(
 		edit_add_character_one_from_start,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -358,7 +358,7 @@ mod tests {
 	process_module_test!(
 		edit_add_character_at_start,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -379,7 +379,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_backspace_at_end,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::Backspace],
 		build_render_output!(
 			"{TITLE}",
@@ -394,7 +394,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_backspace_one_from_end,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft, Input::Backspace],
 		build_render_output!(
 			"{TITLE}",
@@ -409,7 +409,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_backspace_one_from_start,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -429,7 +429,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_backspace_at_start,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -450,7 +450,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_delete_at_end,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::Delete],
 		build_render_output!(
 			"{TITLE}",
@@ -465,7 +465,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_delete_last_character,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![Input::MoveCursorLeft, Input::Delete],
 		build_render_output!(
 			"{TITLE}",
@@ -480,7 +480,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_delete_second_character,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -500,7 +500,7 @@ mod tests {
 	process_module_test!(
 		edit_cursor_delete_first_character,
 		["exec abcd"],
-		process_module_state!(state = State::Edit),
+		process_module_state!(new_state = State::Edit, previous_state = State::List),
 		vec![
 			Input::MoveCursorLeft,
 			Input::MoveCursorLeft,
@@ -524,7 +524,7 @@ mod tests {
 		[Input::Resize],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(&State::Edit, git_interactive);
+			edit.activate(git_interactive, State::List).unwrap();
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_handle_input_result!(result, input = Input::Resize);
 		}
@@ -536,7 +536,7 @@ mod tests {
 		[Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(&State::Edit, git_interactive);
+			edit.activate(git_interactive, State::List).unwrap();
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_handle_input_result!(result, input = Input::Enter, state = State::List);
 			assert_eq!(git_interactive.get_selected_line_edit_content(), "foobar");
@@ -549,7 +549,7 @@ mod tests {
 		[Input::Character('x'), Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(&State::Edit, git_interactive);
+			edit.activate(git_interactive, State::List).unwrap();
 			edit.handle_input(input_handler, git_interactive, view);
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_handle_input_result!(result, input = Input::Enter, state = State::List);
@@ -563,7 +563,7 @@ mod tests {
 		[Input::Other, Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(&State::Edit, git_interactive);
+			edit.activate(git_interactive, State::List).unwrap();
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_handle_input_result!(result, input = Input::Enter, state = State::List);
 		}
@@ -575,9 +575,8 @@ mod tests {
 		[Input::MoveCursorLeft],
 		|_: &InputHandler<'_>, git_interactive: &mut GitInteractive, _: &View<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(&State::Edit, git_interactive);
+			edit.activate(git_interactive, State::List).unwrap();
 			edit.deactivate();
-			assert_eq!(edit.cursor_position, 0);
 			assert!(edit.content.is_empty());
 		}
 	);

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -32,10 +32,11 @@ pub struct ExternalEditor<'e> {
 }
 
 impl<'e> ProcessModule for ExternalEditor<'e> {
-	fn activate(&mut self, _state: &State, _git_interactive: &GitInteractive) {
+	fn activate(&mut self, _: &GitInteractive, _: State) -> Result<(), String> {
 		if self.state != ExternalEditorState::Empty {
 			self.state = ExternalEditorState::Active;
 		}
+		Ok(())
 	}
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
@@ -130,7 +131,7 @@ impl<'e> ExternalEditor<'e> {
 	fn process_active(&mut self, git_interactive: &GitInteractive) -> ProcessResult {
 		let mut result = ProcessResult::new();
 		if let Err(e) = self.run_editor(git_interactive) {
-			result = result.error(e.as_str());
+			result = result.error(e.as_str(), None);
 			self.state = ExternalEditorState::Error;
 		}
 		else {
@@ -142,7 +143,7 @@ impl<'e> ExternalEditor<'e> {
 	fn process_finish(&mut self, git_interactive: &mut GitInteractive) -> ProcessResult {
 		let mut result = ProcessResult::new();
 		if let Err(e) = git_interactive.reload_file() {
-			result = result.error(e.as_str());
+			result = result.error(e.as_str(), None);
 			self.state = ExternalEditorState::Error;
 		}
 		else if git_interactive.get_lines().is_empty() {

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -36,12 +36,12 @@ pub struct List<'l> {
 	config: &'l Config,
 	normal_footer_compact: String,
 	normal_footer_full: String,
-	normal_mode_help_lines: [(&'l str, &'l str); 22],
+	normal_mode_help_lines: Vec<(String, String)>,
 	state: ListState,
 	view_data: ViewData,
 	visual_footer_compact: String,
 	visual_footer_full: String,
-	visual_mode_help_lines: [(&'l str, &'l str); 14],
+	visual_mode_help_lines: Vec<(String, String)>,
 }
 
 impl<'l> ProcessModule for List<'l> {
@@ -133,12 +133,12 @@ impl<'l> ProcessModule for List<'l> {
 		result
 	}
 
-	fn get_help_keybindings_descriptions(&self) -> Option<&[(&str, &str)]> {
+	fn get_help_keybindings_descriptions(&self) -> Option<Vec<(String, String)>> {
 		if self.state == ListState::Normal {
-			Some(&self.normal_mode_help_lines)
+			Some(self.normal_mode_help_lines.clone())
 		}
 		else {
-			Some(&self.visual_mode_help_lines)
+			Some(self.visual_mode_help_lines.clone())
 		}
 	}
 }

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -7,73 +7,130 @@ use crate::list::line::Line;
 use crate::view::line_segment::LineSegment;
 use std::cmp;
 
-pub(super) fn get_list_normal_mode_help_lines(key_bindings: &KeyBindings) -> [(&str, &str); 22] {
-	[
-		(key_bindings.move_up.as_str(), "Move selection up"),
-		(key_bindings.move_down.as_str(), "Move selection down"),
-		(key_bindings.move_up_step.as_str(), "Move selection up 5 lines"),
-		(key_bindings.move_down_step.as_str(), "Move selection down 5 lines"),
-		(key_bindings.abort.as_str(), "Abort interactive rebase"),
+pub(super) fn get_list_normal_mode_help_lines(key_bindings: &KeyBindings) -> Vec<(String, String)> {
+	vec![
+		(key_bindings.move_up.clone(), String::from("Move selection up")),
+		(key_bindings.move_down.clone(), String::from("Move selection down")),
 		(
-			key_bindings.force_abort.as_str(),
-			"Immediately abort interactive rebase",
+			key_bindings.move_up_step.clone(),
+			String::from("Move selection up 5 lines"),
 		),
-		(key_bindings.rebase.as_str(), "Write interactive rebase file"),
 		(
-			key_bindings.force_rebase.as_str(),
-			"Immediately write interactive rebase file",
+			key_bindings.move_down_step.clone(),
+			String::from("Move selection down 5 lines"),
 		),
-		(key_bindings.toggle_visual_mode.as_str(), "Enter visual mode"),
-		(key_bindings.help.as_str(), "Show help"),
-		(key_bindings.show_commit.as_str(), "Show commit information"),
-		(key_bindings.move_selection_down.as_str(), "Move selected commit down"),
-		(key_bindings.move_selection_up.as_str(), "Move selected commit up"),
-		(key_bindings.action_break.as_str(), "Toggle break action"),
-		(key_bindings.action_pick.as_str(), "Set selected commit to be picked"),
+		(key_bindings.abort.clone(), String::from("Abort interactive rebase")),
 		(
-			key_bindings.action_reword.as_str(),
-			"Set selected commit to be reworded",
+			key_bindings.force_abort.clone(),
+			String::from("Immediately abort interactive rebase"),
 		),
-		(key_bindings.action_edit.as_str(), "Set selected commit to be edited"),
 		(
-			key_bindings.action_squash.as_str(),
-			"Set selected commit to be squashed",
+			key_bindings.rebase.clone(),
+			String::from("Write interactive rebase file"),
 		),
-		(key_bindings.action_fixup.as_str(), "Set selected commit to be fixed-up"),
-		(key_bindings.action_drop.as_str(), "Set selected commit to be dropped"),
-		(key_bindings.edit.as_str(), "Edit an exec action's command"),
 		(
-			key_bindings.open_in_external_editor.as_str(),
-			"Open the todo file in the default editor",
+			key_bindings.force_rebase.clone(),
+			String::from("Immediately write interactive rebase file"),
+		),
+		(
+			key_bindings.toggle_visual_mode.clone(),
+			String::from("Enter visual mode"),
+		),
+		(key_bindings.help.clone(), String::from("Show help")),
+		(
+			key_bindings.show_commit.clone(),
+			String::from("Show commit information"),
+		),
+		(
+			key_bindings.move_selection_down.clone(),
+			String::from("Move selected commit down"),
+		),
+		(
+			key_bindings.move_selection_up.clone(),
+			String::from("Move selected commit up"),
+		),
+		(key_bindings.action_break.clone(), String::from("Toggle break action")),
+		(
+			key_bindings.action_pick.clone(),
+			String::from("Set selected commit to be picked"),
+		),
+		(
+			key_bindings.action_reword.clone(),
+			String::from("Set selected commit to be reworded"),
+		),
+		(
+			key_bindings.action_edit.clone(),
+			String::from("Set selected commit to be edited"),
+		),
+		(
+			key_bindings.action_squash.clone(),
+			String::from("Set selected commit to be squashed"),
+		),
+		(
+			key_bindings.action_fixup.clone(),
+			String::from("Set selected commit to be fixed-up"),
+		),
+		(
+			key_bindings.action_drop.clone(),
+			String::from("Set selected commit to be dropped"),
+		),
+		(key_bindings.edit.clone(), String::from("Edit an exec action's command")),
+		(
+			key_bindings.open_in_external_editor.clone(),
+			String::from("Open the todo file in the default editor"),
 		),
 	]
 }
 
-pub(super) fn get_list_visual_mode_help_lines(key_bindings: &KeyBindings) -> [(&str, &str); 14] {
-	[
-		(key_bindings.move_up.as_str(), "Move selection up"),
-		(key_bindings.move_down.as_str(), "Move selection down"),
-		(key_bindings.move_up_step.as_str(), "Move selection up 5 lines"),
-		(key_bindings.move_down_step.as_str(), "Move selection down 5 lines"),
-		(key_bindings.help.as_str(), "Show help"),
-		(key_bindings.move_selection_down.as_str(), "Move selected commits down"),
-		(key_bindings.move_selection_up.as_str(), "Move selected commits up"),
-		(key_bindings.action_pick.as_str(), "Set selected commits to be picked"),
+pub(super) fn get_list_visual_mode_help_lines(key_bindings: &KeyBindings) -> Vec<(String, String)> {
+	vec![
+		(key_bindings.move_up.clone(), String::from("Move selection up")),
+		(key_bindings.move_down.clone(), String::from("Move selection down")),
 		(
-			key_bindings.action_reword.as_str(),
-			"Set selected commits to be reworded",
-		),
-		(key_bindings.action_edit.as_str(), "Set selected commits to be edited"),
-		(
-			key_bindings.action_squash.as_str(),
-			"Set selected commits to be squashed",
+			key_bindings.move_up_step.clone(),
+			String::from("Move selection up 5 lines"),
 		),
 		(
-			key_bindings.action_fixup.as_str(),
-			"Set selected commits to be fixed-up",
+			key_bindings.move_down_step.clone(),
+			String::from("Move selection down 5 lines"),
 		),
-		(key_bindings.action_drop.as_str(), "Set selected commits to be dropped"),
-		(key_bindings.toggle_visual_mode.as_str(), "Exit visual mode"),
+		(key_bindings.help.clone(), String::from("Show help")),
+		(
+			key_bindings.move_selection_down.clone(),
+			String::from("Move selected commits down"),
+		),
+		(
+			key_bindings.move_selection_up.clone(),
+			String::from("Move selected commits up"),
+		),
+		(
+			key_bindings.action_pick.clone(),
+			String::from("Set selected commits to be picked"),
+		),
+		(
+			key_bindings.action_reword.clone(),
+			String::from("Set selected commits to be reworded"),
+		),
+		(
+			key_bindings.action_edit.clone(),
+			String::from("Set selected commits to be edited"),
+		),
+		(
+			key_bindings.action_squash.clone(),
+			String::from("Set selected commits to be squashed"),
+		),
+		(
+			key_bindings.action_fixup.clone(),
+			String::from("Set selected commits to be fixed-up"),
+		),
+		(
+			key_bindings.action_drop.clone(),
+			String::from("Set selected commits to be dropped"),
+		),
+		(
+			key_bindings.toggle_visual_mode.clone(),
+			String::from("Exit visual mode"),
+		),
 	]
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ use crate::display::Display;
 use crate::git_interactive::GitInteractive;
 use crate::input::input_handler::InputHandler;
 use crate::process::exit_status::ExitStatus;
+use crate::process::modules::Modules;
 use crate::process::Process;
 use crate::view::View;
 
@@ -118,9 +119,11 @@ fn try_main() -> Result<ExitStatus, Exit> {
 	let input_handler = InputHandler::new(&display, &config.key_bindings);
 	let view = View::new(&display, &config);
 
-	let mut process = Process::new(git_interactive, &view, &display, &input_handler, &config);
+	let modules = Modules::new(&display, &config);
 
-	let result = process.run();
+	let mut process = Process::new(git_interactive, &view, &input_handler);
+
+	let result = process.run(modules);
 	display.end();
 
 	let exit_code = match result {

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -1,29 +1,65 @@
+use crate::display::display_color::DisplayColor;
+use crate::git_interactive::GitInteractive;
 use crate::input::input_handler::{InputHandler, InputMode};
+use crate::input::Input;
+use crate::process::process_module::ProcessModule;
 use crate::process::process_result::ProcessResult;
+use crate::process::state::State;
+use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
+use crate::view::view_line::ViewLine;
 use crate::view::View;
 
 pub struct Error {
+	return_state: State,
 	view_data: ViewData,
 }
 
-impl Error {
-	pub fn new(message: &str) -> Self {
-		Self {
-			view_data: ViewData::new_error(message),
-		}
+impl ProcessModule for Error {
+	fn activate(&mut self, _: &GitInteractive, previous_state: State) -> Result<(), String> {
+		self.return_state = previous_state;
+		Ok(())
 	}
 
-	pub fn get_view_data(&mut self, view: &View<'_>) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {
 		let (view_width, view_height) = view.get_view_size();
 		self.view_data.set_view_size(view_width, view_height);
 		self.view_data.rebuild();
 		&self.view_data
 	}
 
-	#[allow(clippy::unused_self)]
-	pub fn handle_input(&mut self, input_handler: &InputHandler<'_>) -> ProcessResult {
+	fn handle_input(
+		&mut self,
+		input_handler: &InputHandler<'_>,
+		_: &mut GitInteractive,
+		_: &View<'_>,
+	) -> ProcessResult
+	{
 		let input = input_handler.get_input(InputMode::Default);
-		ProcessResult::new().input(input)
+		let mut result = ProcessResult::new().input(input);
+		match input {
+			Input::Resize => {},
+			_ => result = result.state(self.return_state),
+		}
+		result
+	}
+}
+
+impl Error {
+	pub const fn new() -> Self {
+		Self {
+			return_state: State::List,
+			view_data: ViewData::new(),
+		}
+	}
+
+	pub fn set_error_message(&mut self, error: &str) {
+		self.view_data.reset();
+		self.view_data.push_line(ViewLine::new(vec![LineSegment::new(error)]));
+		self.view_data
+			.push_trailing_line(ViewLine::new(vec![LineSegment::new_with_color(
+				"Press any key to continue",
+				DisplayColor::IndicatorColor,
+			)]));
 	}
 }

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -1,0 +1,129 @@
+use crate::config::Config;
+use crate::confirm_abort::ConfirmAbort;
+use crate::confirm_rebase::ConfirmRebase;
+use crate::display::Display;
+use crate::edit::Edit;
+use crate::exiting::Exiting;
+use crate::external_editor::ExternalEditor;
+use crate::git_interactive::GitInteractive;
+use crate::input::input_handler::InputHandler;
+use crate::list::List;
+use crate::process::error::Error;
+use crate::process::help::Help;
+use crate::process::process_module::ProcessModule;
+use crate::process::process_result::ProcessResult;
+use crate::process::state::State;
+use crate::process::window_size_error::WindowSizeError;
+use crate::show_commit::ShowCommit;
+use crate::view::view_data::ViewData;
+use crate::view::View;
+
+pub struct Modules<'m> {
+	pub confirm_abort: ConfirmAbort,
+	pub confirm_rebase: ConfirmRebase,
+	pub edit: Edit,
+	pub error: Error,
+	pub exiting: Exiting,
+	pub external_editor: ExternalEditor<'m>,
+	pub help: Help,
+	pub list: List<'m>,
+	pub show_commit: ShowCommit<'m>,
+	pub window_size_error: WindowSizeError,
+}
+
+impl<'m> Modules<'m> {
+	pub fn new(display: &'m Display<'m>, config: &'m Config) -> Self {
+		Modules {
+			confirm_abort: ConfirmAbort::new(),
+			confirm_rebase: ConfirmRebase::new(),
+			edit: Edit::new(),
+			error: Error::new(),
+			exiting: Exiting::new(),
+			external_editor: ExternalEditor::new(display, config.git.editor.as_str()),
+			help: Help::new(),
+			list: List::new(config),
+			show_commit: ShowCommit::new(config),
+			window_size_error: WindowSizeError::new(),
+		}
+	}
+
+	fn get_module(&self, state: State) -> &dyn ProcessModule {
+		match state {
+			State::ConfirmAbort => &self.confirm_abort as &dyn ProcessModule,
+			State::ConfirmRebase => &self.confirm_rebase as &dyn ProcessModule,
+			State::Edit => &self.edit as &dyn ProcessModule,
+			State::Error => &self.error as &dyn ProcessModule,
+			State::Exiting => &self.exiting as &dyn ProcessModule,
+			State::ExternalEditor => &self.external_editor as &dyn ProcessModule,
+			State::Help => &self.help as &dyn ProcessModule,
+			State::List => &self.list as &dyn ProcessModule,
+			State::ShowCommit => &self.show_commit as &dyn ProcessModule,
+			State::WindowSizeError => &self.window_size_error as &dyn ProcessModule,
+		}
+	}
+
+	fn get_mut_module(&mut self, state: State) -> &mut dyn ProcessModule {
+		match state {
+			State::ConfirmAbort => &mut self.confirm_abort as &mut dyn ProcessModule,
+			State::ConfirmRebase => &mut self.confirm_rebase as &mut dyn ProcessModule,
+			State::Edit => &mut self.edit as &mut dyn ProcessModule,
+			State::Error => &mut self.error as &mut dyn ProcessModule,
+			State::Exiting => &mut self.exiting as &mut dyn ProcessModule,
+			State::ExternalEditor => &mut self.external_editor as &mut dyn ProcessModule,
+			State::Help => &mut self.help as &mut dyn ProcessModule,
+			State::List => &mut self.list as &mut dyn ProcessModule,
+			State::ShowCommit => &mut self.show_commit as &mut dyn ProcessModule,
+			State::WindowSizeError => &mut self.window_size_error as &mut dyn ProcessModule,
+		}
+	}
+
+	pub fn activate(
+		&mut self,
+		state: State,
+		git_interactive: &GitInteractive,
+		previous_state: State,
+	) -> Result<(), String>
+	{
+		self.get_mut_module(state).activate(git_interactive, previous_state)
+	}
+
+	pub fn deactivate(&mut self, state: State) {
+		self.get_mut_module(state).deactivate()
+	}
+
+	pub fn build_view_data(&mut self, state: State, view: &View<'_>, git_interactive: &GitInteractive) -> &ViewData {
+		self.get_mut_module(state).build_view_data(view, git_interactive)
+	}
+
+	pub fn process(&mut self, state: State, git_interactive: &mut GitInteractive, view: &View<'_>) -> ProcessResult {
+		self.get_mut_module(state).process(git_interactive, view)
+	}
+
+	pub fn handle_input(
+		&mut self,
+		state: State,
+		input_handler: &InputHandler<'_>,
+		git_interactive: &mut GitInteractive,
+		view: &View<'_>,
+	) -> ProcessResult
+	{
+		self.get_mut_module(state)
+			.handle_input(input_handler, git_interactive, view)
+	}
+
+	pub fn set_error_message(&mut self, error: &str) {
+		self.error.set_error_message(error);
+	}
+
+	pub fn update_help_data(&mut self, state: State) {
+		if let Some(ref keybindings_descriptions) = self.get_module(state).get_help_keybindings_descriptions() {
+			self.help.update_from_keybindings_descriptions(keybindings_descriptions);
+		}
+		else if let Some(help_view_data) = self.get_module(state).get_help_view() {
+			self.help.update_from_view_data(help_view_data);
+		}
+		else {
+			self.help.clear_help();
+		}
+	}
+}

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -7,7 +7,9 @@ use crate::view::view_data::ViewData;
 use crate::view::View;
 
 pub trait ProcessModule {
-	fn activate(&mut self, _state: &State, _git_interactive: &GitInteractive) {}
+	fn activate(&mut self, _git_interactive: &GitInteractive, _previous_state: State) -> Result<(), String> {
+		Ok(())
+	}
 
 	fn deactivate(&mut self) {}
 
@@ -27,7 +29,7 @@ pub trait ProcessModule {
 		ProcessResult::new().input(Input::Other)
 	}
 
-	fn get_help_keybindings_descriptions(&self) -> Option<&[(&str, &str)]> {
+	fn get_help_keybindings_descriptions(&self) -> Option<Vec<(String, String)>> {
 		None
 	}
 

--- a/src/process/process_result.rs
+++ b/src/process/process_result.rs
@@ -4,7 +4,7 @@ use crate::process::state::State;
 
 #[derive(Debug, PartialEq)]
 pub struct ProcessResult {
-	pub(super) error_message: Option<String>,
+	pub(super) error: Option<(String, Option<State>)>,
 	pub(super) exit_status: Option<ExitStatus>,
 	pub(super) input: Option<Input>,
 	pub(super) state: Option<State>,
@@ -13,7 +13,7 @@ pub struct ProcessResult {
 impl ProcessResult {
 	pub(crate) const fn new() -> Self {
 		Self {
-			error_message: None,
+			error: None,
 			exit_status: None,
 			input: None,
 			state: None,
@@ -25,8 +25,9 @@ impl ProcessResult {
 		self
 	}
 
-	pub(crate) fn error(mut self, message: &str) -> Self {
-		self.error_message = Some(String::from(message));
+	pub(crate) fn error(mut self, message: &str, return_state: Option<State>) -> Self {
+		self.state = Some(State::Error);
+		self.error = Some((String::from(message), return_state));
 		self
 	}
 

--- a/src/process/state.rs
+++ b/src/process/state.rs
@@ -1,10 +1,13 @@
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum State {
 	ConfirmAbort,
 	ConfirmRebase,
 	Edit,
+	Error,
 	Exiting,
 	ExternalEditor,
+	Help,
 	List,
 	ShowCommit,
+	WindowSizeError,
 }

--- a/src/show_commit/util.rs
+++ b/src/show_commit/util.rs
@@ -7,16 +7,19 @@ use crate::view::view_line::ViewLine;
 use num_format::{Locale, ToFormattedString};
 use unicode_segmentation::UnicodeSegmentation;
 
-pub(super) fn get_show_commit_help_lines(key_bindings: &KeyBindings) -> [(&str, &str); 8] {
-	[
-		(key_bindings.move_up.as_str(), "Scroll up"),
-		(key_bindings.move_down.as_str(), "Scroll down"),
-		(key_bindings.move_up_step.as_str(), "Scroll up half a page"),
-		(key_bindings.move_down_step.as_str(), "Scroll down half a page"),
-		(key_bindings.move_right.as_str(), "Scroll right"),
-		(key_bindings.move_left.as_str(), "Scroll left"),
-		(key_bindings.show_diff.as_str(), "Show full diff"),
-		(key_bindings.help.as_str(), "Show help"),
+pub(super) fn get_show_commit_help_lines(key_bindings: &KeyBindings) -> Vec<(String, String)> {
+	vec![
+		(key_bindings.move_up.clone(), String::from("Scroll up")),
+		(key_bindings.move_down.clone(), String::from("Scroll down")),
+		(key_bindings.move_up_step.clone(), String::from("Scroll up half a page")),
+		(
+			key_bindings.move_down_step.clone(),
+			String::from("Scroll down half a page"),
+		),
+		(key_bindings.move_right.clone(), String::from("Scroll right")),
+		(key_bindings.move_left.clone(), String::from("Scroll left")),
+		(key_bindings.show_diff.clone(), String::from("Show full diff")),
+		(key_bindings.help.clone(), String::from("Show help")),
 	]
 }
 

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -1,4 +1,3 @@
-use crate::display::display_color::DisplayColor;
 use crate::view::line_segment::LineSegment;
 use crate::view::scroll_position::ScrollPosition;
 use crate::view::view_line::ViewLine;
@@ -44,18 +43,6 @@ impl ViewData {
 			trailing_lines_cache: None,
 			width: 0,
 		}
-	}
-
-	pub(crate) fn new_error(error: &str) -> Self {
-		let mut inst = Self::new();
-		inst.set_show_title(true);
-		inst.push_line(ViewLine::new(vec![LineSegment::new(error)]));
-		inst.push_trailing_line(ViewLine::new(vec![LineSegment::new_with_color(
-			"Press any key to continue",
-			DisplayColor::IndicatorColor,
-		)]));
-		inst.rebuild();
-		inst
 	}
 
 	pub(crate) fn new_confirm(prompt: &str) -> Self {
@@ -656,25 +643,6 @@ mod tests {
 		let mut view_data = ViewData::new();
 		view_data.set_show_title(true);
 		assert_eq!(view_data.show_title(), true);
-	}
-
-	#[test]
-	fn view_data_case_new_error() {
-		let mut view_data = ViewData::new_error("My Error");
-		view_data.set_view_size(100, 100);
-		assert_eq!(view_data.show_title(), true);
-		assert_eq!(view_data.show_help(), false);
-		assert_eq!(view_data.get_leading_lines().len(), 0);
-		assert_eq!(view_data.get_lines().len(), 1);
-		assert_eq!(view_data.get_trailing_lines().len(), 1);
-		assert_eq!(
-			get_segment_content_for_view_line(view_data.get_lines(), 0, 0),
-			"My Error"
-		);
-		assert_eq!(
-			get_segment_content_for_view_line(view_data.get_trailing_lines(), 0, 0),
-			"Press any key to continue"
-		);
 	}
 
 	#[test]


### PR DESCRIPTION
# Description

The process module has always been fairly repetitive and adding a new module required updates to several places in the file. This change refactors the process module to use dynamic dispatch to call the functions on the ProcessModule trait dynamically. This required the error, help and window size error systems to be modified to implement the ProcessModule. The show commit module has been refactored to use the error module. And the state and modules have been extracted into their own Modules struct.