### PR TITLE
Improve test render of padding

### DIFF
--- a/src/process/help.rs
+++ b/src/process/help.rs
@@ -165,7 +165,7 @@ mod tests {
 					view_data,
 					"{TITLE}",
 					"{LEADING}",
-					"{Normal,Underline} Key Action{Normal,Underline}           ",
+					"{Normal,Underline} Key Action{Normal,Underline}{Pad  ,11}",
 					"{BODY}",
 					"{IndicatorColor} a{Normal,Dimmed}|{Normal}Description A",
 					"{IndicatorColor} b{Normal,Dimmed}|{Normal}Description B",

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -51,14 +51,14 @@ fn render_view_line(view_line: &ViewLine) -> String {
 	let segments = view_line.get_segments();
 	for (index, segment) in segments.iter().enumerate() {
 		let content = segment.get_content();
-		// skip any trailing padding whitespace segments to make diff building/matching easier
-		// this could probably be done in a better way, but I cannot think of it just now - Tim
-		if index + 1 == segments.len()
+		let is_padding = index + 1 == segments.len() && content.replace(view_line.padding_character(), "").is_empty();
+		// skip standard padding
+		if is_padding
+			&& view_line.padding_character() == " "
 			&& segment.get_color() == DisplayColor::Normal
 			&& !segment.is_dimmed()
 			&& !segment.is_reversed()
 			&& !segment.is_underlined()
-			&& content.trim().is_empty()
 		{
 			continue;
 		}
@@ -72,7 +72,13 @@ fn render_view_line(view_line: &ViewLine) -> String {
 			)
 			.as_str(),
 		);
-		line.push_str(segment.get_content());
+		// only render
+		if is_padding {
+			line.push_str(format!("{{Pad {},{}}}", view_line.padding_character(), content.len()).as_str());
+		}
+		else {
+			line.push_str(segment.get_content());
+		}
 	}
 	line
 }

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -488,6 +488,7 @@ impl ViewData {
 
 				ViewLine::new_with_pinned_segments(segments, line.get_number_of_pinned_segment())
 					.set_selected(line.get_selected())
+					.set_padding_character(line.padding_character())
 			})
 			.collect::<Vec<ViewLine>>()
 	}
@@ -987,6 +988,27 @@ mod tests {
 		view_data.set_view_size(100, 1);
 
 		assert_rendered_output!(view_data, "{TITLE}");
+	}
+
+	#[test]
+	fn rebuild_retains_selected() {
+		let mut view_data = ViewData::new();
+		view_data.set_view_size(100, 10);
+		view_data.push_line(ViewLine::new_empty_line().set_padding_character("*"));
+		view_data.rebuild();
+
+		// padding characters are stripped by the test render, so test it directly
+		assert_eq!(view_data.lines_cache.unwrap()[0].padding_character(), "*");
+	}
+
+	#[test]
+	fn rebuild_retains_padding_character() {
+		let mut view_data = ViewData::new();
+		view_data.set_view_size(100, 10);
+		view_data.push_line(ViewLine::from("a").set_selected(true));
+		view_data.rebuild();
+
+		assert_rendered_output!(view_data, "{BODY}", "{Normal(selected)}a");
 	}
 
 	#[test]


### PR DESCRIPTION
# Description

Previously the render of padding in tests would strip any default padding from the end of lines, but fully print non-default padding. This change keeps the stripping of default padding, but outputs a token
version of other types of padding. A test in process:help was also updated to use the new type of padding.