### PR TITLE
Use anyhow in the main application struct

### DIFF
--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -57,7 +57,7 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 				result = result.error(e.as_str()).exit_status(ExitStatus::StateError);
 			}
 			else if let Err(e) = git_interactive.reload_file() {
-				result = result.error(e.as_str()).exit_status(ExitStatus::StateError);
+				result = result.error(e.to_string().as_str()).exit_status(ExitStatus::StateError);
 			}
 			else if git_interactive.get_lines().is_empty() {
 				self.state = ExternalEditorState::Empty;
@@ -115,7 +115,7 @@ impl<'e> ExternalEditor<'e> {
 				}
 			})?;
 
-		git_interactive.write_file()?;
+		git_interactive.write_file().map_err(|err| err.to_string())?;
 		let filepath = git_interactive.get_filepath();
 		let callback = || -> Result<ProcessExitStatus, String> {
 			let mut file_pattern_found = false;
@@ -279,7 +279,7 @@ mod tests {
 		|module: &mut dyn ProcessModule, git_interactive: &mut GitInteractive| {
 			assert_process_result!(
 				module.process(git_interactive),
-				error = "Error reading file, Invalid line: this-is-invalid",
+				error = "Invalid line: this-is-invalid",
 				exit_status = ExitStatus::StateError
 			);
 		}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,15 +84,13 @@ fn try_main() -> Result<ExitStatus, Exit> {
 		}
 	})?;
 
-	let git_interactive = match GitInteractive::new_from_filepath(filepath, config.git.comment_char.as_str()) {
-		Ok(gi) => gi,
-		Err(message) => {
-			return Err(Exit {
-				message,
+	let git_interactive =
+		GitInteractive::new_from_filepath(filepath, config.git.comment_char.as_str()).map_err(|err| {
+			Exit {
+				message: err.to_string(),
 				status: ExitStatus::FileReadError,
-			});
-		},
-	};
+			}
+		})?;
 
 	if git_interactive.is_noop() {
 		return Err(Exit {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -118,13 +118,10 @@ impl<'r> Process<'r> {
 	}
 
 	fn exit_end(&mut self) -> Result<(), String> {
-		match self.git_interactive.write_file() {
-			Ok(_) => {},
-			Err(msg) => {
-				self.exit_status = Some(ExitStatus::FileWriteError);
-				return Err(msg);
-			},
-		}
+		self.git_interactive.write_file().map_err(|err| {
+			self.exit_status = Some(ExitStatus::FileWriteError);
+			err.to_string()
+		})?;
 		Ok(())
 	}
 }


### PR DESCRIPTION
# Description

The main application struct uses String errors, which make it difficult to provide context on errors. This updates the struct to provide errors with anyhow and fixes any references that used to depend on the String errors. While working on the code, several poor usages of match have been replaced with `map_or*`, `unwrap_or*` chains.