### PR TITLE
Refactor the tests that use process utils

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,8 +64,12 @@ jobs:
       - name: Update Rust
         run: rustup update stable
       - name: Test
-        run: cargo test --target x86_64-pc-windows-msvc --release --
+        run: cargo test --target x86_64-pc-windows-msvc --release
+        env:
+            RUSTFLAGS: '--cap-lints warn'
       - name: Build
         run: cargo build --target x86_64-pc-windows-msvc --release
+        env:
+            RUSTFLAGS: '--cap-lints warn'
       - name: Test Run
         run: cargo run --target x86_64-pc-windows-msvc --release -- --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "git-interactive-rebase-tool"
 version = "1.2.1"
 dependencies = [
@@ -120,6 +131,7 @@ dependencies = [
  "pancurses",
  "rstest",
  "serial_test",
+ "tempfile",
  "unicode-segmentation",
  "unicode-width",
  "xi-unicode",
@@ -339,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,10 +375,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rstest"
@@ -451,6 +519,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +609,12 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,10 @@ default-features = false
 features = []
 
 [dev-dependencies]
-serial_test = "0.4.0"
 concat-idents = "1.0.0"
 rstest = "0.6.4"
+serial_test = "0.4.0"
+tempfile = "3.1.0"
 
 [features]
 default = []

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -54,69 +54,94 @@ impl ConfirmAbort {
 #[cfg(test)]
 mod tests {
 	use crate::assert_process_result;
-	use crate::build_render_output;
-	use crate::config::Config;
+	use crate::assert_rendered_output;
 	use crate::confirm_abort::ConfirmAbort;
-	use crate::display::Display;
-	use crate::git_interactive::GitInteractive;
-	use crate::input::input_handler::InputHandler;
 	use crate::input::Input;
 	use crate::process::exit_status::ExitStatus;
-	use crate::process::process_module::ProcessModule;
 	use crate::process::state::State;
-	use crate::process_module_handle_input_test;
-	use crate::process_module_test;
-	use crate::view::View;
+	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
-	process_module_test!(
-		confirm_abort_build_view_data,
-		["pick aaa comment"],
-		build_render_output!("{TITLE}", "{PROMPT}", "Are you sure you want to abort"),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(ConfirmAbort::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn build_view_data() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[],
+			|test_context: TestContext<'_>| {
+				let mut module = ConfirmAbort::new();
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(view_data, "{TITLE}", "{PROMPT}", "Are you sure you want to abort");
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_abort_handle_input_yes,
-		["pick aaa comment"],
-		[Input::Yes],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_abort = ConfirmAbort::new();
-			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Yes, exit_status = ExitStatus::Good);
-			assert_eq!(git_interactive.get_lines().len(), 0);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_yes() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Yes],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmAbort::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::Yes,
+					exit_status = ExitStatus::Good
+				);
+				assert_eq!(test_context.git_interactive.get_lines().len(), 0);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_abort_handle_input_no,
-		["pick aaa comment"],
-		[Input::No],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_abort = ConfirmAbort::new();
-			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::No, state = State::List);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_no() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::No],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmAbort::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::No,
+					state = State::List
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_abort_handle_input_any_key,
-		["pick aaa comment"],
-		[Input::Character('x')],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_abort = ConfirmAbort::new();
-			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::No, state = State::List);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_any_key() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Character('x')],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmAbort::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::No,
+					state = State::List
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_abort_handle_input_resize,
-		["pick aaa comment"],
-		[Input::Resize],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_abort = ConfirmAbort::new();
-			let result = confirm_abort.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Resize);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_resize() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Resize],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmAbort::new();
+				assert_process_result!(test_context.handle_input(&mut module), input = Input::Resize);
+			},
+		);
+	}
 }

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -53,71 +53,94 @@ impl ConfirmRebase {
 #[cfg(test)]
 mod tests {
 	use crate::assert_process_result;
-	use crate::build_render_output;
-	use crate::config::Config;
+	use crate::assert_rendered_output;
 	use crate::confirm_rebase::ConfirmRebase;
-	use crate::display::Display;
-	use crate::git_interactive::GitInteractive;
-	use crate::input::input_handler::InputHandler;
 	use crate::input::Input;
 	use crate::process::exit_status::ExitStatus;
-	use crate::process::process_module::ProcessModule;
 	use crate::process::state::State;
-	use crate::process_module_handle_input_test;
-	use crate::process_module_test;
-	use crate::view::View;
+	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
-	process_module_test!(
-		confirm_rebase_build_view_data,
-		["pick aaa comment"],
-		build_render_output!("{TITLE}", "{PROMPT}", "Are you sure you want to rebase"),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(ConfirmRebase::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn build_view_data() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[],
+			|test_context: TestContext<'_>| {
+				let mut module = ConfirmRebase::new();
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(view_data, "{TITLE}", "{PROMPT}", "Are you sure you want to rebase");
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_rebase_handle_input_yes,
-		["pick aaa comment"],
-		[Input::Yes],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_rebase = ConfirmRebase::new();
-			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_yes() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Yes],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmRebase::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::Yes,
+					exit_status = ExitStatus::Good
+				);
+				assert_eq!(test_context.git_interactive.get_lines().len(), 1);
+			},
+		);
+	}
 
-			assert_process_result!(result, input = Input::Yes, exit_status = ExitStatus::Good);
-			assert_eq!(git_interactive.get_lines().len(), 1);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_no() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::No],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmRebase::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::No,
+					state = State::List
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_rebase_handle_input_no,
-		["pick aaa comment"],
-		[Input::No],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_rebase = ConfirmRebase::new();
-			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::No, state = State::List);
-			assert_eq!(git_interactive.get_lines().len(), 1);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_any_key() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Character('x')],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmRebase::new();
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::No,
+					state = State::List
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		confirm_rebase_handle_input_any_key,
-		["pick aaa comment"],
-		[Input::Character('x')],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_rebase = ConfirmRebase::new();
-			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::No, state = State::List);
-		}
-	);
-
-	process_module_handle_input_test!(
-		confirm_rebase_handle_input_resize,
-		["pick aaa comment"],
-		[Input::Resize],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut confirm_rebase = ConfirmRebase::new();
-			let result = confirm_rebase.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Resize);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn handle_input_resize() {
+		process_module_test(
+			&["pick aaa comment"],
+			ViewState::default(),
+			&[Input::Resize],
+			|mut test_context: TestContext<'_>| {
+				let mut module = ConfirmRebase::new();
+				assert_process_result!(test_context.handle_input(&mut module), input = Input::Resize);
+			},
+		);
+	}
 }

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -131,6 +131,7 @@ impl ColorManager {
 			},
 			// for indexed colored we assume 8bit color
 			Color::Index(i) => i,
+			#[allow(clippy::option_if_let_else)]
 			Color::RGB { red, green, blue } if color_mode.has_true_color() => {
 				if let Some(index) = self.color_lookup.get(&(red, green, blue)) {
 					*index

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -156,432 +156,718 @@ impl Edit {
 		}
 	}
 }
-
 #[cfg(test)]
 mod tests {
 	use crate::assert_process_result;
-	use crate::build_render_output;
-	use crate::config::Config;
-	use crate::display::Display;
+	use crate::assert_rendered_output;
 	use crate::edit::Edit;
-	use crate::git_interactive::GitInteractive;
-	use crate::input::input_handler::InputHandler;
 	use crate::input::Input;
-	use crate::process::process_module::ProcessModule;
 	use crate::process::state::State;
-	use crate::process_module_handle_input_test;
-	use crate::process_module_state;
-	use crate::process_module_test;
-	use crate::view::View;
+	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
-	process_module_test!(
-		edit_move_cursor_end,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}foobar{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_end() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorRight],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}foobar{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_1_left,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}fooba{Normal,Underline}r",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_1_left() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}fooba{Normal,Underline}r",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_2_left,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 2],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}foob{Normal,Underline}a{Normal}r",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_2_from_start() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 2],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}foob{Normal,Underline}a{Normal}r",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_1_right,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 5],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}f{Normal,Underline}o{Normal}obar",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_1_from_start() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 5],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}f{Normal,Underline}o{Normal}obar",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_right,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 6],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal,Underline}f{Normal}oobar",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_to_start() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 6],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}f{Normal}oobar",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_attempt_past_start,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 10],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal,Underline}f{Normal}oobar",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_to_home() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Home],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}f{Normal}oobar",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_move_cursor_attempt_past_end,
-		["exec foobar"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorRight; 5],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}foobar{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_to_end() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::End,
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}foobar{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_multiple_width_unicode_single_width,
-		["exec a🗳b"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 2],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}a{Normal,Underline}🗳{Normal}b",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_on_empty_content() {
+		process_module_test(
+			&["exec "],
+			ViewState::default(),
+			&[Input::MoveCursorLeft, Input::MoveCursorRight, Input::End, Input::Home],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_multiple_width_unicode_emoji,
-		["exec a😀b"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft; 2],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}a{Normal,Underline}😀{Normal}b",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_attempt_past_start() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 10],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}f{Normal}oobar",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_add_character_end,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::Character('x')],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}abcdx{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn move_cursor_attempt_past_end() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 10],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}f{Normal}oobar",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_add_character_one_from_end,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft, Input::Character('x')],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}abcx{Normal,Underline}d",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn multiple_width_unicode_single_width() {
+		process_module_test(
+			&["exec a🗳b"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 2],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}a{Normal,Underline}🗳{Normal}b",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_add_character_one_from_start,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Character('x')
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}ax{Normal,Underline}b{Normal}cd",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn multiple_width_unicode_emoji() {
+		process_module_test(
+			&["exec a😀b"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft; 2],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}a{Normal,Underline}😀{Normal}b",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_add_character_at_start,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Character('x')
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}x{Normal,Underline}a{Normal}bcd",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn add_character_end() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::Character('x')],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}abcdx{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_backspace_at_end,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::Backspace],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}abc{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn add_character_one_from_end() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft, Input::Character('x')],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}abcx{Normal,Underline}d",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_backspace_one_from_end,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft, Input::Backspace],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}ab{Normal,Underline}d",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn add_character_one_from_start() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Character('x'),
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}ax{Normal,Underline}b{Normal}cd",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_backspace_one_from_start,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Backspace
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal,Underline}b{Normal}cd",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn add_character_at_start() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Character('x'),
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}x{Normal,Underline}a{Normal}bcd",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_backspace_at_start,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Backspace
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal,Underline}a{Normal}bcd",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn backspace_at_end() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::Backspace],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}abc{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_delete_at_end,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::Delete],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}abcd{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn backspace_one_from_end() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft, Input::Backspace],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}ab{Normal,Underline}d",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_delete_last_character,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![Input::MoveCursorLeft, Input::Delete],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}abc{Normal,Underline} ",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn backspace_one_from_start() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Backspace,
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}b{Normal}cd",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_delete_second_character,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Delete
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal}a{Normal,Underline}c{Normal}d",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn backspace_at_start() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Backspace,
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}a{Normal}bcd",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_test!(
-		edit_cursor_delete_first_character,
-		["exec abcd"],
-		process_module_state!(new_state = State::Edit, previous_state = State::List),
-		vec![
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::MoveCursorLeft,
-			Input::Delete
-		],
-		build_render_output!(
-			"{TITLE}",
-			"{BODY}",
-			"{Normal,Underline}b{Normal}cd",
-			"{TRAILING}",
-			"{IndicatorColor}Enter to finish"
-		),
-		|_: &Config, _: &Display<'_>| -> Box<dyn ProcessModule> { Box::new(Edit::new()) }
-	);
+	#[test]
+	#[serial_test::serial]
+	fn delete_at_end() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::Delete],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}abcd{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		edit_resize,
-		["exec foobar"],
-		[Input::Resize],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List);
-			let result = edit.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Resize);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn delete_last_character() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[Input::MoveCursorLeft, Input::Delete],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}abc{Normal,Underline} ",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		edit_finish_edit_no_change,
-		["exec foobar"],
-		[Input::Enter],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List);
-			let result = edit.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Enter, state = State::List);
-			assert_eq!(git_interactive.get_selected_line_edit_content(), "foobar");
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn delete_second_character() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Delete,
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal}a{Normal,Underline}c{Normal}d",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		edit_finish_edit_with_change,
-		["exec foobar"],
-		[Input::Character('x'), Input::Enter],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List);
-			edit.handle_input(input_handler, git_interactive, view);
-			let result = edit.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Enter, state = State::List);
-			assert_eq!(git_interactive.get_selected_line_edit_content(), "foobarx");
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn delete_first_character() {
+		process_module_test(
+			&["exec abcd"],
+			ViewState::default(),
+			&[
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::MoveCursorLeft,
+				Input::Delete,
+			],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_all_inputs(&mut module);
+				let view_data = test_context.build_view_data(&mut module);
+				assert_rendered_output!(
+					view_data,
+					"{TITLE}",
+					"{BODY}",
+					"{Normal,Underline}b{Normal}cd",
+					"{TRAILING}",
+					"{IndicatorColor}Enter to finish"
+				);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		edit_ignore_other_input,
-		["exec foobar"],
-		[Input::Other, Input::Enter],
-		|input_handler: &InputHandler<'_>, git_interactive: &mut GitInteractive, view: &View<'_>, _: &Display<'_>| {
-			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List);
-			let result = edit.handle_input(input_handler, git_interactive, view);
-			assert_process_result!(result, input = Input::Enter, state = State::List);
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn resize() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Resize],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				assert_process_result!(test_context.handle_input(&mut module), input = Input::Resize);
+			},
+		);
+	}
 
-	process_module_handle_input_test!(
-		edit_deactivate,
-		["exec foobar"],
-		[Input::MoveCursorLeft],
-		|_: &InputHandler<'_>, git_interactive: &mut GitInteractive, _: &View<'_>, _: &Display<'_>| {
-			let mut edit = Edit::new();
-			edit.activate(git_interactive, State::List);
-			edit.deactivate();
-			assert!(edit.content.is_empty());
-		}
-	);
+	#[test]
+	#[serial_test::serial]
+	fn finish_edit_no_change() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Enter],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::Enter,
+					state = State::List
+				);
+				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobar");
+			},
+		);
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn finish_edit_with_change() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Character('x'), Input::Enter],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.handle_input(&mut module);
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::Enter,
+					state = State::List
+				);
+				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobarx");
+			},
+		);
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn ignore_other_input() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Other, Input::Enter],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::Enter,
+					state = State::List
+				);
+				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobar");
+			},
+		);
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn deactivate() {
+		process_module_test(
+			&["exec foobar"],
+			ViewState::default(),
+			&[Input::Other, Input::Enter],
+			|mut test_context: TestContext<'_>| {
+				let mut module = Edit::new();
+				test_context.activate(&mut module, State::List);
+				test_context.deactivate(&mut module);
+				assert!(module.content.is_empty());
+			},
+		);
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 	unsafe_code
 )]
 #![deny(clippy::all, clippy::cargo, clippy::nursery, clippy::pedantic, clippy::restriction)]
+#![allow(clippy::blanket_clippy_restriction_lints)]
 #![allow(clippy::as_conversions)]
 #![allow(clippy::blocks_in_if_conditions)] // sometimes rustfmt makes blocks out of simple statements
 #![allow(clippy::cast_possible_truncation)]

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -19,10 +19,11 @@ pub fn panic_trace_error(e: &(String, Vec<String>), trace: &[(String, Vec<String
 		"Trace:",
 		trace
 			.iter()
-			.map(|(f, args): &(String, Vec<String>)| {
+			.map(|t| {
+				let (ref func, ref args) = *t;
 				format!(
 					"\t{}({})",
-					f,
+					func,
 					args.iter()
 						.map(|v| v.replace("\n", "\\n"))
 						.collect::<Vec<String>>()


### PR DESCRIPTION
# Description

This greatly simplifies the process utils based tests to use a function over a macro. The macro did not provide a decent stack-trace on error and was also difficult to maintain. This change uses a basic function with a callback that contains a test context that provides the flexibility needed for future tests.