### PR TITLE
Add support for Exit key and abort

### DIFF
--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -34,6 +34,7 @@ impl<'i> InputHandler<'i> {
 			CursesInput::KeyDown => String::from("Down"),
 			CursesInput::KeyEnd => String::from("End"),
 			CursesInput::KeyEnter => String::from("Enter"),
+			CursesInput::KeyExit => String::from("Exit"),
 			CursesInput::KeyF0 => String::from("F0"),
 			CursesInput::KeyF1 => String::from("F1"),
 			CursesInput::KeyF2 => String::from("F2"),
@@ -98,7 +99,6 @@ impl<'i> InputHandler<'i> {
 			| CursesInput::KeyCommand
 			| CursesInput::KeyCopy
 			| CursesInput::KeyCreate
-			| CursesInput::KeyExit
 			| CursesInput::KeyFind
 			| CursesInput::KeyHelp
 			| CursesInput::KeyMark
@@ -160,6 +160,7 @@ impl<'i> InputHandler<'i> {
 			"PageDown" => Input::ScrollJumpDown,
 			"Home" => Input::ScrollTop,
 			"End" => Input::ScrollBottom,
+			"Exit" => Input::Exit,
 			"Resize" => Input::Resize,
 			_ => return None,
 		})
@@ -205,6 +206,7 @@ impl<'i> InputHandler<'i> {
 			i if i == self.key_bindings.move_down_step.as_str() => Input::MoveCursorPageDown,
 			i if i == self.key_bindings.move_selection_down.as_str() => Input::SwapSelectedDown,
 			i if i == self.key_bindings.move_selection_up.as_str() => Input::SwapSelectedUp,
+			"Exit" => Input::Exit,
 			"Resize" => Input::Resize,
 			_ => Input::Other,
 		}
@@ -220,6 +222,7 @@ impl<'i> InputHandler<'i> {
 			c if c == "Down" => Input::Down,
 			c if c == "End" => Input::End,
 			c if c == "Enter" => Input::Enter,
+			c if c == "Exit" => Input::Exit,
 			c if c == "F0" => Input::F0,
 			c if c == "F1" => Input::F1,
 			c if c == "F2" => Input::F2,
@@ -325,7 +328,8 @@ mod tests {
 		case::standard_move_left(CursesInput::KeyLeft, Input::ScrollLeft),
 		case::standard_move_right(CursesInput::KeyRight, Input::ScrollRight),
 		case::standard_move_jump_up(CursesInput::KeyPPage, Input::ScrollJumpUp),
-		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown)
+		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown),
+		case::exit(CursesInput::KeyExit, Input::Exit)
 	)]
 	#[serial_test::serial]
 	fn confirm_mode(input: CursesInput, expected: Input) {
@@ -350,7 +354,8 @@ mod tests {
 		case::standard_move_left(CursesInput::KeyLeft, Input::ScrollLeft),
 		case::standard_move_right(CursesInput::KeyRight, Input::ScrollRight),
 		case::standard_move_jump_up(CursesInput::KeyPPage, Input::ScrollJumpUp),
-		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown)
+		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown),
+		case::exit(CursesInput::KeyExit, Input::Exit)
 	)]
 	#[serial_test::serial]
 	fn default_mode(input: CursesInput, expected: Input) {
@@ -387,7 +392,8 @@ mod tests {
 		case::swap_selected_down(CursesInput::Character('j'), Input::SwapSelectedDown),
 		case::swap_selected_up(CursesInput::Character('k'), Input::SwapSelectedUp),
 		case::resize(CursesInput::KeyResize, Input::Resize),
-		case::other(CursesInput::Character('z'), Input::Other)
+		case::other(CursesInput::Character('z'), Input::Other),
+		case::exit(CursesInput::KeyExit, Input::Exit)
 	)]
 	#[serial_test::serial]
 	fn list_mode(input: CursesInput, expected: Input) {
@@ -448,7 +454,8 @@ mod tests {
 		case::a3_key(CursesInput::KeyA3, Input::KeypadUpperRight),
 		case::b2_key(CursesInput::KeyB2, Input::KeypadCenter),
 		case::c1_key(CursesInput::KeyC1, Input::KeypadLowerLeft),
-		case::c3_key(CursesInput::KeyC3, Input::KeypadLowerRight)
+		case::c3_key(CursesInput::KeyC3, Input::KeypadLowerRight),
+		case::exit(CursesInput::KeyExit, Input::Exit)
 	)]
 	#[serial_test::serial]
 	fn raw_mode(input: CursesInput, expected: Input) {
@@ -483,7 +490,6 @@ mod tests {
 			CursesInput::KeyCommand,
 			CursesInput::KeyCopy,
 			CursesInput::KeyCreate,
-			CursesInput::KeyExit,
 			CursesInput::KeyFind,
 			CursesInput::KeyHelp,
 			CursesInput::KeyMark,
@@ -545,7 +551,8 @@ mod tests {
 		case::standard_move_left(CursesInput::KeyLeft, Input::ScrollLeft),
 		case::standard_move_right(CursesInput::KeyRight, Input::ScrollRight),
 		case::standard_move_jump_up(CursesInput::KeyPPage, Input::ScrollJumpUp),
-		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown)
+		case::standard_move_jump_down(CursesInput::KeyNPage, Input::ScrollJumpDown),
+		case::exit(CursesInput::KeyExit, Input::Exit)
 	)]
 	#[serial_test::serial]
 	fn confirm_input_mode(input: CursesInput, expected: Input) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -47,6 +47,7 @@ pub enum Input {
 	Down,
 	End,
 	Enter,
+	Exit,
 	F0,
 	F1,
 	F2,

--- a/src/process/exit_status.rs
+++ b/src/process/exit_status.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExitStatus {
+	Abort,
 	ConfigError,
 	FileReadError,
 	FileWriteError,
@@ -10,6 +11,7 @@ pub enum ExitStatus {
 impl ExitStatus {
 	pub const fn to_code(self) -> i32 {
 		match self {
+			Self::Abort => 5,
 			Self::ConfigError => 1,
 			Self::FileReadError => 2,
 			Self::FileWriteError => 3,
@@ -27,6 +29,7 @@ mod tests {
 	#[rstest(
 		input,
 		expected,
+		case::abort(ExitStatus::Abort, 5),
 		case::config_error(ExitStatus::ConfigError, 1),
 		case::file_read_error(ExitStatus::FileReadError, 2),
 		case::file_write_error(ExitStatus::FileWriteError, 3),

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -5,10 +5,13 @@ pub mod modules;
 pub mod process_module;
 pub mod process_result;
 pub mod state;
-#[cfg(test)]
-pub mod testutil;
 pub mod util;
 pub mod window_size_error;
+
+#[cfg(test)]
+mod tests;
+#[cfg(test)]
+pub mod testutil;
 
 use crate::input::input_handler::InputHandler;
 use crate::input::Input;
@@ -52,7 +55,7 @@ impl<'r> Process<'r> {
 			let result = modules.handle_input(self.state, self.input_handler, &mut self.rebase_todo, self.view);
 			self.handle_process_result(&mut modules, &result);
 		}
-		self.exit_end()?;
+		self.rebase_todo.write_file()?;
 		Ok(self.exit_status)
 	}
 
@@ -104,13 +107,5 @@ impl<'r> Process<'r> {
 	fn activate(&mut self, modules: &mut Modules<'_>, previous_state: State) {
 		let result = modules.activate(self.state, &self.rebase_todo, previous_state);
 		self.handle_process_result(modules, &result);
-	}
-
-	fn exit_end(&mut self) -> Result<()> {
-		let result = self.rebase_todo.write_file();
-		if result.is_err() {
-			self.exit_status = Some(ExitStatus::FileWriteError);
-		}
-		result
 	}
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -77,6 +77,9 @@ impl<'r> Process<'r> {
 		}
 
 		match result.input {
+			Some(Input::Exit) => {
+				self.exit_status = Some(ExitStatus::Abort);
+			},
 			Some(Input::Resize) => {
 				let (view_width, view_height) = self.view.get_view_size();
 				if self.state != State::WindowSizeError && WindowSizeError::is_window_too_small(view_width, view_height)

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -1,0 +1,220 @@
+use super::*;
+// use crate::assert_process_result;
+// use crate::assert_rendered_output;
+use crate::process::testutil::{process_module_test, TestContext, ViewState};
+use crate::todo_file::line::Line;
+use anyhow::anyhow;
+
+#[test]
+#[serial_test::serial]
+fn window_too_small() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState {
+			size: (1, 1),
+			..ViewState::default()
+		},
+		&[Input::Exit],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let modules = Modules::new(test_context.display, test_context.config);
+			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Abort);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn force_abort() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[Input::ForceAbort],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let modules = Modules::new(test_context.display, test_context.config);
+			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Good);
+			process.rebase_todo.load_file().unwrap();
+			assert_eq!(process.rebase_todo.get_lines(), &vec![]);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn force_rebase() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[Input::ForceRebase],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let modules = Modules::new(test_context.display, test_context.config);
+			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Good);
+			process.rebase_todo.load_file().unwrap();
+			assert_eq!(process.rebase_todo.get_lines(), &vec![
+				Line::new("pick aaa comment").unwrap()
+			]);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn error_write_todo() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[Input::ForceRebase],
+		|test_context: TestContext<'_>| {
+			let todo_path = test_context.get_todo_file_path();
+			test_context.set_todo_file_readonly();
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let modules = Modules::new(test_context.display, test_context.config);
+			assert_eq!(
+				process.run(modules).unwrap_err().to_string(),
+				format!("Error opening file: {}", todo_path)
+			);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn resize_window_size_okay() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[Input::Resize, Input::Exit],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let modules = Modules::new(test_context.display, test_context.config);
+			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Abort);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn resize_window_size_too_small() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState {
+			size: (1, 1),
+			..ViewState::default()
+		},
+		&[],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let mut modules = Modules::new(test_context.display, test_context.config);
+			process.state = State::List;
+			let result = ProcessResult::new().input(Input::Resize);
+			process.handle_process_result(&mut modules, &result);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn error() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let mut modules = Modules::new(test_context.display, test_context.config);
+			let result = ProcessResult::new().error(anyhow!("Test error"));
+			process.handle_process_result(&mut modules, &result);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn help_start() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let mut modules = Modules::new(test_context.display, test_context.config);
+			let result = ProcessResult::new().input(Input::Help);
+			process.handle_process_result(&mut modules, &result);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn help_exit() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let mut modules = Modules::new(test_context.display, test_context.config);
+			process.state = State::Help;
+			let result = ProcessResult::new().input(Input::Help);
+			process.handle_process_result(&mut modules, &result);
+		},
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn other_input() {
+	process_module_test(
+		&["pick aaa comment"],
+		ViewState::default(),
+		&[],
+		|test_context: TestContext<'_>| {
+			let mut process = Process::new(
+				test_context.rebase_todo_file,
+				test_context.view,
+				test_context.input_handler,
+			);
+			let mut modules = Modules::new(test_context.display, test_context.config);
+			let result = ProcessResult::new().input(Input::Character('a'));
+			process.handle_process_result(&mut modules, &result);
+		},
+	);
+}

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -431,7 +431,8 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 		.to_string();
 
 	set_var("GIT_DIR", git_repo_dir.as_str());
-	let config = Config::new().unwrap();
+	let mut config = Config::new().unwrap();
+	config.git.editor = String::from("true");
 	let mut curses = Curses::new();
 	curses.mv(view_state.position.1, view_state.position.0);
 	curses.resize_term(view_state.size.1, view_state.size.0);
@@ -446,13 +447,13 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 		.tempfile_in(git_repo_dir.as_str())
 		.unwrap();
 
-	let mut rebsae_todo_file = TodoFile::new(todo_file.path().to_str().unwrap(), "#");
-	rebsae_todo_file.set_lines(lines.iter().map(|l| Line::new(l).unwrap()).collect());
+	let mut rebase_todo_file = TodoFile::new(todo_file.path().to_str().unwrap(), "#");
+	rebase_todo_file.set_lines(lines.iter().map(|l| Line::new(l).unwrap()).collect());
 
 	let input_handler = InputHandler::new(&display, &config.key_bindings);
 	callback(TestContext {
 		config: &config,
-		rebase_todo_file: rebsae_todo_file,
+		rebase_todo_file,
 		todo_file: Cell::new(todo_file),
 		view: &view,
 		input_handler: &input_handler,

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -108,6 +108,7 @@ fn map_input_str_to_curses(input: &str) -> PancursesInput {
 		"Down" => PancursesInput::KeyDown,
 		"End" => PancursesInput::KeyEnd,
 		"Enter" => PancursesInput::KeyEnter,
+		"Exit" => PancursesInput::KeyExit,
 		"F0" => PancursesInput::KeyF0,
 		"F1" => PancursesInput::KeyF1,
 		"F2" => PancursesInput::KeyF2,
@@ -168,6 +169,7 @@ fn map_input_to_curses(key_bindings: &KeyBindings, input: Input) -> PancursesInp
 		Input::Edit => map_input_str_to_curses(key_bindings.edit.as_str()),
 		Input::End | Input::ScrollBottom => map_input_str_to_curses("End"),
 		Input::Enter => map_input_str_to_curses("Enter"),
+		Input::Exit => map_input_str_to_curses("Exit"),
 		Input::F0 => map_input_str_to_curses("F0"),
 		Input::F1 => map_input_str_to_curses("F1"),
 		Input::F2 => map_input_str_to_curses("F2"),
@@ -243,6 +245,7 @@ fn format_process_result(
 		"ExitStatus({}), State({}), Input({}), Error({})",
 		exit_status.map_or("None", |exit_status| {
 			match exit_status {
+				ExitStatus::Abort => "Abort",
 				ExitStatus::ConfigError => "ConfigError",
 				ExitStatus::FileReadError => "FileReadError",
 				ExitStatus::FileWriteError => "FileWriteError",
@@ -280,6 +283,7 @@ fn format_process_result(
 				Input::Edit => "Edit".to_string(),
 				Input::End => "End".to_string(),
 				Input::Enter => "Enter".to_string(),
+				Input::Exit => "Exit".to_string(),
 				Input::F0 => "F0".to_string(),
 				Input::F1 => "F1".to_string(),
 				Input::F2 => "F2".to_string(),


### PR DESCRIPTION
# Description

Add tests for the process module. To support the tests, support for the Exit key has been added and allow it to trigger an application abort.