### PR TITLE
Remove content from view data

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -56,14 +56,15 @@ impl ProcessModule for Edit {
 			));
 		}
 		self.view_data.clear();
-		self.view_data.set_content(ViewLine::from(segments));
+		self.view_data.push_line(ViewLine::from(segments));
 		self.view_data
-			.push_trailing_line(ViewLine::from(LineSegment::new_with_color(
+			.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new_with_color(
 				"Enter to finish",
 				DisplayColor::IndicatorColor,
-			)));
+			)]));
 		self.view_data.set_view_size(view_width, view_height);
 		self.view_data.rebuild();
+		self.view_data.ensure_column_visible(pointer);
 		&self.view_data
 	}
 

--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -63,7 +63,7 @@ impl ProcessModule for Help {
 impl Help {
 	pub fn new() -> Self {
 		let mut no_help_view_data = ViewData::new();
-		no_help_view_data.set_content(ViewLine::from("Help not available"));
+		no_help_view_data.push_line(ViewLine::from("Help not available"));
 
 		Self {
 			return_state: None,


### PR DESCRIPTION
# Description

Not much to write. Remove the content functionality from ViewData and replace it with a line-based solution instead.