### PR TITLE
Remove references to the lines vec

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -81,7 +81,7 @@ mod tests {
 					input = Input::Yes,
 					exit_status = ExitStatus::Good
 				);
-				assert_eq!(test_context.rebase_todo_file.get_lines().len(), 0);
+				assert!(test_context.rebase_todo_file.is_empty());
 			},
 		);
 	}

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -80,7 +80,7 @@ mod tests {
 					input = Input::Yes,
 					exit_status = ExitStatus::Good
 				);
-				assert_eq!(test_context.rebase_todo_file.get_lines().len(), 1);
+				assert!(!test_context.rebase_todo_file.is_empty());
 			},
 		);
 	}

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -39,7 +39,7 @@ impl ProcessModule for ExternalEditor {
 			result = result.error(err).state(State::List);
 		}
 		else if self.lines.is_empty() {
-			self.lines = todo_file.get_lines().to_owned();
+			self.lines = todo_file.get_lines_owned();
 		}
 		result
 	}
@@ -115,7 +115,7 @@ impl ProcessModule for ExternalEditor {
 				else {
 					match todo_file.load_file() {
 						Ok(_) => {
-							if todo_file.get_lines().is_empty() || todo_file.is_noop() {
+							if todo_file.is_empty() || todo_file.is_noop() {
 								self.state = ExternalEditorState::Empty;
 							}
 							else {
@@ -318,7 +318,7 @@ mod tests {
 			|test_context: TestContext<'_>| {
 				let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "0").as_str());
 				assert_process_result!(test_context.activate(&mut module, State::List));
-				assert_eq!(test_context.rebase_todo_file.get_lines(), &vec![
+				assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![
 					Line::new("pick aaa comment1").unwrap(),
 					Line::new("drop bbb comment2").unwrap()
 				]);
@@ -471,7 +471,7 @@ mod tests {
 				test_context.build_view_data(&mut module);
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::Character('3'));
 				assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
-				assert_eq!(test_context.rebase_todo_file.get_lines(), &vec![
+				assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![
 					Line::new("pick aaa comment").unwrap(),
 					Line::new("drop bbb comment").unwrap()
 				]);
@@ -708,7 +708,7 @@ mod tests {
 					input = Input::Character('1'),
 					exit_status = ExitStatus::Good
 				);
-				assert_eq!(test_context.rebase_todo_file.get_lines(), &vec![]);
+				assert!(test_context.rebase_todo_file.is_empty());
 			},
 		);
 	}
@@ -748,7 +748,7 @@ mod tests {
 					input = Input::Character('3'),
 					state = State::List
 				);
-				assert_eq!(test_context.rebase_todo_file.get_lines(), &vec![Line::new(
+				assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![Line::new(
 					"pick aaa comment"
 				)
 				.unwrap()]);
@@ -770,7 +770,7 @@ mod tests {
 				test_context.build_view_data(&mut module);
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::Character('4'));
 				assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
-				assert_eq!(test_context.rebase_todo_file.get_lines(), &vec![Line::new(
+				assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![Line::new(
 					"pick aaa comment"
 				)
 				.unwrap()]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn try_main(filepath: &str) -> Result<ExitStatus, Exit> {
 		});
 	}
 
-	if todo_file.get_lines().is_empty() {
+	if todo_file.is_empty() {
 		return Err(Exit {
 			message: String::from("An empty rebase was provided, nothing to edit"),
 			status: ExitStatus::Good,

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -37,7 +37,7 @@ fn force_abort() {
 			let modules = Modules::new(test_context.config);
 			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Good);
 			process.rebase_todo.load_file().unwrap();
-			assert_eq!(process.rebase_todo.get_lines(), &vec![]);
+			assert!(process.rebase_todo.is_empty());
 		},
 	);
 }
@@ -54,9 +54,10 @@ fn force_rebase() {
 			let modules = Modules::new(test_context.config);
 			assert_eq!(process.run(modules).unwrap().unwrap(), ExitStatus::Good);
 			process.rebase_todo.load_file().unwrap();
-			assert_eq!(process.rebase_todo.get_lines(), &vec![
-				Line::new("pick aaa comment").unwrap()
-			]);
+			assert_eq!(process.rebase_todo.get_lines_owned(), vec![Line::new(
+				"pick aaa comment"
+			)
+			.unwrap()]);
 		},
 	);
 }


### PR DESCRIPTION
# Description

The internal Vec<Line> containing the lines list was an escape hatch to allow the addition of some functionality. It should be an internal implementation detail and should not be accessible. So this change:

- Add is_empty function to check if there are no lines
- Add iter for iteration over the lines
- Add get_line function to get a line at index
- Add get_maximum_line_index to replace calls getting the length
- Add get_lines_owned which returns a owned copy of the lines