### PR TITLE
Fix release GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,48 @@ on:
         types: [published]
 
 jobs:
+    build-ubuntu-legacy:
+        strategy:
+            matrix:
+                version: ['14.04', '16.04']
+        runs-on: ubuntu-latest
+        container:
+            image: 'docker://ubuntu:${{ matrix.version }}'
+        steps:
+            - name: "Get Tag Name"
+              id: ref
+              shell: bash
+              run: |
+                  ref="${{ github.ref }}";
+                  ref="${ref//refs\/heads\//}";
+                  ref="${ref//refs\/tags\//}";
+                  ref="${ref//master/dev}";
+                  echo "$ref";
+                  echo "::set-output name=name::$ref"
+            - name: "Checkout project"
+              uses: actions/checkout@v2
+            - name: "System Setup"
+              run: |
+                  apt-get update;
+                  apt-get --assume-yes -f install curl build-essential pkg-config;
+                  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- --default-toolchain stable -y;
+                  $HOME/.cargo/bin/cargo install --force cargo-deb
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  TZ: "America/St_Johns"
+            - name: "Build Deb"
+              run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-ubuntu-${{ matrix.version }}_amd64.deb"
+            - name: "Upload Release"
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: |
+                      target/debian/*.deb
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build-ubuntu:
         strategy:
             matrix:
-                version: ['14.04', '16.04', '18.04', '19.10', '20.04']
+                version: ['18.04', '20.04', '20.10']
         runs-on: ubuntu-latest
         container:
             image: 'docker://ubuntu:${{ matrix.version }}'
@@ -31,6 +69,9 @@ jobs:
                   apt-get --assume-yes -f install curl build-essential pkg-config liblzma-dev;
                   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- --default-toolchain stable -y;
                   $HOME/.cargo/bin/cargo install --force cargo-deb
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  TZ: "America/St_Johns"
             - name: "Build Deb"
               run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-ubuntu-${{ matrix.version }}_amd64.deb"
             - name: "Upload Release"
@@ -41,10 +82,48 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    build-debian-legacy:
+        strategy:
+            matrix:
+                version: ['8']
+        runs-on: ubuntu-latest
+        container:
+            image: 'docker://debian:${{ matrix.version }}-slim'
+        steps:
+            - name: "Get Tag Name"
+              id: ref
+              shell: bash
+              run: |
+                  ref="${{ github.ref }}";
+                  ref="${ref//refs\/heads\//}";
+                  ref="${ref//refs\/tags\//}";
+                  ref="${ref//master/dev}";
+                  echo "$ref";
+                  echo "::set-output name=name::$ref"
+            - name: "Checkout project"
+              uses: actions/checkout@v2
+            - name: "System Setup"
+              run: |
+                  apt-get update;
+                  apt-get --assume-yes -f install curl build-essential pkg-config;
+                  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- --default-toolchain stable -y;
+                  $HOME/.cargo/bin/cargo install --force cargo-deb
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  TZ: "America/St_Johns"
+            - name: "Build Deb"
+              run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-debian-${{ matrix.version }}_amd64.deb"
+            - name: "Upload Release"
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: |
+                      target/debian/*.deb
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build-debian:
         strategy:
             matrix:
-                version: ['8', '9', '10', 'bullseye', 'sid']
+                version: ['9', '10', 'bullseye', 'sid']
         runs-on: ubuntu-latest
         container:
             image: 'docker://debian:${{ matrix.version }}-slim'
@@ -67,6 +146,9 @@ jobs:
                   apt-get --assume-yes -f install curl build-essential pkg-config liblzma-dev;
                   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- --default-toolchain stable -y;
                   $HOME/.cargo/bin/cargo install --force cargo-deb
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  TZ: "America/St_Johns"
             - name: "Build Deb"
               run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-debian-${{ matrix.version }}_amd64.deb"
             - name: "Upload Release"
@@ -98,7 +180,7 @@ jobs:
             - name: "Checkout project"
               uses: actions/checkout@v2
             - name: "Build"
-              run: "cargo rustc --target x86_64-pc-windows-msvc --release --bin interactive-rebase-tool -- -C lto"
+              run: "cargo rustc --target x86_64-pc-windows-msvc --release --bin interactive-rebase-tool"
             - name: "Upload Release"
               uses: softprops/action-gh-release@v1
               with:


### PR DESCRIPTION
# Description

The last release failed due to Ubuntu 19.10 no longer being supported and because of a breaking change in Rust > 1.45 that caused the Windows build to fail.