### PR TITLE
Limit action update on static actions

### DIFF
--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -2579,9 +2579,8 @@ mod tests {
 			&[],
 			|mut test_context: TestContext<'_>| {
 				let mut module = List::new(test_context.config);
-				test_context
-					.rebase_todo_file
-					.update_range(1, 1, &EditContext::new().action(Action::Noop));
+				test_context.rebase_todo_file.remove_line(1);
+				test_context.rebase_todo_file.add_line(1, Line::new("noop").unwrap());
 				let view_data = test_context.build_view_data(&mut module);
 				assert_rendered_output!(
 					view_data,

--- a/src/todo_file/action.rs
+++ b/src/todo_file/action.rs
@@ -42,6 +42,13 @@ impl Action {
 			Self::Squash => "s",
 		})
 	}
+
+	pub const fn is_static(self) -> bool {
+		match self {
+			Self::Break | Self::Exec | Self::Noop => true,
+			Self::Drop | Self::Edit | Self::Fixup | Self::Pick | Self::Reword | Self::Squash => false,
+		}
+	}
 }
 
 impl TryFrom<&str> for Action {
@@ -66,6 +73,7 @@ impl TryFrom<&str> for Action {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rstest::rstest;
 
 	macro_rules! test_action_to_string {
 		($name:ident, $action:expr, $expected:expr) => {
@@ -146,4 +154,21 @@ mod tests {
 	test_action_to_abbreviation!(p, Action::Pick, "p");
 	test_action_to_abbreviation!(r, Action::Reword, "r");
 	test_action_to_abbreviation!(s, Action::Squash, "s");
+
+	#[rstest(
+		action,
+		expected,
+		case::break_action(Action::Break, true),
+		case::drop(Action::Drop, false),
+		case::edit(Action::Edit, false),
+		case::exec(Action::Exec, true),
+		case::fixup(Action::Fixup, false),
+		case::noop(Action::Noop, true),
+		case::pick(Action::Pick, false),
+		case::reword(Action::Reword, false),
+		case::squash(Action::Squash, false)
+	)]
+	fn module_lifecycle(action: Action, expected: bool) {
+		assert_eq!(action.is_static(), expected);
+	}
 }


### PR DESCRIPTION
# Description

The break, exec and noop actions should not allow the action to be changed. So ensure that they cannot be changed.