### PR TITLE
Refactor rebase todo file read and write

### DIFF
--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -123,7 +123,7 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 					self.state = ExternalEditorState::Error(e);
 				}
 				else {
-					match git_interactive.reload_file() {
+					match git_interactive.load_file() {
 						Ok(_) => {
 							if git_interactive.get_lines().is_empty() || git_interactive.is_noop() {
 								self.state = ExternalEditorState::Empty;
@@ -234,14 +234,14 @@ impl<'e> ExternalEditor<'e> {
 			for arg in arguments {
 				if arg.as_os_str() == "%" {
 					file_pattern_found = true;
-					cmd.arg(filepath.as_os_str());
+					cmd.arg(filepath);
 				}
 				else {
 					cmd.arg(arg);
 				}
 			}
 			if !file_pattern_found {
-				cmd.arg(filepath.as_os_str());
+				cmd.arg(filepath);
 			}
 			cmd.status().map_err(|e| anyhow!(e).context("Unable to run editor"))
 		};

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,13 +93,13 @@ fn try_main(matches: &ArgMatches<'_>) -> Result<ExitStatus, Exit> {
 		}
 	})?;
 
-	let git_interactive =
-		GitInteractive::new_from_filepath(filepath, config.git.comment_char.as_str()).map_err(|err| {
-			Exit {
-				message: err.to_string(),
-				status: ExitStatus::FileReadError,
-			}
-		})?;
+	let mut git_interactive = GitInteractive::new(filepath, config.git.comment_char.as_str());
+	git_interactive.load_file().map_err(|err| {
+		Exit {
+			message: err.to_string(),
+			status: ExitStatus::FileReadError,
+		}
+	})?;
 
 	if git_interactive.is_noop() {
 		return Err(Exit {

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -470,12 +470,9 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 		.tempfile_in(git_repo_dir.as_str())
 		.unwrap();
 
-	let mut git_interactive = GitInteractive::new(
-		lines.iter().map(|l| Line::new(l).unwrap()).collect(),
-		todo_file.path().to_path_buf(),
-		"#",
-	)
-	.unwrap();
+	let mut git_interactive = GitInteractive::new(todo_file.path().to_str().unwrap(), "#");
+	git_interactive.set_lines(lines.iter().map(|l| Line::new(l).unwrap()).collect());
+
 	let input_handler = InputHandler::new(&display, &config.key_bindings);
 	callback(TestContext {
 		git_interactive: &mut git_interactive,


### PR DESCRIPTION
# Description

This rewrites how the rebase todo file is read and written to disk.

- The file path is now stored as a String instead of a PathBuf.
- A noop rebase file is now written as a "noop"
- Extraneous noop lines are filtered out
- The file load is no longer done during GitInteractive::new and now is done through a separate method call