### PR TITLE
Use TestContext functions in tests

### DIFF
--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -139,7 +139,7 @@ mod tests {
 			&[Input::Character('a')],
 			|mut test_context: TestContext<'_>| {
 				let mut module = Error::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				module.set_error_message(&anyhow!("Test Error"));
 				assert_process_result!(
 					test_context.handle_input(&mut module),
@@ -159,7 +159,7 @@ mod tests {
 			&[Input::Resize],
 			|mut test_context: TestContext<'_>| {
 				let mut module = Error::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				module.set_error_message(&anyhow!("Test Error"));
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::Resize)
 			},
@@ -182,7 +182,7 @@ mod tests {
 			],
 			|mut test_context: TestContext<'_>| {
 				let mut module = Error::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				module.set_error_message(&anyhow!("Test Error"));
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::ScrollLeft);
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::ScrollRight);

--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -217,7 +217,7 @@ mod tests {
 			&[Input::Character('a')],
 			|mut test_context: TestContext<'_>| {
 				let mut module = Help::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				assert_process_result!(
 					test_context.handle_input(&mut module),
 					input = Input::Character('a'),

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -167,7 +167,7 @@ mod tests {
 			&[Input::Resize],
 			|mut test_context: TestContext<'_>| {
 				let mut module = WindowSizeError::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::Resize);
 			},
 		);
@@ -185,7 +185,7 @@ mod tests {
 			&[Input::Resize],
 			|mut test_context: TestContext<'_>| {
 				let mut module = WindowSizeError::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				assert_process_result!(
 					test_context.handle_input(&mut module),
 					input = Input::Resize,
@@ -207,7 +207,7 @@ mod tests {
 			&[Input::Character('a')],
 			|mut test_context: TestContext<'_>| {
 				let mut module = WindowSizeError::new();
-				module.activate(test_context.rebase_todo_file, State::ConfirmRebase);
+				test_context.activate(&mut module, State::ConfirmRebase);
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::Character('a'));
 			},
 		);


### PR DESCRIPTION
# Description

A few cases of process module tests where directly calling functions that should be using the TestContext wrappers.