### PR TITLE
Remove &String

### DIFF
--- a/src/list/line.rs
+++ b/src/list/line.rs
@@ -104,8 +104,8 @@ impl Line {
 		self.hash.as_str()
 	}
 
-	pub(super) const fn get_comment(&self) -> &String {
-		&self.comment
+	pub(super) fn get_comment(&self) -> &str {
+		self.comment.as_str()
 	}
 
 	pub(crate) fn to_text(&self) -> String {

--- a/src/list/line.rs
+++ b/src/list/line.rs
@@ -100,8 +100,8 @@ impl Line {
 		self.command.as_str()
 	}
 
-	pub(crate) const fn get_hash(&self) -> &String {
-		&self.hash
+	pub(crate) fn get_hash(&self) -> &str {
+		self.hash.as_str()
 	}
 
 	pub(super) const fn get_comment(&self) -> &String {
@@ -324,7 +324,7 @@ mod tests {
 		case::squash("squash aaa comment", "aaa")
 	)]
 	fn get_hash(line: &str, expected: &str) {
-		assert_eq!(Line::new(line).unwrap().get_hash(), &expected);
+		assert_eq!(Line::new(line).unwrap().get_hash(), expected);
 	}
 
 	#[rstest(

--- a/src/list/line.rs
+++ b/src/list/line.rs
@@ -96,8 +96,8 @@ impl Line {
 		&self.action
 	}
 
-	pub(super) const fn get_command(&self) -> &String {
-		&self.command
+	pub(super) fn get_command(&self) -> &str {
+		self.command.as_str()
 	}
 
 	pub(crate) const fn get_hash(&self) -> &String {
@@ -308,7 +308,7 @@ mod tests {
 		case::squash("squash aaa comment", "")
 	)]
 	fn get_command(line: &str, expected: &str) {
-		assert_eq!(Line::new(line).unwrap().get_command(), &expected);
+		assert_eq!(Line::new(line).unwrap().get_command(), expected);
 	}
 
 	#[rstest(

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -174,7 +174,7 @@ pub(super) fn get_todo_line_segments(
 
 		segments.push(LineSegment::new(
 			if *action == Action::Exec {
-				line.get_command().clone()
+				String::from(line.get_command())
 			}
 			else if *action == Action::Break {
 				String::from("")
@@ -202,7 +202,7 @@ pub(super) fn get_todo_line_segments(
 
 		segments.push(LineSegment::new(
 			if *action == Action::Exec {
-				line.get_command().clone()
+				String::from(line.get_command())
 			}
 			else if *action == Action::Break {
 				String::from("    ")

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -215,7 +215,7 @@ pub(super) fn get_todo_line_segments(
 		));
 	}
 	if *action != Action::Exec && *action != Action::Break {
-		segments.push(LineSegment::new(line.get_comment().as_str()));
+		segments.push(LineSegment::new(line.get_comment()));
 	}
 	segments
 }

--- a/src/show_commit/file_stat.rs
+++ b/src/show_commit/file_stat.rs
@@ -48,8 +48,8 @@ impl FileStat {
 	}
 
 	/// Get the source file name for this change.
-	pub(super) const fn get_from_name(&self) -> &String {
-		&self.from_name
+	pub(super) fn get_from_name(&self) -> &str {
+		self.from_name.as_str()
 	}
 
 	pub(crate) const fn largest_old_line_number(&self) -> u32 {

--- a/src/show_commit/file_stat.rs
+++ b/src/show_commit/file_stat.rs
@@ -43,8 +43,8 @@ impl FileStat {
 	}
 
 	/// Get the destination file name for this change.
-	pub(super) const fn get_to_name(&self) -> &String {
-		&self.to_name
+	pub(super) fn get_to_name(&self) -> &str {
+		self.to_name.as_str()
 	}
 
 	/// Get the source file name for this change.

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -50,18 +50,15 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		}
 		self.view_data.reset();
 
-		let new_commit = Commit::new_from_hash(
-			git_interactive.get_selected_line().get_hash().as_str(),
-			LoadCommitDiffOptions {
-				context_lines: self.config.git.diff_context,
-				copies: self.config.git.diff_copies,
-				ignore_whitespace: self.config.diff_ignore_whitespace == DiffIgnoreWhitespaceSetting::All,
-				ignore_whitespace_change: self.config.diff_ignore_whitespace == DiffIgnoreWhitespaceSetting::Change,
-				interhunk_lines: self.config.git.diff_interhunk_lines,
-				rename_limit: self.config.git.diff_rename_limit,
-				renames: self.config.git.diff_renames,
-			},
-		);
+		let new_commit = Commit::new_from_hash(git_interactive.get_selected_line().get_hash(), LoadCommitDiffOptions {
+			context_lines: self.config.git.diff_context,
+			copies: self.config.git.diff_copies,
+			ignore_whitespace: self.config.diff_ignore_whitespace == DiffIgnoreWhitespaceSetting::All,
+			ignore_whitespace_change: self.config.diff_ignore_whitespace == DiffIgnoreWhitespaceSetting::Change,
+			interhunk_lines: self.config.git.diff_interhunk_lines,
+			rename_limit: self.config.git.diff_rename_limit,
+			renames: self.config.git.diff_renames,
+		});
 
 		match new_commit {
 			Ok(c) => {

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -109,7 +109,7 @@ impl ViewBuilder {
 		for stat in commit.get_file_stats() {
 			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
-				stat.get_to_name().as_str(),
+				stat.get_to_name(),
 				stat.get_from_name().as_str(),
 				is_full_width,
 			)));
@@ -184,7 +184,7 @@ impl ViewBuilder {
 		for stat in commit.get_file_stats() {
 			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
-				stat.get_to_name().as_str(),
+				stat.get_to_name(),
 				stat.get_from_name().as_str(),
 				true,
 			)));

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -110,7 +110,7 @@ impl ViewBuilder {
 			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
 				stat.get_to_name(),
-				stat.get_from_name().as_str(),
+				stat.get_from_name(),
 				is_full_width,
 			)));
 		}
@@ -185,7 +185,7 @@ impl ViewBuilder {
 			view_data.push_line(ViewLine::from(get_stat_item_segments(
 				stat.get_status(),
 				stat.get_to_name(),
-				stat.get_from_name().as_str(),
+				stat.get_from_name(),
 				true,
 			)));
 


### PR DESCRIPTION
# Description

There were several cases where a `&String` was returned from a function instead of `&str`. This replaces all cases of `&String` with `&str`.