### PR TITLE
Clear prompt on ViewData::clear or ::reset

### DIFF
--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -62,6 +62,7 @@ impl ViewData {
 		self.lines_cache = None;
 		self.trailing_lines.clear();
 		self.trailing_lines_cache = None;
+		self.prompt = None;
 	}
 
 	pub(crate) fn scroll_up(&mut self) {


### PR DESCRIPTION
# Description

While not really used with the current system, calling clear or reset in ViewData should also clear the prompt value.