### PR TITLE
Use latest nightly for rustfmt

### DIFF
--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -4,8 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-rust_version="nightly-2019-09-13"
+rustup update nightly
+rustup component add rustfmt --toolchain nightly
+cargo +nightly fmt --all -- --check
 
-rustup update "$rust_version"
-rustup component add rustfmt --toolchain "$rust_version"
-cargo +"$rust_version" fmt --all -- --check


### PR DESCRIPTION
# Description

The nightly version of Rust had to be pinned a while back due to a compatibility issue between Rust nightly and rustfmt. Undo this pin now that this issue is resolved.