### PR TITLE
Remove unused function added by bad merge

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,3 @@ fn try_main(matches: &ArgMatches<'_>) -> Result<ExitStatus, Exit> {
 		})
 		.map(|exit_code| exit_code.unwrap_or(ExitStatus::Good))
 }
-
-fn build_cli() -> App<'static, 'static> {
-	App::new(NAME)
-		.version(VERSION)
-		.about("Full feature terminal based sequence editor for git interactive rebase.")
-		.author("Tim Oram <dev@mitmaro.ca>")
-		.args_from_usage("<rebase-todo-filepath> 'The path to the git rebase todo file'")
-}


### PR DESCRIPTION
# What

The last pull request merge caused a function to be left behind that should have been deleted. This change removes that unused function.