### PR TITLE
Remove process function from process module

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -50,11 +50,8 @@ impl<'r> Process<'r> {
 		if WindowSizeError::is_window_too_small(view_width, view_height) {
 			self.handle_process_result(&mut modules, &ProcessResult::new().state(State::WindowSizeError));
 		}
+		self.activate(&mut modules, State::List);
 		while self.exit_status.is_none() {
-			let result = modules.process(self.state, &mut self.git_interactive);
-			if self.handle_process_result(&mut modules, &result) {
-				continue;
-			}
 			self.view
 				.render(modules.build_view_data(self.state, self.view, &self.git_interactive));
 			let result = modules.handle_input(self.state, self.input_handler, &mut self.git_interactive, self.view);

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -84,10 +84,6 @@ impl<'m> Modules<'m> {
 		self.get_mut_module(state).build_view_data(view, git_interactive)
 	}
 
-	pub fn process(&mut self, state: State, git_interactive: &mut GitInteractive) -> ProcessResult {
-		self.get_mut_module(state).process(git_interactive)
-	}
-
 	pub fn handle_input(
 		&mut self,
 		state: State,

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -15,10 +15,6 @@ pub trait ProcessModule {
 
 	fn build_view_data(&mut self, _view: &View<'_>, _git_interactive: &GitInteractive) -> &ViewData;
 
-	fn process(&mut self, _git_interactive: &mut GitInteractive) -> ProcessResult {
-		ProcessResult::new()
-	}
-
 	fn handle_input(
 		&mut self,
 		_input_handler: &InputHandler<'_>,

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -43,22 +43,14 @@ impl<'t> TestContext<'t> {
 	}
 
 	pub fn handle_input(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
-		assert_ne!(self.num_inputs, 0);
-		self.num_inputs -= 1;
 		module.handle_input(self.input_handler, self.git_interactive, self.view)
 	}
 
-	pub fn process(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
-		module.process(self.git_interactive)
-	}
-
 	pub fn handle_all_inputs(&mut self, module: &'_ mut dyn ProcessModule) -> Vec<ProcessResult> {
-		assert_ne!(self.num_inputs, 0);
 		let mut results = vec![];
 		for _ in 0..self.num_inputs {
 			results.push(module.handle_input(self.input_handler, self.git_interactive, self.view));
 		}
-		self.num_inputs -= 1;
 		results
 	}
 


### PR DESCRIPTION
# Description

The process function from the process module was only being used in the external editor system. The usage in the external editor system was only used as a faux "on activate" hook. Since the existing activate function can instead be used to perform the same action, the process function can be removed. This change removes the last usage of the process function and then completely removes the usage of the process function from the project.