### PR TITLE
Import super::* in tests

### DIFF
--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,6 +1,4 @@
-use crate::config::diff_ignore_whitespace_setting::DiffIgnoreWhitespaceSetting;
-use crate::config::diff_show_whitespace_setting::DiffShowWhitespaceSetting;
-use crate::config::Config;
+use super::*;
 use crate::display::color::Color;
 use serial_test::serial;
 use std::env::{remove_var, set_var};

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -53,12 +53,9 @@ impl ConfirmAbort {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::assert_process_result;
 	use crate::assert_rendered_output;
-	use crate::confirm_abort::ConfirmAbort;
-	use crate::input::Input;
-	use crate::process::exit_status::ExitStatus;
-	use crate::process::state::State;
 	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
 	#[test]

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -46,12 +46,9 @@ impl ConfirmRebase {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::assert_process_result;
 	use crate::assert_rendered_output;
-	use crate::confirm_rebase::ConfirmRebase;
-	use crate::input::Input;
-	use crate::process::exit_status::ExitStatus;
-	use crate::process::state::State;
 	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
 	#[test]

--- a/src/display/color.rs
+++ b/src/display/color.rs
@@ -84,8 +84,7 @@ impl TryFrom<&str> for Color {
 
 #[cfg(test)]
 mod tests {
-	use super::Color;
-	use std::convert::TryFrom;
+	use super::*;
 
 	macro_rules! test_color_try_from {
 		($name:ident, $color_string:expr, $expected:expr) => {

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -178,11 +178,9 @@ impl ColorManager {
 
 #[cfg(test)]
 mod tests {
-	use super::ColorManager;
+	use super::*;
 	use crate::build_trace;
-	use crate::display::color::Color;
 	use crate::display::color_mode::ColorMode;
-	use crate::display::curses::Curses;
 	use crate::testutil::compare_trace;
 	use concat_idents::concat_idents;
 

--- a/src/display/color_mode.rs
+++ b/src/display/color_mode.rs
@@ -21,7 +21,7 @@ impl ColorMode {
 
 #[cfg(test)]
 mod tests {
-	use crate::display::color_mode::ColorMode;
+	use super::*;
 
 	#[test]
 	fn color_mode_has_minimum_four_bit_color_two_tone() {

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -292,7 +292,7 @@ impl<'d> Display<'d> {
 
 #[cfg(all(windows, test))]
 mod tests {
-	use super::Display;
+	use super::*;
 	use crate::build_trace;
 	use crate::display_module_test;
 
@@ -309,10 +309,8 @@ mod tests {
 
 #[cfg(all(unix, test))]
 mod tests {
-	use super::display_color::DisplayColor;
-	use super::Display;
+	use super::*;
 	use crate::build_trace;
-	use crate::display::curses::Input;
 	use crate::display_module_test;
 
 	display_module_test!(

--- a/src/display/utils.rs
+++ b/src/display/utils.rs
@@ -56,8 +56,7 @@ pub(super) fn detect_color_mode(number_of_colors: i16) -> ColorMode {
 
 #[cfg(all(windows, test))]
 mod tests {
-	use crate::display::color_mode::ColorMode;
-	use crate::display::utils::detect_color_mode;
+	use super::*;
 
 	#[test]
 	fn detect_color_mode_windows() {
@@ -67,8 +66,7 @@ mod tests {
 
 #[cfg(all(unix, test))]
 mod tests {
-	use crate::display::color_mode::ColorMode;
-	use crate::display::utils::detect_color_mode;
+	use super::*;
 	use serial_test::serial;
 	use std::env::{remove_var, set_var};
 

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -158,11 +158,9 @@ impl Edit {
 }
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::assert_process_result;
 	use crate::assert_rendered_output;
-	use crate::edit::Edit;
-	use crate::input::Input;
-	use crate::process::state::State;
 	use crate::process::testutil::{process_module_test, TestContext, ViewState};
 
 	#[test]

--- a/src/external_editor/argument_tolkenizer.rs
+++ b/src/external_editor/argument_tolkenizer.rs
@@ -116,7 +116,7 @@ pub(super) fn tolkenize(input: &str) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-	use crate::external_editor::argument_tolkenizer::tolkenize;
+	use super::*;
 
 	#[test]
 	fn tolkenize_empty_string() {

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -257,15 +257,10 @@ impl<'e> ExternalEditor<'e> {
 
 #[cfg(all(unix, test))]
 mod tests {
+	use super::*;
 	use crate::assert_process_result;
 	use crate::assert_rendered_output;
-	use crate::external_editor::{ExternalEditor, ExternalEditorState};
-	use crate::input::Input;
-	use crate::process::exit_status::ExitStatus;
-	use crate::process::state::State;
 	use crate::process::testutil::{process_module_test, TestContext, ViewState};
-	use crate::todo_file::line::Line;
-	use anyhow::anyhow;
 	use std::path::Path;
 
 	fn get_external_editor(content: &str, exit_code: &str) -> String {

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -283,12 +283,9 @@ impl<'i> InputHandler<'i> {
 
 #[cfg(test)]
 mod tests {
-	use super::CursesInput;
+	use super::*;
 	use crate::config::Config;
 	use crate::display::curses::Curses;
-	use crate::display::Display;
-	use crate::input::input_handler::{InputHandler, InputMode};
-	use crate::input::Input;
 	use rstest::rstest;
 	use std::env::set_var;
 	use std::path::Path;

--- a/src/show_commit/commit.rs
+++ b/src/show_commit/commit.rs
@@ -221,9 +221,7 @@ impl Commit {
 mod tests {
 	// some of this file is difficult to test because it would require a non-standard git repo, so
 	// we test what is possible
-	use crate::show_commit::commit::{Commit, LoadCommitDiffOptions};
-	use crate::show_commit::status::Status;
-	use anyhow::Result;
+	use super::*;
 	use serial_test::serial;
 	use std::env::set_var;
 	use std::path::Path;

--- a/src/show_commit/file_stat.rs
+++ b/src/show_commit/file_stat.rs
@@ -67,8 +67,7 @@ impl FileStat {
 
 #[cfg(test)]
 mod tests {
-	use crate::show_commit::file_stat::FileStat;
-	use crate::show_commit::status::Status;
+	use super::*;
 
 	#[test]
 	fn commit_user_file_stat() {

--- a/src/show_commit/user.rs
+++ b/src/show_commit/user.rs
@@ -40,7 +40,7 @@ impl User {
 
 #[cfg(test)]
 mod tests {
-	use crate::show_commit::user::User;
+	use super::*;
 
 	#[test]
 	fn commit_user_with_none_name_email() {

--- a/src/todo_file/action.rs
+++ b/src/todo_file/action.rs
@@ -65,8 +65,7 @@ impl TryFrom<&str> for Action {
 
 #[cfg(test)]
 mod tests {
-	use super::Action;
-	use std::convert::TryFrom;
+	use super::*;
 
 	macro_rules! test_action_to_string {
 		($name:ident, $action:expr, $expected:expr) => {

--- a/src/todo_file/line.rs
+++ b/src/todo_file/line.rs
@@ -119,8 +119,7 @@ impl Line {
 
 #[cfg(test)]
 mod tests {
-	use super::Line;
-	use crate::todo_file::action::Action;
+	use super::*;
 	use rstest::rstest;
 
 	#[rstest(

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -147,8 +147,7 @@ impl LineSegment {
 
 #[cfg(test)]
 mod tests {
-	use crate::display::display_color::DisplayColor;
-	use crate::view::line_segment::LineSegment;
+	use super::*;
 
 	#[test]
 	fn line_segment_case_new() {

--- a/src/view/scroll_position.rs
+++ b/src/view/scroll_position.rs
@@ -174,7 +174,7 @@ impl ScrollPosition {
 #[cfg(test)]
 mod tests {
 	// Note: Some of these tests are duplicates logically, but are described differently
-	use crate::view::scroll_position::ScrollPosition;
+	use super::*;
 
 	#[test]
 	fn scroll_position_new() {

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -546,9 +546,7 @@ impl ViewData {
 
 #[cfg(test)]
 mod tests {
-	use crate::view::line_segment::LineSegment;
-	use crate::view::view_data::ViewData;
-	use crate::view::view_line::ViewLine;
+	use super::*;
 
 	fn create_mock_view_line() -> ViewLine {
 		ViewLine::from("Mocked Line")

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -120,9 +120,7 @@ impl<'a> From<Vec<LineSegment>> for ViewLine {
 
 #[cfg(test)]
 mod tests {
-	use crate::display::display_color::DisplayColor;
-	use crate::view::line_segment::LineSegment;
-	use crate::view::view_line::ViewLine;
+	use super::*;
 
 	#[test]
 	fn from_str() {


### PR DESCRIPTION
# Description

Most tests were re-importing items that were already imported in the super module. This updates all the tests to import super::* and removes any imports duplicated by the super::* import.