### PR TITLE
Do not write noop on rebase abort

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -25,8 +25,7 @@ impl ProcessModule for ConfirmAbort {
 		input_handler: &InputHandler<'_>,
 		rebase_todo: &mut TodoFile,
 		_view: &View<'_>,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let input = input_handler.get_input(InputMode::Confirm);
 		let mut result = ProcessResult::new().input(input);
 		match input {

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -30,7 +30,7 @@ impl ProcessModule for ConfirmAbort {
 		let mut result = ProcessResult::new().input(input);
 		match input {
 			Input::Yes => {
-				rebase_todo.set_noop();
+				rebase_todo.set_lines(vec![]);
 				result = result.exit_status(ExitStatus::Good);
 			},
 			Input::No => {

--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -34,8 +34,7 @@ impl ColorManager {
 		foreground: Color,
 		background: Color,
 		selected_background: Color,
-	) -> (chtype, chtype)
-	{
+	) -> (chtype, chtype) {
 		let fg = self.find_color(curses, foreground);
 		let bg = self.find_color(curses, background);
 		let standard_pair = curses.init_color_pair(self.color_pair_index, fg, bg);

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -74,8 +74,7 @@ impl ProcessModule for Edit {
 		input_handler: &InputHandler<'_>,
 		todo_file: &mut TodoFile,
 		view: &View<'_>,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let result = loop {
 			let input = input_handler.get_input(InputMode::Raw);
 			let result = ProcessResult::new().input(input);

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -114,8 +114,7 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 		input_handler: &InputHandler<'_>,
 		todo_file: &mut TodoFile,
 		view: &View<'_>,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let mut result = ProcessResult::new();
 		match self.state {
 			ExternalEditorState::Active => {

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -159,7 +159,7 @@ impl<'e> ProcessModule for ExternalEditor<'e> {
 					self.invalid_selection = false;
 					match input {
 						Input::Character('1') => {
-							todo_file.set_noop();
+							todo_file.set_lines(vec![]);
 							result = result.exit_status(ExitStatus::Good)
 						},
 						Input::Character('2') => self.state = ExternalEditorState::Active,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -71,8 +71,7 @@ impl<'l> ProcessModule for List<'l> {
 		input_handler: &InputHandler<'_>,
 		todo_file: &mut TodoFile,
 		view: &View<'_>,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let (_, view_height) = view.get_view_size();
 		let input = input_handler.get_input(InputMode::List);
 		let mut result = ProcessResult::new().input(input);
@@ -206,8 +205,7 @@ impl<'l> List<'l> {
 		input: Input,
 		result: ProcessResult,
 		rebase_todo: &mut TodoFile,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let mut result = result;
 		match input {
 			Input::ShowCommit => {
@@ -269,8 +267,7 @@ impl<'l> List<'l> {
 		input: Input,
 		result: ProcessResult,
 		rebase_todo: &mut TodoFile,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		let mut result = result;
 		match input {
 			Input::Abort => {

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -217,7 +217,7 @@ impl<'l> List<'l> {
 				result = result.state(State::ConfirmAbort);
 			},
 			Input::ForceAbort => {
-				rebase_todo.set_noop();
+				rebase_todo.set_lines(vec![]);
 				result = result.exit_status(ExitStatus::Good);
 			},
 			Input::Rebase => {
@@ -274,7 +274,7 @@ impl<'l> List<'l> {
 				result = result.state(State::ConfirmAbort);
 			},
 			Input::ForceAbort => {
-				rebase_todo.set_noop();
+				rebase_todo.set_lines(vec![]);
 				result = result.exit_status(ExitStatus::Good);
 			},
 			Input::Rebase => {
@@ -1596,7 +1596,7 @@ mod tests {
 					input = Input::ForceAbort,
 					exit_status = ExitStatus::Good
 				);
-				assert!(test_context.rebase_todo_file.is_noop())
+				assert_eq!(test_context.rebase_todo_file.get_lines().len(), 0)
 			},
 		);
 	}
@@ -2061,7 +2061,7 @@ mod tests {
 					input = Input::ForceAbort,
 					exit_status = ExitStatus::Good
 				);
-				assert!(test_context.rebase_todo_file.is_noop())
+				assert_eq!(test_context.rebase_todo_file.get_lines().len(), 0)
 			},
 		);
 	}

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -153,8 +153,7 @@ pub(super) fn get_todo_line_segments(
 	is_cursor_line: bool,
 	selected: bool,
 	view_width: usize,
-) -> Vec<LineSegment>
-{
+) -> Vec<LineSegment> {
 	let mut segments: Vec<LineSegment> = vec![];
 
 	let action = line.get_action();

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -90,8 +90,7 @@ impl<'m> Modules<'m> {
 		input_handler: &InputHandler<'_>,
 		rebase_todo: &mut TodoFile,
 		view: &View<'_>,
-	) -> ProcessResult
-	{
+	) -> ProcessResult {
 		self.get_mut_module(state)
 			.handle_input(input_handler, rebase_todo, view)
 	}

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -239,8 +239,7 @@ fn format_process_result(
 	state: Option<State>,
 	exit_status: Option<ExitStatus>,
 	error: &Option<Error>,
-) -> String
-{
+) -> String {
 	format!(
 		"ExitStatus({}), State({}), Input({}), Error({})",
 		exit_status.map_or("None", |exit_status| {
@@ -367,8 +366,7 @@ pub fn _assert_process_result(
 	state: Option<State>,
 	exit_status: Option<ExitStatus>,
 	error: &Option<Error>,
-)
-{
+) {
 	if !(exit_status.map_or(actual.exit_status.is_none(), |expected| {
 		actual.exit_status.map_or(false, |actual| expected == actual)
 	}) && state.map_or(actual.state.is_none(), |expected| {

--- a/src/show_commit/diff_line.rs
+++ b/src/show_commit/diff_line.rs
@@ -17,8 +17,7 @@ impl DiffLine {
 		old_line_number: Option<u32>,
 		new_line_number: Option<u32>,
 		end_of_file: bool,
-	) -> Self
-	{
+	) -> Self {
 		Self {
 			end_of_file,
 			// remove the end of file marker from diff

--- a/src/show_commit/util.rs
+++ b/src/show_commit/util.rs
@@ -28,8 +28,7 @@ pub(super) fn get_stat_item_segments(
 	to_name: &str,
 	from_name: &str,
 	is_full_width: bool,
-) -> Vec<LineSegment>
-{
+) -> Vec<LineSegment> {
 	let status_name = if is_full_width {
 		match *status {
 			Status::Added => format!("{:>8}: ", "added"),

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -26,8 +26,7 @@ impl ViewBuilderOptions {
 		space_character: &str,
 		show_leading_whitespace: bool,
 		show_trailing_whitespace: bool,
-	) -> Self
-	{
+	) -> Self {
 		Self {
 			space_character: String::from(space_character),
 			tab_character: String::from(tab_character),
@@ -122,8 +121,7 @@ impl ViewBuilder {
 		diff_line: &DiffLine,
 		old_largest_line_number_length: usize,
 		new_largest_line_number_length: usize,
-	) -> Vec<LineSegment>
-	{
+	) -> Vec<LineSegment> {
 		let mut line_segments = vec![];
 		line_segments.push(match diff_line.old_line_number() {
 			Some(line_number) => {

--- a/src/todo_file/mod.rs
+++ b/src/todo_file/mod.rs
@@ -70,11 +70,6 @@ impl TodoFile {
 		Ok(())
 	}
 
-	pub(crate) fn set_noop(&mut self) {
-		self.is_noop = true;
-		self.lines.clear();
-	}
-
 	pub(crate) fn set_selected_line_index(&mut self, selected_line_index: usize) {
 		self.selected_line_index = selected_line_index;
 	}

--- a/src/view/line_segment.rs
+++ b/src/view/line_segment.rs
@@ -64,8 +64,7 @@ impl LineSegment {
 		dim: bool,
 		underline: bool,
 		reverse: bool,
-	) -> Self
-	{
+	) -> Self {
 		Self {
 			text: String::from(text),
 			color,

--- a/src/view/view_line.rs
+++ b/src/view/view_line.rs
@@ -52,8 +52,7 @@ impl ViewLine {
 		dim: bool,
 		underline: bool,
 		reverse: bool,
-	) -> Self
-	{
+	) -> Self {
 		self.padding_color = color;
 		self.padding_dim = dim;
 		self.padding_underline = underline;


### PR DESCRIPTION
# Description

Writing a noop in the rebase file for abort updates the HEAD ref, which is not desired. Update abort to go back to writing an empty rebase file instead.


Closes #383 