### PR TITLE
ViewData test refactor

### DIFF
--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -10,7 +10,6 @@ use crate::process::process_result::ProcessResult;
 use crate::process::state::State;
 use crate::todo_file::line::Line;
 use crate::todo_file::TodoFile;
-use crate::view::testutil::render_view_data;
 use crate::view::view_data::ViewData;
 use crate::view::View;
 use anyhow::Error;
@@ -364,60 +363,6 @@ fn format_process_result(
 			.as_ref()
 			.map_or("None".to_string(), |error| { format!("{:#}", error) })
 	)
-}
-
-pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
-	let output = render_view_data(view_data);
-	let mut mismatch = false;
-	let mut error_output = vec![
-		"\nUnexpected output!".to_string(),
-		"--- Expected".to_string(),
-		"+++ Actual".to_string(),
-		"==========".to_string(),
-	];
-
-	for (expected_line, output_line) in expected.iter().zip(output.iter()) {
-		let e = expected_line.replace(" ", "·").replace("\t", "   →");
-		if expected_line == output_line {
-			error_output.push(format!(" {}", e));
-		}
-		else {
-			mismatch = true;
-			let o = output_line.replace(" ", "·").replace("\t", "   →");
-			error_output.push(format!("-{}", e));
-			error_output.push(format!("+{}", o));
-		}
-	}
-
-	match expected.len() {
-		a if a > output.len() => {
-			mismatch = true;
-			for line in expected.iter().skip(output.len()) {
-				error_output.push(format!("-{}", line.replace(" ", "·").replace("\t", "   →")));
-			}
-		},
-		a if a < output.len() => {
-			mismatch = true;
-			for line in output.iter().skip(expected.len()) {
-				error_output.push(format!("+{}", line.replace(" ", "·").replace("\t", "   →")));
-			}
-		},
-		_ => {},
-	}
-
-	if mismatch {
-		error_output.push(String::from("==========\n"));
-		panic!(error_output.join("\n"));
-	}
-}
-
-#[macro_export]
-macro_rules! assert_rendered_output {
-	($view_data:expr, $($arg:expr),*) => {
-		let mut expected = vec![];
-		$( expected.push(String::from($arg)); )*
-		crate::process::testutil::_assert_rendered_output(&$view_data, &expected);
-	};
 }
 
 pub fn _assert_process_result(

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -77,7 +77,7 @@ fn render_view_line(view_line: &ViewLine) -> String {
 	line
 }
 
-pub fn render_view_data(view_data: &ViewData) -> Vec<String> {
+fn render_view_data(view_data: &ViewData) -> Vec<String> {
 	let mut lines = vec![];
 	if view_data.show_title() {
 		if view_data.show_help() {
@@ -86,6 +86,10 @@ pub fn render_view_data(view_data: &ViewData) -> Vec<String> {
 		else {
 			lines.push("{TITLE}".to_string());
 		}
+	}
+
+	if view_data.is_empty() {
+		lines.push("{EMPTY}".to_string());
 	}
 
 	if let Some(ref prompt) = *view_data.get_prompt() {
@@ -118,4 +122,62 @@ pub fn render_view_data(view_data: &ViewData) -> Vec<String> {
 		}
 	}
 	lines
+}
+
+pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
+	let output = render_view_data(view_data);
+	let mut mismatch = false;
+	let mut error_output = vec![
+		"\nUnexpected output!".to_string(),
+		"--- Expected".to_string(),
+		"+++ Actual".to_string(),
+		"==========".to_string(),
+	];
+
+	for (expected_line, output_line) in expected.iter().zip(output.iter()) {
+		let e = expected_line.replace(" ", "·").replace("\t", "   →");
+		if expected_line == output_line {
+			error_output.push(format!(" {}", e));
+		}
+		else {
+			mismatch = true;
+			let o = output_line.replace(" ", "·").replace("\t", "   →");
+			error_output.push(format!("-{}", e));
+			error_output.push(format!("+{}", o));
+		}
+	}
+
+	match expected.len() {
+		a if a > output.len() => {
+			mismatch = true;
+			for line in expected.iter().skip(output.len()) {
+				error_output.push(format!("-{}", line.replace(" ", "·").replace("\t", "   →")));
+			}
+		},
+		a if a < output.len() => {
+			mismatch = true;
+			for line in output.iter().skip(expected.len()) {
+				error_output.push(format!("+{}", line.replace(" ", "·").replace("\t", "   →")));
+			}
+		},
+		_ => {},
+	}
+
+	if mismatch {
+		error_output.push(String::from("==========\n"));
+		panic!(error_output.join("\n"));
+	}
+}
+
+#[macro_export]
+macro_rules! assert_rendered_output {
+	($view_data:expr) => {
+		let expected: Vec<String> = vec![];
+		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
+	};
+	($view_data:expr, $($arg:expr),*) => {
+		let mut expected = vec![];
+		$( expected.push(String::from($arg)); )*
+		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
+	};
 }


### PR DESCRIPTION
# Description

Update the tests for ViewData to use the `assert_rendered_output` macro and add any additional tests that are missing.