### PR TITLE
Fix cache in the ViewData set_view_size

### DIFF
--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -120,22 +120,27 @@ impl ViewData {
 	}
 
 	pub(crate) fn set_view_size(&mut self, view_width: usize, view_height: usize) {
-		if self.height != view_height || self.width != view_width {
+		if self.height != view_height
+			|| self.width != view_width
+			|| self.leading_lines_cache.is_none()
+			|| self.lines_cache.is_none()
+			|| self.trailing_lines_cache.is_none()
+		{
 			self.height = view_height;
 			self.width = view_width;
 			self.leading_lines_cache = None;
 			self.lines_cache = None;
 			self.trailing_lines_cache = None;
 
+			let title_height = if self.show_title { 1 } else { 0 };
+
 			self.scroll_position.view_resize(
-				if self.height == 0 || self.leading_lines.len() + self.trailing_lines.len() >= self.height {
+				if self.height == 0 || self.leading_lines.len() + self.trailing_lines.len() + title_height > self.height
+				{
 					0
 				}
 				else {
-					self.height
-						- self.leading_lines.len()
-						- self.trailing_lines.len()
-						- if self.show_title { 1 } else { 0 }
+					self.height - self.leading_lines.len() - self.trailing_lines.len() - title_height
 				},
 				if self.width == 0 {
 					0

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -1,6 +1,7 @@
 use crate::display::display_color::DisplayColor;
 use crate::view::line_segment::LineSegment;
 
+#[derive(Debug)]
 pub struct ViewLine {
 	pinned_segments: usize,
 	segments: Vec<LineSegment>,


### PR DESCRIPTION
# What

The cache check in the ViewData set_view_size function was not recalculating the scroll position when the lines vectors change. This updates the function to also cause a recalculation when one of those
vectors change size.