### PR TITLE
Use ViewLine::from trait instead of ViewLine::new

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -56,12 +56,12 @@ impl ProcessModule for Edit {
 			));
 		}
 		self.view_data.clear();
-		self.view_data.set_content(ViewLine::new(segments));
+		self.view_data.set_content(ViewLine::from(segments));
 		self.view_data
-			.push_trailing_line(ViewLine::new(vec![LineSegment::new_with_color(
+			.push_trailing_line(ViewLine::from(LineSegment::new_with_color(
 				"Enter to finish",
 				DisplayColor::IndicatorColor,
-			)]));
+			)));
 		self.view_data.set_view_size(view_width, view_height);
 		self.view_data.rebuild();
 		&self.view_data

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -56,12 +56,11 @@ impl Error {
 	pub fn set_error_message(&mut self, error: &anyhow::Error) {
 		self.view_data.reset();
 		// TODO expand error messaging
+		self.view_data.push_line(ViewLine::from(error.to_string()));
 		self.view_data
-			.push_line(ViewLine::new(vec![LineSegment::new(error.to_string().as_str())]));
-		self.view_data
-			.push_trailing_line(ViewLine::new(vec![LineSegment::new_with_color(
+			.push_trailing_line(ViewLine::from(LineSegment::new_with_color(
 				"Press any key to continue",
 				DisplayColor::IndicatorColor,
-			)]));
+			)));
 	}
 }

--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -69,7 +69,7 @@ impl ProcessModule for Help {
 impl Help {
 	pub fn new() -> Self {
 		let mut no_help_view_data = ViewData::new();
-		no_help_view_data.set_content(ViewLine::new(vec![LineSegment::new("Help not available")]));
+		no_help_view_data.set_content(ViewLine::from("Help not available"));
 
 		Self {
 			return_state: None,

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -5,7 +5,6 @@ use crate::input::Input;
 use crate::process::process_module::ProcessModule;
 use crate::process::process_result::ProcessResult;
 use crate::process::state::State;
-use crate::view::line_segment::LineSegment;
 use crate::view::view_data::ViewData;
 use crate::view::view_line::ViewLine;
 use crate::view::View;
@@ -54,7 +53,7 @@ impl ProcessModule for WindowSizeError {
 		};
 
 		self.view_data.clear();
-		self.view_data.push_line(ViewLine::new(vec![LineSegment::new(message)]));
+		self.view_data.push_line(ViewLine::from(message));
 		self.view_data.set_view_size(view_width, view_height);
 		self.view_data.rebuild();
 		&self.view_data

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -78,7 +78,7 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		if self.view_data.is_empty() {
 			let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
 
-			self.view_data.push_leading_line(ViewLine::new(vec![
+			self.view_data.push_leading_line(ViewLine::from(vec![
 				LineSegment::new_with_color(
 					if is_full_width { "Commit: " } else { "" },
 					DisplayColor::IndicatorColor,

--- a/src/show_commit/util.rs
+++ b/src/show_commit/util.rs
@@ -97,7 +97,7 @@ pub(super) fn get_files_changed_summary(commit: &Commit, is_full_width: bool) ->
 	let deletions = commit.get_number_deletions();
 
 	if is_full_width {
-		ViewLine::new(vec![
+		ViewLine::from(vec![
 			LineSegment::new_with_color(
 				files_changed.to_formatted_string(&Locale::en).as_str(),
 				DisplayColor::IndicatorColor,
@@ -118,7 +118,7 @@ pub(super) fn get_files_changed_summary(commit: &Commit, is_full_width: bool) ->
 		])
 	}
 	else {
-		ViewLine::new(vec![
+		ViewLine::from(vec![
 			LineSegment::new_with_color(
 				files_changed.to_formatted_string(&Locale::en).as_str(),
 				DisplayColor::IndicatorColor,

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -128,7 +128,7 @@ impl<'d> ViewBuilder<'d> {
 	}
 
 	pub(super) fn build_view_data_for_overview(&self, view_data: &mut ViewData, commit: &Commit, is_full_width: bool) {
-		view_data.push_line(ViewLine::new(vec![
+		view_data.push_line(ViewLine::from(vec![
 			LineSegment::new_with_color(
 				if is_full_width { "Date: " } else { "D: " },
 				DisplayColor::IndicatorColor,
@@ -137,7 +137,7 @@ impl<'d> ViewBuilder<'d> {
 		]));
 
 		if let Some(author) = commit.get_author().to_string() {
-			view_data.push_line(ViewLine::new(vec![
+			view_data.push_line(ViewLine::from(vec![
 				LineSegment::new_with_color(
 					if is_full_width { "Author: " } else { "A: " },
 					DisplayColor::IndicatorColor,
@@ -147,7 +147,7 @@ impl<'d> ViewBuilder<'d> {
 		}
 
 		if let Some(committer) = commit.get_committer().to_string() {
-			view_data.push_line(ViewLine::new(vec![
+			view_data.push_line(ViewLine::from(vec![
 				LineSegment::new_with_color(
 					if is_full_width { "Committer: " } else { "C: " },
 					DisplayColor::IndicatorColor,
@@ -158,15 +158,15 @@ impl<'d> ViewBuilder<'d> {
 
 		if let Some(ref body) = *commit.get_body() {
 			for line in body.lines() {
-				view_data.push_line(ViewLine::new(vec![LineSegment::new(line)]));
+				view_data.push_line(ViewLine::from(line));
 			}
 		}
 
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("")]));
+		view_data.push_line(ViewLine::from(""));
 
 		view_data.push_line(get_files_changed_summary(commit, is_full_width));
 		for stat in commit.get_file_stats() {
-			view_data.push_line(ViewLine::new(get_stat_item_segments(
+			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
 				stat.get_to_name().as_str(),
 				stat.get_from_name().as_str(),
@@ -245,7 +245,7 @@ impl<'d> ViewBuilder<'d> {
 		view_data.push_leading_line(get_files_changed_summary(commit, is_full_width));
 		view_data.push_line(ViewLine::new_empty_line().set_padding_character("―"));
 		for stat in commit.get_file_stats() {
-			view_data.push_line(ViewLine::new(get_stat_item_segments(
+			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
 				stat.get_to_name().as_str(),
 				stat.get_from_name().as_str(),
@@ -256,7 +256,7 @@ impl<'d> ViewBuilder<'d> {
 			let old_largest_line_number_length = stat.largest_old_line_number().to_string().len();
 			let new_largest_line_number_length = stat.largest_new_line_number().to_string().len();
 			for delta in stat.deltas() {
-				view_data.push_line(ViewLine::new(vec![
+				view_data.push_line(ViewLine::from(vec![
 					LineSegment::new_with_color_and_style("@@", DisplayColor::Normal, true, false, false),
 					LineSegment::new_with_color(
 						format!(
@@ -283,7 +283,7 @@ impl<'d> ViewBuilder<'d> {
 
 				for line in delta.lines() {
 					if line.end_of_file() && line.line() != "\n" {
-						view_data.push_line(ViewLine::new(vec![
+						view_data.push_line(ViewLine::from(vec![
 							LineSegment::new(
 								" ".repeat(old_largest_line_number_length + new_largest_line_number_length + 3)
 									.as_str(),
@@ -296,7 +296,7 @@ impl<'d> ViewBuilder<'d> {
 						continue;
 					}
 
-					view_data.push_line(ViewLine::new(self.get_diff_line_segments(
+					view_data.push_line(ViewLine::from(self.get_diff_line_segments(
 						line,
 						old_largest_line_number_length,
 						new_largest_line_number_length,

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -368,7 +368,7 @@ impl ViewData {
 							segments.push(segment.clone());
 
 							if remaining_width == 0 {
-								view_lines.push(ViewLine::new(segments.to_vec()));
+								view_lines.push(ViewLine::from(segments.to_vec()));
 								segments.clear();
 								remaining_width = self.width;
 							}
@@ -389,7 +389,7 @@ impl ViewData {
 									));
 
 									if remaining_width == 0 {
-										view_lines.push(ViewLine::new(segments.to_vec()));
+										view_lines.push(ViewLine::from(segments.to_vec()));
 										segments.clear();
 										remaining_width = self.width;
 									}
@@ -401,7 +401,7 @@ impl ViewData {
 						}
 					}
 					if !segments.is_empty() {
-						view_lines.push(ViewLine::new(segments.to_vec()));
+						view_lines.push(ViewLine::from(segments.to_vec()));
 					}
 
 					self.max_line_length = self.width;
@@ -551,7 +551,7 @@ mod tests {
 	use crate::view::view_line::ViewLine;
 
 	fn create_mock_view_line() -> ViewLine {
-		ViewLine::new(vec![LineSegment::new("Mocked Line")])
+		ViewLine::from("Mocked Line")
 	}
 
 	fn create_mocked_view_data() -> ViewData {
@@ -578,15 +578,15 @@ mod tests {
 		view_data.push_leading_line(create_mock_view_line());
 		view_data.push_leading_line(create_mock_view_line());
 
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("a")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("b")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("c")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("d")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("1")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("2")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("3")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("4")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("5")]));
+		view_data.push_line(ViewLine::from("a"));
+		view_data.push_line(ViewLine::from("b"));
+		view_data.push_line(ViewLine::from("c"));
+		view_data.push_line(ViewLine::from("d"));
+		view_data.push_line(ViewLine::from("1"));
+		view_data.push_line(ViewLine::from("2"));
+		view_data.push_line(ViewLine::from("3"));
+		view_data.push_line(ViewLine::from("4"));
+		view_data.push_line(ViewLine::from("5"));
 
 		view_data.push_trailing_line(create_mock_view_line());
 		view_data.push_trailing_line(create_mock_view_line());
@@ -597,14 +597,14 @@ mod tests {
 
 	fn create_mocked_scroll_horizontal_view_data() -> ViewData {
 		let mut view_data = ViewData::new();
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("aaaaa")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("aaaaaaaaaa")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("aaaaaaaaaaaaaaa")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("aaaaaaaaaa")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("aaaaa")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("bbbbb")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("ccccc")]));
-		view_data.push_line(ViewLine::new(vec![LineSegment::new("ddddd")]));
+		view_data.push_line(ViewLine::from("aaaaa"));
+		view_data.push_line(ViewLine::from("aaaaaaaaaa"));
+		view_data.push_line(ViewLine::from("aaaaaaaaaaaaaaa"));
+		view_data.push_line(ViewLine::from("aaaaaaaaaa"));
+		view_data.push_line(ViewLine::from("aaaaa"));
+		view_data.push_line(ViewLine::from("bbbbb"));
+		view_data.push_line(ViewLine::from("ccccc"));
+		view_data.push_line(ViewLine::from("ddddd"));
 		view_data.set_view_size(7, 20);
 
 		view_data
@@ -1175,8 +1175,8 @@ mod tests {
 	#[test]
 	fn view_data_case_calculate_max_line_length_max_first() {
 		let view_lines = [
-			ViewLine::new(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("012345")]),
+			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+			ViewLine::from("012345"),
 		];
 		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 1), 16);
 	}
@@ -1184,8 +1184,8 @@ mod tests {
 	#[test]
 	fn view_data_case_calculate_max_line_length_max_last() {
 		let view_lines = [
-			ViewLine::new(vec![LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+			ViewLine::from("012345"),
+			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
 		];
 		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 2), 16);
 	}
@@ -1193,10 +1193,10 @@ mod tests {
 	#[test]
 	fn view_data_case_calculate_max_line_length_with_slice() {
 		let view_lines = [
-			ViewLine::new(vec![LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
+			ViewLine::from("012345"),
+			ViewLine::from("012345"),
+			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
 		];
 		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 1, 2), 16);
 	}
@@ -1204,9 +1204,9 @@ mod tests {
 	#[test]
 	fn view_data_case_calculate_max_line_length_ignore_pinned() {
 		let view_lines = [
-			ViewLine::new(vec![LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("012345")]),
-			ViewLine::new(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+			ViewLine::from("012345"),
+			ViewLine::from("012345"),
+			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
 			ViewLine::new_pinned(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
 		];
 		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 4), 16);

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -18,10 +18,6 @@ impl ViewLine {
 		Self::new_with_pinned_segments(vec![], 1)
 	}
 
-	pub(crate) fn new(segments: Vec<LineSegment>) -> Self {
-		Self::new_with_pinned_segments(segments, 0)
-	}
-
 	pub(crate) fn new_pinned(segments: Vec<LineSegment>) -> Self {
 		let segments_length = segments.len();
 		Self::new_with_pinned_segments(segments, segments_length)
@@ -98,6 +94,30 @@ impl ViewLine {
 	}
 }
 
+impl<'a> From<&'a str> for ViewLine {
+	fn from(line: &'a str) -> Self {
+		Self::from(LineSegment::new(line))
+	}
+}
+
+impl<'a> From<String> for ViewLine {
+	fn from(line: String) -> Self {
+		Self::from(LineSegment::new(line.as_str()))
+	}
+}
+
+impl<'a> From<LineSegment> for ViewLine {
+	fn from(line_segment: LineSegment) -> Self {
+		Self::from(vec![line_segment])
+	}
+}
+
+impl<'a> From<Vec<LineSegment>> for ViewLine {
+	fn from(line_segment: Vec<LineSegment>) -> Self {
+		Self::new_with_pinned_segments(line_segment, 0)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::display::display_color::DisplayColor;
@@ -105,17 +125,49 @@ mod tests {
 	use crate::view::view_line::ViewLine;
 
 	#[test]
-	fn view_line_new() {
-		let view_line = ViewLine::new(vec![LineSegment::new("foo"), LineSegment::new("bar")]);
+	fn from_str() {
+		let view_line = ViewLine::from("foo");
+
+		assert_eq!(view_line.get_number_of_pinned_segment(), 0);
+		assert_eq!(view_line.get_segments().len(), 1);
+		assert_eq!(view_line.get_segments().first().unwrap().get_content(), "foo");
+		assert_eq!(view_line.get_selected(), false);
+	}
+
+	#[test]
+	fn from_string() {
+		let view_line = ViewLine::from(String::from("foo"));
+
+		assert_eq!(view_line.get_number_of_pinned_segment(), 0);
+		assert_eq!(view_line.get_segments().len(), 1);
+		assert_eq!(view_line.get_segments().first().unwrap().get_content(), "foo");
+		assert_eq!(view_line.get_selected(), false);
+	}
+
+	#[test]
+	fn from_line_segment() {
+		let view_line = ViewLine::from(LineSegment::new("foo"));
+
+		assert_eq!(view_line.get_number_of_pinned_segment(), 0);
+		assert_eq!(view_line.get_segments().len(), 1);
+		assert_eq!(view_line.get_segments().first().unwrap().get_content(), "foo");
+		assert_eq!(view_line.get_selected(), false);
+	}
+
+	#[test]
+	fn from_list_line_segment() {
+		let view_line = ViewLine::from(vec![LineSegment::new("foo"), LineSegment::new("bar")]);
 
 		assert_eq!(view_line.get_number_of_pinned_segment(), 0);
 		assert_eq!(view_line.get_segments().len(), 2);
+		assert_eq!(view_line.get_segments().first().unwrap().get_content(), "foo");
+		assert_eq!(view_line.get_segments().last().unwrap().get_content(), "bar");
 		assert_eq!(view_line.get_selected(), false);
 	}
 
 	#[test]
 	fn view_line_new_selected() {
-		let view_line = ViewLine::new(vec![LineSegment::new("foo"), LineSegment::new("bar")]).set_selected(true);
+		let view_line = ViewLine::from(vec![LineSegment::new("foo"), LineSegment::new("bar")]).set_selected(true);
 
 		assert_eq!(view_line.get_number_of_pinned_segment(), 0);
 		assert_eq!(view_line.get_segments().len(), 2);
@@ -135,6 +187,7 @@ mod tests {
 		assert_eq!(view_line.get_segments().len(), 4);
 		assert_eq!(view_line.get_selected(), false);
 	}
+
 	#[test]
 	fn view_line_new_with_pinned_segments() {
 		let view_line = ViewLine::new_with_pinned_segments(
@@ -154,7 +207,7 @@ mod tests {
 
 	#[test]
 	fn view_line_set_padding_color_and_style() {
-		let view_line = ViewLine::new(vec![LineSegment::new("foo")]);
+		let view_line = ViewLine::from("foo");
 		let view_line = view_line.set_padding_color_and_style(DisplayColor::IndicatorColor, true, true, true);
 
 		assert_eq!(view_line.get_padding_color(), DisplayColor::IndicatorColor);


### PR DESCRIPTION
# Description

The From trait was meant to handle conversion from one type to another, and the ViewLine struct did not take advantage of it. This removes the ViewLine::new function and replaces the existing usages of the function with a simplified version using the From trait. This greatly reduces the complexity of the usages of ViewLine in most cases.