### PR TITLE
Remove proxy functions to selected line

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -19,7 +19,7 @@ pub struct Edit {
 
 impl ProcessModule for Edit {
 	fn activate(&mut self, git_interactive: &GitInteractive, _: State) -> ProcessResult {
-		self.content = git_interactive.get_selected_line_edit_content().clone();
+		self.content = git_interactive.get_selected_line().get_edit_content().to_string();
 		self.cursor_position = UnicodeSegmentation::graphemes(self.content.as_str(), true).count();
 		ProcessResult::new()
 	}
@@ -809,7 +809,10 @@ mod tests {
 					input = Input::Enter,
 					state = State::List
 				);
-				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobar");
+				assert_eq!(
+					test_context.git_interactive.get_selected_line().get_edit_content(),
+					"foobar"
+				);
 			},
 		);
 	}
@@ -830,7 +833,10 @@ mod tests {
 					input = Input::Enter,
 					state = State::List
 				);
-				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobarx");
+				assert_eq!(
+					test_context.git_interactive.get_selected_line().get_edit_content(),
+					"foobarx"
+				);
 			},
 		);
 	}
@@ -850,7 +856,10 @@ mod tests {
 					input = Input::Enter,
 					state = State::List
 				);
-				assert_eq!(test_context.git_interactive.get_selected_line_edit_content(), "foobar");
+				assert_eq!(
+					test_context.git_interactive.get_selected_line().get_edit_content(),
+					"foobar"
+				);
 			},
 		);
 	}

--- a/src/git_interactive.rs
+++ b/src/git_interactive.rs
@@ -143,10 +143,6 @@ impl GitInteractive {
 		self.lines[self.selected_line_index - 1].edit_content(content);
 	}
 
-	pub(crate) fn get_selected_line_edit_content(&self) -> &String {
-		self.lines[self.selected_line_index - 1].get_edit_content()
-	}
-
 	pub(crate) fn set_visual_range_action(&mut self, action: Action) {
 		let range = if self.selected_line_index <= self.visual_index_start {
 			self.selected_line_index..=self.visual_index_start
@@ -190,12 +186,8 @@ impl GitInteractive {
 		!self.lines.is_empty() && *self.lines[0].get_action() == Action::Noop
 	}
 
-	pub(crate) fn get_selected_line_hash(&self) -> &String {
-		self.lines[self.selected_line_index - 1].get_hash()
-	}
-
-	pub(crate) fn get_selected_line_action(&self) -> &Action {
-		self.lines[self.selected_line_index - 1].get_action()
+	pub(crate) fn get_selected_line(&self) -> &Line {
+		&self.lines[self.selected_line_index - 1]
 	}
 
 	pub(crate) const fn get_selected_line_index(&self) -> &usize {

--- a/src/list/line.rs
+++ b/src/list/line.rs
@@ -85,10 +85,10 @@ impl Line {
 		}
 	}
 
-	pub(crate) const fn get_edit_content(&self) -> &String {
+	pub(crate) fn get_edit_content(&self) -> &str {
 		match self.action {
-			Action::Exec => &self.command,
-			_ => &self.comment,
+			Action::Exec => self.command.as_str(),
+			_ => self.comment.as_str(),
 		}
 	}
 
@@ -260,7 +260,7 @@ mod tests {
 	fn edit_content(line: &str, expected: &str) {
 		let mut line = Line::new(line).unwrap();
 		line.edit_content("new");
-		assert_eq!(line.get_edit_content(), &expected);
+		assert_eq!(line.get_edit_content(), expected);
 	}
 
 	#[rstest(

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -131,7 +131,7 @@ impl<'l> List<'l> {
 		let mut result = result;
 		match input {
 			Input::ShowCommit => {
-				if !git_interactive.get_selected_line_hash().is_empty() {
+				if !git_interactive.get_selected_line().get_hash().is_empty() {
 					result = result.state(State::ShowCommit);
 				}
 			},
@@ -156,7 +156,7 @@ impl<'l> List<'l> {
 			Input::ActionReword => self.set_selected_line_action(git_interactive, Action::Reword),
 			Input::ActionSquash => self.set_selected_line_action(git_interactive, Action::Squash),
 			Input::Edit => {
-				if *git_interactive.get_selected_line_action() == Action::Exec {
+				if git_interactive.get_selected_line().get_action() == &Action::Exec {
 					result = result.state(State::Edit);
 				}
 			},

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -44,14 +44,14 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		// skip loading commit data if the currently loaded commit has not changed, this retains
 		// position after returning to the list view or help
 		if let Some(ref commit) = self.commit {
-			if commit.get_hash() == git_interactive.get_selected_line_hash() {
+			if commit.get_hash() == git_interactive.get_selected_line().get_hash() {
 				return ProcessResult::new();
 			}
 		}
 		self.view_data.reset();
 
 		let new_commit = Commit::new_from_hash(
-			git_interactive.get_selected_line_hash().as_str(),
+			git_interactive.get_selected_line().get_hash().as_str(),
 			LoadCommitDiffOptions {
 				context_lines: self.config.git.diff_context,
 				copies: self.config.git.diff_copies,


### PR DESCRIPTION
# Description

The main application struct had proxy functions for retrieving data from the selected line. This was due to a poor understanding of ownership during some of the early development of the project. These functions can be replaced with a single function to return the selected line.
