### PR TITLE
Remove String parameter in functions

### DIFF
--- a/src/show_commit/commit.rs
+++ b/src/show_commit/commit.rs
@@ -114,7 +114,11 @@ fn load_commit_state(hash: &str, config: LoadCommitDiffOptions) -> Result<Commit
 					.path()
 					.map_or_else(|| String::from("unknown"), |p| String::from(p.to_str().unwrap()));
 
-				fsb.add_file_stat(from_file_path, to_file_path, Status::from(diff_delta.status()));
+				fsb.add_file_stat(
+					from_file_path.as_str(),
+					to_file_path.as_str(),
+					Status::from(diff_delta.status()),
+				);
 
 				true
 			},

--- a/src/show_commit/file_stat.rs
+++ b/src/show_commit/file_stat.rs
@@ -14,11 +14,11 @@ pub struct FileStat {
 
 impl FileStat {
 	/// Create a new `FileStat`
-	pub(super) const fn new(from_name: String, to_name: String, status: Status) -> Self {
+	pub(super) fn new(from_name: &str, to_name: &str, status: Status) -> Self {
 		Self {
 			status,
-			to_name,
-			from_name,
+			to_name: String::from(to_name),
+			from_name: String::from(from_name),
 			largest_old_line_number: 0,
 			largest_new_line_number: 0,
 			deltas: vec![],
@@ -71,7 +71,7 @@ mod tests {
 
 	#[test]
 	fn no_deltas() {
-		let file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		let file_stat = FileStat::new("/from/path", "/to/path", Status::Renamed);
 		assert_eq!(*file_stat.get_status(), Status::Renamed);
 		assert_eq!(file_stat.get_from_name(), "/from/path");
 		assert_eq!(file_stat.get_to_name(), "/to/path");
@@ -82,7 +82,7 @@ mod tests {
 
 	#[test]
 	fn add_delta() {
-		let mut file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		let mut file_stat = FileStat::new("/from/path", "/to/path", Status::Renamed);
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 12, 3, 4));
 		assert_eq!(file_stat.largest_old_line_number(), 13);
 		assert_eq!(file_stat.largest_new_line_number(), 16);
@@ -91,7 +91,7 @@ mod tests {
 
 	#[test]
 	fn add_delta_with_larger_old_line_number() {
-		let mut file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		let mut file_stat = FileStat::new("/from/path", "/to/path", Status::Renamed);
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 12, 3, 4));
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 14, 12, 3, 4));
 		assert_eq!(file_stat.largest_old_line_number(), 17);
@@ -101,7 +101,7 @@ mod tests {
 
 	#[test]
 	fn add_delta_with_larger_new_line_number() {
-		let mut file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		let mut file_stat = FileStat::new("/from/path", "/to/path", Status::Renamed);
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 12, 3, 4));
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 17, 3, 4));
 		assert_eq!(file_stat.largest_old_line_number(), 13);
@@ -111,7 +111,7 @@ mod tests {
 
 	#[test]
 	fn add_delta_with_larger_new_and_old_line_number() {
-		let mut file_stat = FileStat::new("/from/path".to_string(), "/to/path".to_string(), Status::Renamed);
+		let mut file_stat = FileStat::new("/from/path", "/to/path", Status::Renamed);
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 12, 3, 4));
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 14, 12, 3, 4));
 		file_stat.add_delta(Delta::new("@ src/show_commit/delta.rs:56 @ impl Delta {", 10, 17, 3, 4));

--- a/src/show_commit/file_stats_builder.rs
+++ b/src/show_commit/file_stats_builder.rs
@@ -34,7 +34,7 @@ impl FileStatsBuilder {
 		}
 	}
 
-	pub(crate) fn add_file_stat(&mut self, from_name: String, to_name: String, status: Status) {
+	pub(crate) fn add_file_stat(&mut self, from_name: &str, to_name: &str, status: Status) {
 		self.close_delta();
 		self.close_file_stat();
 		self.delta = None;

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -23,8 +23,11 @@ pub struct SegmentPartial {
 }
 
 impl SegmentPartial {
-	const fn new(content: String, length: usize) -> Self {
-		Self { content, length }
+	fn new(content: &str, length: usize) -> Self {
+		Self {
+			content: String::from(content),
+			length,
+		}
 	}
 
 	pub(super) fn get_content(&self) -> &str {
@@ -102,7 +105,7 @@ impl LineSegment {
 
 		// segment is hidden to the left of the line/scroll
 		if segment_length <= left {
-			SegmentPartial::new(String::from(""), 0)
+			SegmentPartial::new("", 0)
 		}
 		else {
 			let graphemes = UnicodeSegmentation::graphemes(self.text.as_str(), true);
@@ -135,11 +138,11 @@ impl LineSegment {
 						}
 					})
 					.collect::<String>();
-				SegmentPartial::new(partial_line, take_length.into_inner())
+				SegmentPartial::new(partial_line.as_str(), take_length.into_inner())
 			}
 			else {
 				let partial_line = graphemes.collect::<String>();
-				SegmentPartial::new(partial_line, segment_length - skip_length.into_inner())
+				SegmentPartial::new(partial_line.as_str(), segment_length - skip_length.into_inner())
 			}
 		}
 	}


### PR DESCRIPTION
# Description

There were a handful of functions that were taking `String` as a parameter that should be a `&str` instead.