### PR TITLE
Fix panic! usage of non-format strings

### DIFF
--- a/src/display/color.rs
+++ b/src/display/color.rs
@@ -24,7 +24,7 @@ pub enum Color {
 	DarkYellow,
 	DarkGrey,
 	Index(u8),
-	RGB { red: u8, green: u8, blue: u8 },
+	Rgb { red: u8, green: u8, blue: u8 },
 }
 
 impl TryFrom<&str> for Color {
@@ -73,7 +73,7 @@ impl TryFrom<&str> for Color {
 						let blue = matches[2].parse::<i16>().unwrap_or(-1);
 
 						if red >= 0 && green >= 0 && blue >= 0 && red < 256 && green < 256 && blue < 256 {
-							return Ok(Self::RGB {
+							return Ok(Self::Rgb {
 								red: red as u8,
 								green: green as u8,
 								blue: blue as u8,
@@ -141,7 +141,7 @@ mod tests {
 	test_color_try_from!(named_dark_yellow, "dark yellow", Color::DarkYellow);
 	test_color_try_from!(index_0, "0", Color::Index(0));
 	test_color_try_from!(index_255, "255", Color::Index(255));
-	test_color_try_from!(rgb, "100,101,102", Color::RGB {
+	test_color_try_from!(rgb, "100,101,102", Color::Rgb {
 		red: 100,
 		green: 101,
 		blue: 102

--- a/src/display/mockcrossterm.rs
+++ b/src/display/mockcrossterm.rs
@@ -112,12 +112,13 @@ impl CrossTerm {
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(super) fn flush(&mut self) -> Result<()> {
 		self.dirty = false;
 		Ok(())
 	}
 
-	#[allow(clippy::unused_self)]
+	#[allow(clippy::unused_self, clippy::unnecessary_wraps)]
 	pub(super) fn print(&mut self, s: &str) -> Result<()> {
 		OUTPUT
 			.lock()
@@ -126,11 +127,13 @@ impl CrossTerm {
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(super) fn set_color(&mut self, colors: Colors) -> Result<()> {
 		self.colors = colors;
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(super) fn set_dim(&mut self, dim: bool) -> Result<()> {
 		if dim {
 			self.attributes.set(Attribute::Dim)
@@ -141,6 +144,7 @@ impl CrossTerm {
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(super) fn set_underline(&mut self, dim: bool) -> Result<()> {
 		if dim {
 			self.attributes.set(Attribute::Underlined)
@@ -151,6 +155,7 @@ impl CrossTerm {
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(super) fn set_reverse(&mut self, dim: bool) -> Result<()> {
 		if dim {
 			self.attributes.set(Attribute::Reverse)
@@ -179,6 +184,7 @@ impl CrossTerm {
 		self.size
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(crate) fn move_to_column(&mut self, x: u16) -> Result<()> {
 		self.position.0 = x;
 		Ok(())
@@ -194,11 +200,13 @@ impl CrossTerm {
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(crate) fn start(&mut self) -> Result<()> {
 		self.state = State::Normal;
 		Ok(())
 	}
 
+	#[allow(clippy::unnecessary_wraps)]
 	pub(crate) fn end(&mut self) -> Result<()> {
 		self.state = State::Ended;
 		Ok(())

--- a/src/display/testutil.rs
+++ b/src/display/testutil.rs
@@ -55,8 +55,7 @@ macro_rules! create_key_event {
 	};
 	($char:expr, $($modifiers:expr),*) => {
 		{
-			let mut modifiers = vec![];
-			$( modifiers.push(String::from($modifiers)); )*
+			let modifiers = vec![$( String::from($modifiers), )*];
 			crate::display::testutil::_create_key_event(crate::display::KeyCode::Char($char), &modifiers)
 		}
 	};

--- a/src/display/utils.rs
+++ b/src/display/utils.rs
@@ -146,8 +146,8 @@ fn find_color(color_mode: ColorMode, color: Color) -> CrosstermColor {
 		},
 		// for indexed colored we assume 8bit color
 		Color::Index(i) => CrosstermColor::AnsiValue(i),
-		Color::RGB { red, green, blue } if color_mode.has_true_color() => CrosstermColor::from((red, green, blue)),
-		Color::RGB { red, green, blue } if color_mode.has_minimum_four_bit_color() => {
+		Color::Rgb { red, green, blue } if color_mode.has_true_color() => CrosstermColor::from((red, green, blue)),
+		Color::Rgb { red, green, blue } if color_mode.has_minimum_four_bit_color() => {
 			// If red, green and blue are equal then we assume a grey scale color
 			// shades less than 8 should go to pure black, while shades greater than 247 should go to pure white
 			if red == green && green == blue && red >= 8 && red < 247 {
@@ -163,7 +163,7 @@ fn find_color(color_mode: ColorMode, color: Color) -> CrosstermColor {
 				CrosstermColor::AnsiValue((16 + 36 * r + 6 * g + b) as u8)
 			}
 		},
-		Color::RGB { red, green, blue } => {
+		Color::Rgb { red, green, blue } => {
 			// Have to hack it down to 8 colors.
 			let r = if red > 127 { 1 } else { 0 };
 			let g = if green > 127 { 1 } else { 0 };
@@ -369,7 +369,7 @@ mod tests {
 		case::white(155, 255, 255, 7)
 	)]
 	fn find_color_three_bit_rgb(red: u8, green: u8, blue: u8, expected_index: u8) {
-		let color = Color::RGB { red, green, blue };
+		let color = Color::Rgb { red, green, blue };
 		assert_eq!(
 			find_color(ColorMode::ThreeBit, color),
 			CrosstermColor::AnsiValue(expected_index)
@@ -435,7 +435,7 @@ mod tests {
 		case::sample(255, 95, 0, 208)
 	)]
 	fn find_color_four_bit_rgb(red: u8, green: u8, blue: u8, expected_index: u8) {
-		let color = Color::RGB { red, green, blue };
+		let color = Color::Rgb { red, green, blue };
 		assert_eq!(
 			find_color(ColorMode::FourBit, color),
 			CrosstermColor::AnsiValue(expected_index)
@@ -489,7 +489,7 @@ mod tests {
 		case::sample(255, 95, 0)
 	)]
 	fn find_color_true_rgb(red: u8, green: u8, blue: u8) {
-		let color = Color::RGB { red, green, blue };
+		let color = Color::Rgb { red, green, blue };
 		assert_eq!(find_color(ColorMode::TrueColor, color), CrosstermColor::Rgb {
 			r: red,
 			g: green,

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -16,7 +16,7 @@ pub struct Edit {
 
 impl ProcessModule for Edit {
 	fn activate(&mut self, todo_file: &TodoFile, _: State) -> ProcessResult {
-		self.content = todo_file.get_selected_line().get_edit_content().to_string();
+		self.content = todo_file.get_selected_line().get_edit_content().to_owned();
 		self.cursor_position = UnicodeSegmentation::graphemes(self.content.as_str(), true).count();
 		ProcessResult::new()
 	}

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -291,17 +291,20 @@ mod tests {
 		};
 
 		if actual_state != expected_state {
-			panic!(vec![
-				"\n",
-				"ExternalEditorState does not match",
-				"==========",
-				"Expected:",
-				expected_state.as_str(),
-				"Actual:",
-				actual_state.as_str(),
-				"==========\n"
-			]
-			.join("\n"));
+			panic!(
+				"{}",
+				vec![
+					"\n",
+					"ExternalEditorState does not match",
+					"==========",
+					"Expected:",
+					expected_state.as_str(),
+					"Actual:",
+					actual_state.as_str(),
+					"==========\n"
+				]
+				.join("\n")
+			);
 		}
 	}
 

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -71,7 +71,7 @@ impl<'i> InputHandler<'i> {
 						KeyCode::Char(c) if c == '\t' => String::from("Tab"),
 						KeyCode::Char(c) if c == '\n' => String::from("Enter"),
 						KeyCode::Char(c) if c == '\u{7f}' => String::from("Backspace"),
-						KeyCode::Char(c) => c.to_string(),
+						KeyCode::Char(c) => String::from(c),
 					}
 				);
 
@@ -233,7 +233,7 @@ mod tests {
 			.join("simple")
 			.to_str()
 			.unwrap()
-			.to_string();
+			.to_owned();
 
 		set_var("GIT_DIR", git_repo_dir.as_str());
 		let config = Config::new().unwrap();

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -183,7 +183,7 @@ pub(super) fn get_todo_line_segments(
 			}
 			else {
 				let max_index = cmp::min(line.get_hash().len(), 8);
-				format!("{:8} ", line.get_hash()[0..max_index].to_string())
+				format!("{:8} ", line.get_hash()[0..max_index].to_owned())
 			}
 			.as_str(),
 		));
@@ -211,7 +211,7 @@ pub(super) fn get_todo_line_segments(
 			}
 			else {
 				let max_index = cmp::min(line.get_hash().len(), 3);
-				format!("{:3} ", line.get_hash()[0..max_index].to_string())
+				format!("{:3} ", line.get_hash()[0..max_index].to_owned())
 			}
 			.as_str(),
 		));

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ pub struct Exit {
 }
 
 // TODO use the termination trait once rust-lang/rust#43301 is stable
-#[allow(clippy::exit)]
+#[allow(clippy::exit, clippy::print_stderr)]
 fn main() {
 	let app = App::new(NAME)
 		.version(VERSION)

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -290,17 +290,20 @@ pub fn _assert_process_result(
 			.as_ref()
 			.map_or(false, |actual| format!("{:#}", expected) == format!("{:#}", actual))
 	})) {
-		panic!(vec![
-			"\n",
-			"ProcessResult does not match",
-			"==========",
-			"Expected State:",
-			format_process_result(input, state, exit_status, error).as_str(),
-			"Actual:",
-			format_process_result(actual.input, actual.state, actual.exit_status, &actual.error).as_str(),
-			"==========\n"
-		]
-		.join("\n"));
+		panic!(
+			"{}",
+			vec![
+				"\n",
+				"ProcessResult does not match",
+				"==========",
+				"Expected State:",
+				format_process_result(input, state, exit_status, error).as_str(),
+				"Actual:",
+				format_process_result(actual.input, actual.state, actual.exit_status, &actual.error).as_str(),
+				"==========\n"
+			]
+			.join("\n")
+		);
 	}
 }
 

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -58,7 +58,7 @@ impl<'t> TestContext<'t> {
 
 	pub fn get_todo_file_path(&self) -> String {
 		let t = self.todo_file.replace(NamedTempFile::new().unwrap());
-		let path = t.path().to_str().unwrap().to_string();
+		let path = t.path().to_str().unwrap().to_owned();
 		self.todo_file.replace(t);
 		path
 	}
@@ -134,7 +134,7 @@ fn map_input_to_event(key_bindings: &KeyBindings, input: Input) -> Event {
 		Input::ActionReword => map_str_to_event(key_bindings.action_reword.as_str()),
 		Input::ActionSquash => map_str_to_event(key_bindings.action_squash.as_str()),
 		Input::Backspace => map_str_to_event("Backspace"),
-		Input::Character(c) => map_str_to_event(c.to_string().as_str()),
+		Input::Character(c) => map_str_to_event(String::from(c).as_str()),
 		Input::Delete => map_str_to_event("Delete"),
 		Input::Down | Input::ScrollDown => map_str_to_event("Down"),
 		Input::Edit => map_str_to_event(key_bindings.edit.as_str()),
@@ -205,69 +205,69 @@ fn format_process_result(
 				State::WindowSizeError => "WindowSizeError",
 			}
 		}),
-		input.map_or("None".to_string(), |input| {
+		input.map_or(String::from("None"), |input| {
 			match input {
-				Input::Abort => "Abort".to_string(),
-				Input::ActionBreak => "ActionBreak".to_string(),
-				Input::ActionDrop => "ActionDrop".to_string(),
-				Input::ActionEdit => "ActionEdit".to_string(),
-				Input::ActionFixup => "ActionFixup".to_string(),
-				Input::ActionPick => "ActionPick".to_string(),
-				Input::ActionReword => "ActionReword".to_string(),
-				Input::ActionSquash => "ActionSquash".to_string(),
-				Input::Backspace => "Backspace".to_string(),
-				Input::BackTab => "BackTab".to_string(),
-				Input::Character(char) => char.to_string(),
-				Input::Delete => "Delete".to_string(),
-				Input::Down => "Down".to_string(),
-				Input::Edit => "Edit".to_string(),
-				Input::End => "End".to_string(),
-				Input::Enter => "Enter".to_string(),
-				Input::Escape => "Escape".to_string(),
-				Input::Exit => "Exit".to_string(),
-				Input::ForceAbort => "ForceAbort".to_string(),
-				Input::ForceRebase => "ForceRebase".to_string(),
-				Input::Help => "Help".to_string(),
-				Input::Home => "Home".to_string(),
-				Input::Ignore => "Ignore".to_string(),
-				Input::Insert => "Insert".to_string(),
-				Input::Kill => "Kill".to_string(),
-				Input::Left => "Left".to_string(),
-				Input::MoveCursorDown => "MoveCursorDown".to_string(),
-				Input::MoveCursorLeft => "MoveCursorLeft".to_string(),
-				Input::MoveCursorPageDown => "MoveCursorPageDown".to_string(),
-				Input::MoveCursorPageUp => "MoveCursorPageUp".to_string(),
-				Input::MoveCursorRight => "MoveCursorRight".to_string(),
-				Input::MoveCursorUp => "MoveCursorUp".to_string(),
-				Input::No => "No".to_string(),
-				Input::OpenInEditor => "OpenInEditor".to_string(),
-				Input::Other => "Other".to_string(),
-				Input::PageDown => "PageDown".to_string(),
-				Input::PageUp => "PageUp".to_string(),
-				Input::Rebase => "Rebase".to_string(),
-				Input::Resize => "Resize".to_string(),
-				Input::Right => "Right".to_string(),
-				Input::ScrollBottom => "ScrollBottom".to_string(),
-				Input::ScrollDown => "ScrollDown".to_string(),
-				Input::ScrollJumpDown => "ScrollJumpDown".to_string(),
-				Input::ScrollJumpUp => "ScrollJumpUp".to_string(),
-				Input::ScrollLeft => "ScrollLeft".to_string(),
-				Input::ScrollRight => "ScrollRight".to_string(),
-				Input::ScrollTop => "ScrollTop".to_string(),
-				Input::ScrollUp => "ScrollUp".to_string(),
-				Input::ShowCommit => "ShowCommit".to_string(),
-				Input::ShowDiff => "ShowDiff".to_string(),
-				Input::SwapSelectedDown => "SwapSelectedDown".to_string(),
-				Input::SwapSelectedUp => "SwapSelectedUp".to_string(),
-				Input::Tab => "Tab".to_string(),
-				Input::ToggleVisualMode => "ToggleVisualMode".to_string(),
-				Input::Up => "Up".to_string(),
-				Input::Yes => "Yes".to_string(),
+				Input::Abort => String::from("Abort"),
+				Input::ActionBreak => String::from("ActionBreak"),
+				Input::ActionDrop => String::from("ActionDrop"),
+				Input::ActionEdit => String::from("ActionEdit"),
+				Input::ActionFixup => String::from("ActionFixup"),
+				Input::ActionPick => String::from("ActionPick"),
+				Input::ActionReword => String::from("ActionReword"),
+				Input::ActionSquash => String::from("ActionSquash"),
+				Input::Backspace => String::from("Backspace"),
+				Input::BackTab => String::from("BackTab"),
+				Input::Character(char) => String::from(char),
+				Input::Delete => String::from("Delete"),
+				Input::Down => String::from("Down"),
+				Input::Edit => String::from("Edit"),
+				Input::End => String::from("End"),
+				Input::Enter => String::from("Enter"),
+				Input::Escape => String::from("Escape"),
+				Input::Exit => String::from("Exit"),
+				Input::ForceAbort => String::from("ForceAbort"),
+				Input::ForceRebase => String::from("ForceRebase"),
+				Input::Help => String::from("Help"),
+				Input::Home => String::from("Home"),
+				Input::Ignore => String::from("Ignore"),
+				Input::Insert => String::from("Insert"),
+				Input::Kill => String::from("Kill"),
+				Input::Left => String::from("Left"),
+				Input::MoveCursorDown => String::from("MoveCursorDown"),
+				Input::MoveCursorLeft => String::from("MoveCursorLeft"),
+				Input::MoveCursorPageDown => String::from("MoveCursorPageDown"),
+				Input::MoveCursorPageUp => String::from("MoveCursorPageUp"),
+				Input::MoveCursorRight => String::from("MoveCursorRight"),
+				Input::MoveCursorUp => String::from("MoveCursorUp"),
+				Input::No => String::from("No"),
+				Input::OpenInEditor => String::from("OpenInEditor"),
+				Input::Other => String::from("Other"),
+				Input::PageDown => String::from("PageDown"),
+				Input::PageUp => String::from("PageUp"),
+				Input::Rebase => String::from("Rebase"),
+				Input::Resize => String::from("Resize"),
+				Input::Right => String::from("Right"),
+				Input::ScrollBottom => String::from("ScrollBottom"),
+				Input::ScrollDown => String::from("ScrollDown"),
+				Input::ScrollJumpDown => String::from("ScrollJumpDown"),
+				Input::ScrollJumpUp => String::from("ScrollJumpUp"),
+				Input::ScrollLeft => String::from("ScrollLeft"),
+				Input::ScrollRight => String::from("ScrollRight"),
+				Input::ScrollTop => String::from("ScrollTop"),
+				Input::ScrollUp => String::from("ScrollUp"),
+				Input::ShowCommit => String::from("ShowCommit"),
+				Input::ShowDiff => String::from("ShowDiff"),
+				Input::SwapSelectedDown => String::from("SwapSelectedDown"),
+				Input::SwapSelectedUp => String::from("SwapSelectedUp"),
+				Input::Tab => String::from("Tab"),
+				Input::ToggleVisualMode => String::from("ToggleVisualMode"),
+				Input::Up => String::from("Up"),
+				Input::Yes => String::from("Yes"),
 			}
 		}),
 		error
 			.as_ref()
-			.map_or("None".to_string(), |error| { format!("{:#}", error) })
+			.map_or(String::from("None"), |error| { format!("{:#}", error) })
 	)
 }
 
@@ -340,7 +340,7 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 		.join("simple")
 		.to_str()
 		.unwrap()
-		.to_string();
+		.to_owned();
 
 	set_var("GIT_DIR", git_repo_dir.as_str());
 	let mut config = Config::new().unwrap();

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -91,12 +91,12 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 				),
 				LineSegment::new(
 					if is_full_width {
-						commit.get_hash().to_string()
+						commit.get_hash().to_owned()
 					}
 					else {
 						let hash = commit.get_hash();
 						let max_index = hash.len().min(8);
-						format!("{:8}", hash[0..max_index].to_string())
+						format!("{:8}", hash[0..max_index].to_owned())
 					}
 					.as_str(),
 				),

--- a/src/show_commit/user.rs
+++ b/src/show_commit/user.rs
@@ -25,7 +25,7 @@ impl User {
 			Some(ref n) => {
 				match *email {
 					Some(ref e) => Some(format!("{} <{}>", *n, *e)),
-					None => Some(n.to_string()),
+					None => Some(n.to_owned()),
 				}
 			},
 			None => {

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -120,22 +120,26 @@ impl ViewBuilder {
 		old_largest_line_number_length: usize,
 		new_largest_line_number_length: usize,
 	) -> Vec<LineSegment> {
-		let mut line_segments = vec![];
-		line_segments.push(match diff_line.old_line_number() {
-			Some(line_number) => {
-				LineSegment::new(format!("{:<width$}", line_number, width = old_largest_line_number_length).as_str())
+		let mut line_segments = vec![
+			match diff_line.old_line_number() {
+				Some(line_number) => {
+					LineSegment::new(
+						format!("{:<width$}", line_number, width = old_largest_line_number_length).as_str(),
+					)
+				},
+				None => LineSegment::new(" ".repeat(old_largest_line_number_length).as_str()),
 			},
-			None => LineSegment::new(" ".repeat(old_largest_line_number_length).as_str()),
-		});
-		line_segments.push(LineSegment::new(" "));
-
-		line_segments.push(match diff_line.new_line_number() {
-			Some(line_number) => {
-				LineSegment::new(format!("{:<width$}", line_number, width = new_largest_line_number_length).as_str())
+			LineSegment::new(" "),
+			match diff_line.new_line_number() {
+				Some(line_number) => {
+					LineSegment::new(
+						format!("{:<width$}", line_number, width = new_largest_line_number_length).as_str(),
+					)
+				},
+				None => LineSegment::new(" ".repeat(new_largest_line_number_length).as_str()),
 			},
-			None => LineSegment::new(" ".repeat(new_largest_line_number_length).as_str()),
-		});
-		line_segments.push(LineSegment::new("| "));
+			LineSegment::new("| "),
+		];
 
 		if self.show_leading_whitespace || self.show_trailing_whitespace {
 			let line = diff_line.line();

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -31,17 +31,20 @@ pub fn _assert_exit_status(actual: &Result<ExitStatus, Exit>, expected: &Result<
 			}
 		},
 	} {
-		panic!(vec![
-			"\n",
-			"Exit result does not match",
-			"==========",
-			"Expected:",
-			format_exit_status(expected).as_str(),
-			"Actual:",
-			format_exit_status(actual).as_str(),
-			"==========\n"
-		]
-		.join("\n"));
+		panic!(
+			"{}",
+			vec![
+				"\n",
+				"Exit result does not match",
+				"==========",
+				"Expected:",
+				format_exit_status(expected).as_str(),
+				"Actual:",
+				format_exit_status(actual).as_str(),
+				"==========\n"
+			]
+			.join("\n")
+		);
 	}
 }
 

--- a/src/todo_file/edit_content.rs
+++ b/src/todo_file/edit_content.rs
@@ -19,7 +19,7 @@ impl EditContext {
 	}
 
 	pub fn content(mut self, content: &str) -> Self {
-		self.content = Some(content.to_string());
+		self.content = Some(content.to_owned());
 		self
 	}
 

--- a/src/todo_file/mod.rs
+++ b/src/todo_file/mod.rs
@@ -25,8 +25,8 @@ pub struct TodoFile {
 impl TodoFile {
 	pub(crate) fn new(path: &str, comment_char: &str) -> Self {
 		Self {
-			comment_char: comment_char.to_string(),
-			filepath: path.to_string(),
+			comment_char: String::from(comment_char),
+			filepath: path.to_owned(),
 			lines: vec![],
 			is_noop: false,
 			selected_line_index: 1,

--- a/src/todo_file/mod.rs
+++ b/src/todo_file/mod.rs
@@ -150,8 +150,8 @@ mod tests {
 	macro_rules! assert_todo_lines {
 		($todo_file_path:expr, $($arg:expr),*) => {
 			let actual_lines = $todo_file_path.get_lines();
-			let mut expected = vec![];
-			$( expected.push(Line::new($arg).unwrap()); )*
+
+			let expected = vec![$( Line::new($arg).unwrap(), )*];
 			assert_eq!(
 				actual_lines.iter().map(Line::to_text).collect::<String>(),
 				expected.iter().map(Line::to_text).collect::<String>()
@@ -161,8 +161,7 @@ mod tests {
 
 	macro_rules! assert_read_todo_file {
 		($todo_file_path:expr, $($arg:expr),*) => {
-			let mut expected = vec![];
-			$( expected.push($arg); )*
+			let expected = vec![$( $arg, )*];
 			let content = read_to_string(Path::new($todo_file_path.path().as_os_str().to_str().unwrap())).unwrap();
 			assert_eq!(content, format!("{}\n", expected.join("\n")));
 		};

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -172,7 +172,7 @@ pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
 
 	if mismatch {
 		error_output.push(String::from("==========\n"));
-		panic!(error_output.join("\n"));
+		panic!("{}", error_output.join("\n"));
 	}
 }
 

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -88,26 +88,26 @@ fn render_view_data(view_data: &ViewData) -> Vec<String> {
 	let mut lines = vec![];
 	if view_data.show_title() {
 		if view_data.show_help() {
-			lines.push("{TITLE}{HELP}".to_string());
+			lines.push(String::from("{TITLE}{HELP}"));
 		}
 		else {
-			lines.push("{TITLE}".to_string());
+			lines.push(String::from("{TITLE}"));
 		}
 	}
 
 	if view_data.is_empty() {
-		lines.push("{EMPTY}".to_string());
+		lines.push(String::from("{EMPTY}"));
 	}
 
 	if let Some(ref prompt) = *view_data.get_prompt() {
-		lines.push("{PROMPT}".to_string());
-		lines.push(prompt.to_string());
+		lines.push(String::from("{PROMPT}"));
+		lines.push(prompt.to_owned());
 		return lines;
 	}
 
 	let leading_lines = view_data.get_leading_lines();
 	if !leading_lines.is_empty() {
-		lines.push("{LEADING}".to_string());
+		lines.push(String::from("{LEADING}"));
 		for line in leading_lines {
 			lines.push(render_view_line(line));
 		}
@@ -115,7 +115,7 @@ fn render_view_data(view_data: &ViewData) -> Vec<String> {
 
 	let body_lines = view_data.get_lines();
 	if !body_lines.is_empty() {
-		lines.push("{BODY}".to_string());
+		lines.push(String::from("{BODY}"));
 		for line in body_lines {
 			lines.push(render_view_line(line));
 		}
@@ -123,7 +123,7 @@ fn render_view_data(view_data: &ViewData) -> Vec<String> {
 
 	let trailing_lines = view_data.get_trailing_lines();
 	if !trailing_lines.is_empty() {
-		lines.push("{TRAILING}".to_string());
+		lines.push(String::from("{TRAILING}"));
 		for line in trailing_lines {
 			lines.push(render_view_line(line));
 		}
@@ -135,10 +135,10 @@ pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
 	let output = render_view_data(view_data);
 	let mut mismatch = false;
 	let mut error_output = vec![
-		"\nUnexpected output!".to_string(),
-		"--- Expected".to_string(),
-		"+++ Actual".to_string(),
-		"==========".to_string(),
+		String::from("\nUnexpected output!"),
+		String::from("--- Expected"),
+		String::from("+++ Actual"),
+		String::from("=========="),
 	];
 
 	for (expected_line, output_line) in expected.iter().zip(output.iter()) {

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -183,8 +183,7 @@ macro_rules! assert_rendered_output {
 		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
 	};
 	($view_data:expr, $($arg:expr),*) => {
-		let mut expected = vec![];
-		$( expected.push(String::from($arg)); )*
+		let expected = vec![$( String::from($arg), )*];
 		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
 	};
 }


### PR DESCRIPTION
# Description

Fix the newest batch of linting issues caught by the latest Rust nightly and Clippy.