### PR TITLE
Pin cargo-tarpaulin version to 0.16.0

### DIFF
--- a/scripts/coverage.bash
+++ b/scripts/coverage.bash
@@ -5,5 +5,5 @@ set -u
 set -o pipefail
 
 rustup update nightly
-cargo +nightly install cargo-tarpaulin
-cargo +nightly tarpaulin --exclude-files=src/display/ncurses.rs --all-features --ignore-tests --line --verbose --out Html --out Lcov --output-dir coverage
+cargo +nightly install --version 0.16.0 cargo-tarpaulin
+cargo +nightly tarpaulin --exclude-files=src/display/ncurses.rs --all-features --ignore-tests --line --verbose --out Html --out Lcov --output-dir coverage "$@"


### PR DESCRIPTION
# Description

Version 0.17.0 currently causes a segfault in this project, so pin the version until the issue is resolved.

This should be resolved once the issues in https://github.com/xd009642/tarpaulin/issues/618 are fixed.