### PR TITLE
Remove trailing semcolons from macros

### DIFF
--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -4,7 +4,9 @@ set -e
 set -u
 set -o pipefail
 
-rustup update nightly
-rustup component add rustfmt --toolchain nightly
-cargo +nightly fmt --all -- --check
+RUST_VERSION="nightly-2021-01-31"
+
+rustup update "$RUST_VERSION"
+rustup component add rustfmt --toolchain "$RUST_VERSION"
+cargo +"$RUST_VERSION" fmt --all -- --check
 

--- a/src/display/testutil.rs
+++ b/src/display/testutil.rs
@@ -48,7 +48,7 @@ pub fn _create_key_event(c: KeyCode, modifiers: &[String]) -> Event {
 #[macro_export]
 macro_rules! create_key_event {
 	($char:expr) => {
-		crate::display::testutil::_create_key_event(crate::display::KeyCode::Char($char), &[]);
+		crate::display::testutil::_create_key_event(crate::display::KeyCode::Char($char), &[])
 	};
 	($char:expr, $($modifiers:expr),*) => {
 		{
@@ -58,12 +58,12 @@ macro_rules! create_key_event {
 		}
 	};
 	(code $code:expr) => {
-		crate::display::testutil::_create_key_event($code, &[]);
+		crate::display::testutil::_create_key_event($code, &[])
 	};
 	(code $code:expr, $($modifiers:expr),*) => {
 		let mut modifiers = vec![];
 		$( modifiers.push(String::from($modifiers)); )*
-		crate::display::testutil::_create_key_event($code, &modifiers);
+		crate::display::testutil::_create_key_event($code, &modifiers)
 	};
 }
 

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -313,25 +313,25 @@ pub fn _assert_process_result(
 #[macro_export]
 macro_rules! assert_process_result {
 	($actual:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, None, None, None, &None);
+		crate::process::testutil::_assert_process_result(&$actual, None, None, None, &None)
 	};
 	($actual:expr, error = $error:expr, exit_status = $exit_status:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, None, None, Some($exit_status), &Some($error));
+		crate::process::testutil::_assert_process_result(&$actual, None, None, Some($exit_status), &Some($error))
 	};
 	($actual:expr, state = $state:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, None, Some($state), None, &None);
+		crate::process::testutil::_assert_process_result(&$actual, None, Some($state), None, &None)
 	};
 	($actual:expr, state = $state:expr, error = $error:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, None, Some($state), None, &Some($error));
+		crate::process::testutil::_assert_process_result(&$actual, None, Some($state), None, &Some($error))
 	};
 	($actual:expr, input = $input:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, Some($input), None, None, &None);
+		crate::process::testutil::_assert_process_result(&$actual, Some($input), None, None, &None)
 	};
 	($actual:expr, input = $input:expr, state = $state:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, Some($input), Some($state), None, &None);
+		crate::process::testutil::_assert_process_result(&$actual, Some($input), Some($state), None, &None)
 	};
 	($actual:expr, input = $input:expr, exit_status = $exit_status:expr) => {
-		crate::process::testutil::_assert_process_result(&$actual, Some($input), None, Some($exit_status), &None);
+		crate::process::testutil::_assert_process_result(&$actual, Some($input), None, Some($exit_status), &None)
 	};
 }
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -49,7 +49,7 @@ pub fn _assert_exit_status(actual: &Result<ExitStatus, Exit>, expected: &Result<
 #[macro_export]
 macro_rules! assert_exit_status {
 	($actual:expr, status = $status:expr) => {
-		crate::testutil::_assert_exit_status(&$actual, &Ok($status));
+		crate::testutil::_assert_exit_status(&$actual, &Ok($status))
 	};
 	($actual:expr, message = $message:expr, status = $status:expr) => {
 		crate::testutil::_assert_exit_status(
@@ -58,6 +58,6 @@ macro_rules! assert_exit_status {
 				message: String::from($message),
 				status: $status,
 			}),
-		);
+		)
 	};
 }


### PR DESCRIPTION
# Description

Marcos should not have trailing semicolons, and they fail to compile in the latest nightly.