### PR TITLE
Move TodoFile instance into TestContext

### DIFF
--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -318,7 +318,7 @@ mod tests {
 			&["pick aaa comment1", "drop bbb comment2"],
 			ViewState::default(),
 			&[Input::Up],
-			|mut test_context: TestContext<'_>| {
+			|test_context: TestContext<'_>| {
 				let mut module = ExternalEditor::new(
 					test_context.display,
 					get_external_editor("pick aaa comment", "0").as_str(),
@@ -340,7 +340,7 @@ mod tests {
 			&["pick aaa comment"],
 			ViewState::default(),
 			&[Input::Up],
-			|mut test_context: TestContext<'_>| {
+			|test_context: TestContext<'_>| {
 				let todo_path = test_context.get_todo_file_path();
 				let mut module = ExternalEditor::new(
 					test_context.display,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -2580,7 +2580,7 @@ mod tests {
 			&["break"],
 			ViewState::default(),
 			&[],
-			|test_context: TestContext<'_>| {
+			|mut test_context: TestContext<'_>| {
 				let mut module = List::new(test_context.config);
 				test_context
 					.rebase_todo_file

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -137,18 +137,18 @@ mod tests {
 			&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment"],
 			ViewState::default(),
 			&[Input::Resize],
-			|test_context: TestContext<'_>| {
+			|mut test_context: TestContext<'_>| {
 				let mut config = test_context.config.clone();
 				config.git.editor = String::from("true");
 				let mut modules = Modules::new(test_context.display, &config);
-				modules.activate(state, test_context.rebase_todo_file, State::List);
+				modules.activate(state, &test_context.rebase_todo_file, State::List);
 				modules.handle_input(
 					state,
 					test_context.input_handler,
-					test_context.rebase_todo_file,
+					&mut test_context.rebase_todo_file,
 					test_context.view,
 				);
-				modules.build_view_data(state, test_context.view, test_context.rebase_todo_file);
+				modules.build_view_data(state, test_context.view, &test_context.rebase_todo_file);
 				modules.deactivate(state);
 				modules.update_help_data(state);
 			},

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -20,7 +20,7 @@ use tempfile::{Builder, NamedTempFile};
 
 pub struct TestContext<'t> {
 	pub config: &'t Config,
-	pub rebase_todo_file: &'t mut TodoFile,
+	pub rebase_todo_file: TodoFile,
 	todo_file: Cell<NamedTempFile>,
 	pub input_handler: &'t InputHandler<'t>,
 	pub view: &'t View<'t>,
@@ -29,8 +29,8 @@ pub struct TestContext<'t> {
 }
 
 impl<'t> TestContext<'t> {
-	pub fn activate(&mut self, module: &'_ mut dyn ProcessModule, state: State) -> ProcessResult {
-		module.activate(self.rebase_todo_file, state)
+	pub fn activate(&self, module: &'_ mut dyn ProcessModule, state: State) -> ProcessResult {
+		module.activate(&self.rebase_todo_file, state)
 	}
 
 	#[allow(clippy::unused_self)]
@@ -39,17 +39,17 @@ impl<'t> TestContext<'t> {
 	}
 
 	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc ViewData {
-		module.build_view_data(self.view, self.rebase_todo_file)
+		module.build_view_data(self.view, &self.rebase_todo_file)
 	}
 
 	pub fn handle_input(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
-		module.handle_input(self.input_handler, self.rebase_todo_file, self.view)
+		module.handle_input(self.input_handler, &mut self.rebase_todo_file, self.view)
 	}
 
 	pub fn handle_n_inputs(&mut self, module: &'_ mut dyn ProcessModule, n: usize) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..n {
-			results.push(module.handle_input(self.input_handler, self.rebase_todo_file, self.view));
+			results.push(module.handle_input(self.input_handler, &mut self.rebase_todo_file, self.view));
 		}
 		results
 	}
@@ -57,7 +57,7 @@ impl<'t> TestContext<'t> {
 	pub fn handle_all_inputs(&mut self, module: &'_ mut dyn ProcessModule) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..self.num_inputs {
-			results.push(module.handle_input(self.input_handler, self.rebase_todo_file, self.view));
+			results.push(module.handle_input(self.input_handler, &mut self.rebase_todo_file, self.view));
 		}
 		results
 	}
@@ -448,7 +448,7 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 	let input_handler = InputHandler::new(&display, &config.key_bindings);
 	callback(TestContext {
 		config: &config,
-		rebase_todo_file: &mut rebsae_todo_file,
+		rebase_todo_file: rebsae_todo_file,
 		todo_file: Cell::new(todo_file),
 		view: &view,
 		input_handler: &input_handler,


### PR DESCRIPTION
# Description

The reference to the TodoFile instance in TestContext, limits the usability of the TodoFile instance in tests. Since the instance isn't used after the test callback, the value can be moved into the TestContext.
