### PR TITLE
Drop init_color trace from virtual curses

### DIFF
--- a/src/display/color_manager.rs
+++ b/src/display/color_manager.rs
@@ -390,12 +390,11 @@ mod tests {
 				blue: 220,
 			},
 		);
-		let trace = curses.get_function_trace();
-		let expected_trace = vec![
-			build_trace!("init_color", "16", "392", "588", "784"),
-			build_trace!("init_color", "17", "470", "666", "862"),
-		];
-		compare_trace(&trace, &expected_trace);
+
+		let colors = curses.get_colors();
+
+		assert_eq!(colors[16], (392, 588, 784));
+		assert_eq!(colors[17], (470, 666, 862));
 	}
 
 	#[test]

--- a/src/display/virtual_curses.rs
+++ b/src/display/virtual_curses.rs
@@ -49,6 +49,10 @@ impl Curses {
 		self.function_call_trace.borrow().clone()
 	}
 
+	pub(crate) const fn get_colors(&self) -> &[(i16, i16, i16); 255] {
+		&self.colors
+	}
+
 	pub(crate) fn push_input(&self, input: Input) {
 		self.input.borrow_mut().insert(0, input);
 	}
@@ -58,9 +62,6 @@ impl Curses {
 	}
 
 	pub(super) fn init_color(&mut self, index: i16, red: i16, green: i16, blue: i16) {
-		self.function_call_trace
-			.borrow_mut()
-			.push(build_trace!("init_color", index, red, green, blue));
 		self.colors[index as usize] = (red, green, blue);
 	}
 


### PR DESCRIPTION
# Description

Drop init_color trace from virtual curses. Verifying the colors initialized is a better way to determine the result of initializing colors in tests.