### PR TITLE
Convert activate to use ProcessResult

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -9,7 +9,6 @@ use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 use crate::view::View;
-use anyhow::Result;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub struct Edit {
@@ -19,10 +18,10 @@ pub struct Edit {
 }
 
 impl ProcessModule for Edit {
-	fn activate(&mut self, git_interactive: &GitInteractive, _: State) -> Result<()> {
+	fn activate(&mut self, git_interactive: &GitInteractive, _: State) -> ProcessResult {
 		self.content = git_interactive.get_selected_line_edit_content().clone();
 		self.cursor_position = UnicodeSegmentation::graphemes(self.content.as_str(), true).count();
-		Ok(())
+		ProcessResult::new()
 	}
 
 	fn deactivate(&mut self) {
@@ -529,7 +528,7 @@ mod tests {
 		[Input::Resize],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List).unwrap();
+			edit.activate(git_interactive, State::List);
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_process_result!(result, input = Input::Resize);
 		}
@@ -541,7 +540,7 @@ mod tests {
 		[Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List).unwrap();
+			edit.activate(git_interactive, State::List);
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_process_result!(result, input = Input::Enter, state = State::List);
 			assert_eq!(git_interactive.get_selected_line_edit_content(), "foobar");
@@ -554,7 +553,7 @@ mod tests {
 		[Input::Character('x'), Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List).unwrap();
+			edit.activate(git_interactive, State::List);
 			edit.handle_input(input_handler, git_interactive, view);
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_process_result!(result, input = Input::Enter, state = State::List);
@@ -568,7 +567,7 @@ mod tests {
 		[Input::Other, Input::Enter],
 		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List).unwrap();
+			edit.activate(git_interactive, State::List);
 			let result = edit.handle_input(input_handler, git_interactive, view);
 			assert_process_result!(result, input = Input::Enter, state = State::List);
 		}
@@ -580,7 +579,7 @@ mod tests {
 		[Input::MoveCursorLeft],
 		|_: &InputHandler<'_>, git_interactive: &mut GitInteractive, _: &View<'_>, _: &Display<'_>| {
 			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List).unwrap();
+			edit.activate(git_interactive, State::List);
 			edit.deactivate();
 			assert!(edit.content.is_empty());
 		}

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -31,11 +31,11 @@ pub struct ExternalEditor<'e> {
 }
 
 impl<'e> ProcessModule for ExternalEditor<'e> {
-	fn activate(&mut self, _: &GitInteractive, _: State) -> Result<()> {
+	fn activate(&mut self, _: &GitInteractive, _: State) -> ProcessResult {
 		if self.state != ExternalEditorState::Empty {
 			self.state = ExternalEditorState::Active;
 		}
-		Ok(())
+		ProcessResult::new()
 	}
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -10,7 +10,6 @@ use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 use crate::view::View;
-use anyhow::Result;
 
 pub struct Error {
 	return_state: State,
@@ -18,9 +17,9 @@ pub struct Error {
 }
 
 impl ProcessModule for Error {
-	fn activate(&mut self, _: &GitInteractive, previous_state: State) -> Result<()> {
+	fn activate(&mut self, _: &GitInteractive, previous_state: State) -> ProcessResult {
 		self.return_state = previous_state;
-		Ok(())
+		ProcessResult::new()
 	}
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {

--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -10,7 +10,6 @@ use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 use crate::view::View;
-use anyhow::Result;
 use unicode_segmentation::UnicodeSegmentation;
 
 fn get_max_help_key_length(lines: &[(String, String)]) -> usize {
@@ -31,11 +30,11 @@ pub struct Help {
 }
 
 impl ProcessModule for Help {
-	fn activate(&mut self, _: &GitInteractive, return_state: State) -> Result<()> {
+	fn activate(&mut self, _: &GitInteractive, return_state: State) -> ProcessResult {
 		if self.return_state.is_none() {
 			self.return_state = Some(return_state);
 		}
-		Ok(())
+		ProcessResult::new()
 	}
 
 	fn deactivate(&mut self) {

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -16,7 +16,6 @@ use crate::process::window_size_error::WindowSizeError;
 use crate::show_commit::ShowCommit;
 use crate::view::view_data::ViewData;
 use crate::view::View;
-use anyhow::Result;
 
 pub struct Modules<'m> {
 	pub confirm_abort: ConfirmAbort,
@@ -73,7 +72,7 @@ impl<'m> Modules<'m> {
 		}
 	}
 
-	pub fn activate(&mut self, state: State, git_interactive: &GitInteractive, previous_state: State) -> Result<()> {
+	pub fn activate(&mut self, state: State, git_interactive: &GitInteractive, previous_state: State) -> ProcessResult {
 		self.get_mut_module(state).activate(git_interactive, previous_state)
 	}
 

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -5,11 +5,10 @@ use crate::process::process_result::ProcessResult;
 use crate::process::state::State;
 use crate::view::view_data::ViewData;
 use crate::view::View;
-use anyhow::Result;
 
 pub trait ProcessModule {
-	fn activate(&mut self, _git_interactive: &GitInteractive, _previous_state: State) -> Result<()> {
-		Ok(())
+	fn activate(&mut self, _git_interactive: &GitInteractive, _previous_state: State) -> ProcessResult {
+		ProcessResult::new()
 	}
 
 	fn deactivate(&mut self) {}

--- a/src/process/process_result.rs
+++ b/src/process/process_result.rs
@@ -27,7 +27,6 @@ impl ProcessResult {
 	}
 
 	pub(crate) fn error(mut self, error: Error) -> Self {
-		self.state = Some(State::Error);
 		self.error = Some(error);
 		self
 	}

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -83,7 +83,7 @@ pub fn _process_module_test<F, C>(
 	.unwrap();
 	let mut module = get_module(&config, &display);
 	if let Some((_, previous_state)) = module_state.state {
-		module.activate(&git_interactive, previous_state).unwrap();
+		module.activate(&git_interactive, previous_state);
 	}
 	if let Some(ref input) = *input {
 		let input_handler = InputHandler::new(&display, &config.key_bindings);
@@ -508,13 +508,7 @@ macro_rules! assert_process_result {
 		crate::process::testutil::_assert_process_result(&$actual, None, None, None, &None);
 	};
 	($actual:expr, error = $error:expr, exit_status = $exit_status:expr) => {
-		crate::process::testutil::_assert_process_result(
-			&$actual,
-			None,
-			Some(State::Error),
-			Some($exit_status),
-			&Some($error),
-			);
+		crate::process::testutil::_assert_process_result(&$actual, None, None, Some($exit_status), &Some($error));
 	};
 	($actual:expr, state = $state:expr) => {
 		crate::process::testutil::_assert_process_result(&$actual, None, Some($state), None, &None);

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -9,7 +9,6 @@ use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 use crate::view::View;
-use anyhow::Result;
 
 const HEIGHT_ERROR_MESSAGE: &str = "Window too small, increase height to continue";
 const SHORT_ERROR_MESSAGE: &str = "Window too small";
@@ -22,9 +21,9 @@ pub struct WindowSizeError {
 }
 
 impl ProcessModule for WindowSizeError {
-	fn activate(&mut self, _: &GitInteractive, previous_state: State) -> Result<()> {
+	fn activate(&mut self, _: &GitInteractive, previous_state: State) -> ProcessResult {
 		self.return_state = previous_state;
-		Ok(())
+		ProcessResult::new()
 	}
 
 	fn build_view_data(&mut self, view: &View<'_>, _: &GitInteractive) -> &ViewData {


### PR DESCRIPTION
# Description

The way that Result was used to handle errors in activate does not allow an error to return the user to another state. This converts the activate function to use ProcessResult that supports error results and
state change.