### PR TITLE
Fix custom keybindings using modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Label and description to commit edit
 - Basic support to merge rebasing
+- Modifier keys can now be provided in any order
+
+### Fixed
+- Most modifier key combinations could not be used as key bindings
 
 ## [2.0.0] - 2021-01-28
 

--- a/readme/customization.md
+++ b/readme/customization.md
@@ -141,6 +141,7 @@ Keys that do not have easily printable characters, such as the arrow keys, are s
 | `Down`             | Down arrow key |
 | `End`              | End key |
 | `Enter`            | Enter key |
+| `Esc`              | Escape key |
 | `F{1..255}`        | Function X key |
 | `Home`             | Home key |
 | `Insert`           | Insert key |
@@ -153,7 +154,17 @@ Keys that do not have easily printable characters, such as the arrow keys, are s
 
 ### Modifier Keys
 
-Most keybindings can be prefixed with `Shift`, `Control` or `Alt`. These bindings can also be combined, but if combined must be combined in the order defined above. That is `ShiftAltEnter` is valid but `AltShiftEnter` is not. This is a limitation that hopefully will be removed in the future. `Shift` combined with any ASCII alphabetic character will not work and the uppercase character must be used instead.
+Most keybindings can be prefixed with `Shift`, `Control` or `Alt`, followed by a `+`. These bindings can also be combined in any order, for example `Alt+Control+Delete`. `Shift` combined with any ASCII alphabetic character will not work and the uppercase character must be used instead.
+
+### Restricted Keys
+
+Some key combinations are restricted as they have special meaning. They are:
+
+| Key                | Description |
+| ------------------ | ----------- |
+| `Control+c`        | Immediately aborts the program without writing the rebase todo file to disk |
+| `Control+d`        | Immediately writes the rebase todo file to disk and exits |
+
 
 ## External Editor
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,45 +3,29 @@ use std::{
 	path::Path,
 };
 
+use rstest::rstest;
 use serial_test::serial;
+use tempfile::NamedTempFile;
 
 use super::*;
 use crate::display::color::Color;
 
-fn load_with_config_file(case: &str, test: &str) -> Config {
-	Config::new_from_config(
-		&git2::Config::open(
-			Path::new(env!("CARGO_MANIFEST_DIR"))
-				.join("test")
-				.join("fixtures")
-				.join("config")
-				.join(case)
-				.join(test)
-				.as_path(),
-		)
-		.unwrap(),
-	)
-	.unwrap()
+fn load_with_git_config_callback<F>(callback: F) -> Result<Config>
+where F: FnOnce(&mut git2::Config) {
+	let tmp_file = NamedTempFile::new().unwrap().into_temp_path();
+	let mut config = git2::Config::open(tmp_file.to_path_buf().as_path()).unwrap();
+	callback(&mut config);
+	Config::new_from_config(&config)
 }
 
-fn load_error_with_config_file(case: &str, test: &str) -> String {
-	format!(
-		"{:#}",
-		Config::new_from_config(
-			&git2::Config::open(
-				Path::new(env!("CARGO_MANIFEST_DIR"))
-					.join("test")
-					.join("fixtures")
-					.join("config")
-					.join(case)
-					.join(test)
-					.as_path(),
-			)
-			.unwrap(),
-		)
-		.err()
-		.unwrap()
-	)
+fn load<F>(callback: F) -> Config
+where F: FnOnce(&mut git2::Config) {
+	load_with_git_config_callback(callback).unwrap()
+}
+
+fn load_error<F>(callback: F) -> String
+where F: FnOnce(&mut git2::Config) {
+	format!("{:#}", load_with_git_config_callback(callback).err().unwrap())
 }
 
 #[test]
@@ -89,88 +73,136 @@ fn config_new_invalid_repo() {
 
 #[test]
 fn config_auto_select_next_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert!(!config.auto_select_next);
 }
 
 #[test]
 fn config_auto_select_next_true() {
-	let config = load_with_config_file("auto-select-next", "true.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.autoSelectNext", true)
+			.unwrap();
+	});
 	assert!(config.auto_select_next);
 }
 
 #[test]
 fn config_auto_select_next_false() {
-	let config = load_with_config_file("auto-select-next", "false.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.autoSelectNext", false)
+			.unwrap();
+	});
 	assert!(!config.auto_select_next);
 }
 
 #[test]
 fn config_auto_select_next_invalid() {
 	assert_eq!(
-		load_error_with_config_file("auto-select-next", "invalid.gitconfig"),
-		"\"interactive-rebase-tool.autoSelectNext\" is not valid: failed to parse \'invalid\' as a boolean value",
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.autoSelectNext", "invalid")
+				.unwrap();
+		}),
+		"\"interactive-rebase-tool.autoSelectNext\" is not valid: failed to parse \'invalid\' as a boolean value"
 	);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_true() {
-	let config = load_with_config_file("diff-ignore-whitespace", "true.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.diffIgnoreWhitespace", true)
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_on() {
-	let config = load_with_config_file("diff-ignore-whitespace", "on.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "on")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_all() {
-	let config = load_with_config_file("diff-ignore-whitespace", "all.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "all")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::All);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_change() {
-	let config = load_with_config_file("diff-ignore-whitespace", "change.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "change")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_false() {
-	let config = load_with_config_file("diff-ignore-whitespace", "false.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.diffIgnoreWhitespace", false)
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_off() {
-	let config = load_with_config_file("diff-ignore-whitespace", "off.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "off")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_none() {
-	let config = load_with_config_file("diff-ignore-whitespace", "none.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "none")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_mixed_case() {
-	let config = load_with_config_file("diff-ignore-whitespace", "mixed-case.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "ChAnGe")
+			.unwrap();
+	});
 	assert_eq!(config.diff_ignore_whitespace, DiffIgnoreWhitespaceSetting::Change);
 }
 
 #[test]
 fn config_diff_ignore_whitespace_invalid() {
 	assert_eq!(
-		load_error_with_config_file("diff-ignore-whitespace", "invalid.gitconfig"),
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.diffIgnoreWhitespace", "invalid")
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffIgnoreWhitespace\" is not valid: \"invalid\" does not match one of \"true\", \
 		 \"on\", \"all\", \"change\", \"false\", \"off\" or \"none\""
 	);
@@ -178,68 +210,108 @@ fn config_diff_ignore_whitespace_invalid() {
 
 #[test]
 fn config_diff_show_whitespace_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
 }
 
 #[test]
 fn config_diff_show_whitespace_true() {
-	let config = load_with_config_file("diff-show-whitespace", "true.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.diffShowWhitespace", true)
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
 }
 
 #[test]
 fn config_diff_show_whitespace_on() {
-	let config = load_with_config_file("diff-show-whitespace", "on.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "on")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
 }
 
 #[test]
 fn config_diff_show_whitespace_both() {
-	let config = load_with_config_file("diff-show-whitespace", "both.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "both")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Both);
 }
 
 #[test]
 fn config_diff_show_whitespace_trailing() {
-	let config = load_with_config_file("diff-show-whitespace", "trailing.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "trailing")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
 }
 
 #[test]
 fn config_diff_show_whitespace_leading() {
-	let config = load_with_config_file("diff-show-whitespace", "leading.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "leading")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Leading);
 }
 
 #[test]
 fn config_diff_show_whitespace_false() {
-	let config = load_with_config_file("diff-show-whitespace", "false.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_bool("interactive-rebase-tool.diffShowWhitespace", false)
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_show_whitespace_off() {
-	let config = load_with_config_file("diff-show-whitespace", "off.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "off")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_show_whitespace_none() {
-	let config = load_with_config_file("diff-show-whitespace", "none.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "none")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::None);
 }
 
 #[test]
 fn config_diff_show_whitespace_mixed_case() {
-	let config = load_with_config_file("diff-show-whitespace", "mixed-case.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffShowWhitespace", "tRaIlInG")
+			.unwrap();
+	});
 	assert_eq!(config.diff_show_whitespace, DiffShowWhitespaceSetting::Trailing);
 }
 
 #[test]
 fn config_diff_show_whitespace_invalid() {
 	assert_eq!(
-		load_error_with_config_file("diff-show-whitespace", "invalid.gitconfig"),
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.diffShowWhitespace", "invalid")
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffShowWhitespace\" is not valid: \"invalid\" does not match one of \"true\", \
 		 \"on\", \"both\", \"trailing\", \"leading\", \"false\", \"off\" or \"none\""
 	);
@@ -247,20 +319,26 @@ fn config_diff_show_whitespace_invalid() {
 
 #[test]
 fn config_diff_tab_width_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.diff_tab_width, 4);
 }
 
 #[test]
 fn config_diff_tab_width() {
-	let config = load_with_config_file("diff-tab-width", ".gitconfig");
+	let config = load(|git_config| {
+		git_config.set_i32("interactive-rebase-tool.diffTabWidth", 14).unwrap();
+	});
 	assert_eq!(config.diff_tab_width, 14);
 }
 
 #[test]
 fn config_diff_tab_invalid() {
 	assert_eq!(
-		load_error_with_config_file("diff-tab-width", "invalid.gitconfig"),
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.diffTabWidth", "invalid")
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffTabWidth\" is not valid: failed to parse \'invalid\' as a 32-bit integer"
 	);
 }
@@ -268,7 +346,11 @@ fn config_diff_tab_invalid() {
 #[test]
 fn config_diff_tab_invalid_range() {
 	assert_eq!(
-		load_error_with_config_file("diff-tab-width", "invalid-range.gitconfig"),
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.diffTabWidth", "-100")
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffTabWidth\" is not valid: \"-100\" is outside of valid range for an unsigned \
 		 32-bit integer"
 	);
@@ -276,86 +358,127 @@ fn config_diff_tab_invalid_range() {
 
 #[test]
 fn config_diff_tab_symbol_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.diff_tab_symbol, "→");
 }
 
 #[test]
 fn config_diff_tab_symbol() {
-	let config = load_with_config_file("diff-tab-symbol", ".gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffTabSymbol", "|")
+			.unwrap();
+	});
 	assert_eq!(config.diff_tab_symbol, "|");
 }
 
 #[test]
+#[allow(unsafe_code)]
 fn config_diff_tab_symbol_invalid_utf8() {
 	assert_eq!(
-		load_error_with_config_file("diff-tab-symbol", "invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"interactive-rebase-tool.diffTabSymbol",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffTabSymbol\" is not valid: configuration value is not valid utf8"
 	);
 }
 
 #[test]
 fn config_diff_space_symbol_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.diff_space_symbol, "·");
 }
 
 #[test]
 fn config_diff_space_symbol() {
-	let config = load_with_config_file("diff-space-symbol", ".gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffSpaceSymbol", "-")
+			.unwrap();
+	});
 	assert_eq!(config.diff_space_symbol, "-");
 }
 
 #[test]
+#[allow(unsafe_code)]
 fn config_diff_space_symbol_invalid_utf8() {
 	assert_eq!(
-		load_error_with_config_file("diff-space-symbol", "invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"interactive-rebase-tool.diffSpaceSymbol",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.diffSpaceSymbol\" is not valid: configuration value is not valid utf8"
 	);
 }
 
 #[test]
 fn config_git_comment_char_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.comment_char, "#");
 }
 
 #[test]
 fn config_git_comment_char_auto() {
-	let config = load_with_config_file("comment-char", "auto.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("core.commentChar", "auto").unwrap();
+	});
+
 	assert_eq!(config.git.comment_char, "#");
 }
 
 #[test]
 fn config_git_comment_char() {
-	let config = load_with_config_file("comment-char", ".gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("core.commentChar", ";").unwrap();
+	});
 	assert_eq!(config.git.comment_char, ";");
 }
 
 #[test]
+#[allow(unsafe_code)]
 fn config_git_comment_char_invalid() {
 	assert_eq!(
-		load_error_with_config_file("comment-char", "invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"core.commentChar",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"core.commentChar\" is not valid: configuration value is not valid utf8"
 	);
 }
 
 #[test]
 fn config_git_diff_context_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.diff_context, 3);
 }
 
 #[test]
 fn config_git_diff_context() {
-	let config = load_with_config_file("diff-context", ".gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.context", "5").unwrap();
+	});
 	assert_eq!(config.git.diff_context, 5);
 }
 
 #[test]
 fn config_git_diff_context_invalid() {
 	assert_eq!(
-		load_error_with_config_file("diff-context", "invalid.gitconfig"),
+		load_error(|git_config| {
+			git_config.set_str("diff.context", "invalid").unwrap();
+		}),
 		"\"diff.context\" is not valid: failed to parse \'invalid\' as a 32-bit integer"
 	);
 }
@@ -363,49 +486,61 @@ fn config_git_diff_context_invalid() {
 #[test]
 fn config_git_diff_context_invalid_range() {
 	assert_eq!(
-		load_error_with_config_file("diff-context", "invalid-range.gitconfig"),
+		load_error(|git_config| {
+			git_config.set_str("diff.context", "-100").unwrap();
+		}),
 		"\"diff.context\" is not valid: \"-100\" is outside of valid range for an unsigned 32-bit integer"
 	);
 }
 
 #[test]
 fn config_git_diff_renames_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.diff_renames, true);
 	assert_eq!(config.git.diff_copies, false);
 }
 
 #[test]
 fn config_git_diff_renames_true() {
-	let config = load_with_config_file("diff-renames", "true.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.renames", "true").unwrap();
+	});
 	assert_eq!(config.git.diff_renames, true);
 	assert_eq!(config.git.diff_copies, false);
 }
 
 #[test]
 fn config_git_diff_renames_false() {
-	let config = load_with_config_file("diff-renames", "false.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.renames", "false").unwrap();
+	});
 	assert_eq!(config.git.diff_renames, false);
 	assert_eq!(config.git.diff_copies, false);
 }
 
 #[test]
 fn config_git_diff_renames_copy() {
-	let config = load_with_config_file("diff-renames", "copy.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.renames", "copy").unwrap();
+	});
 	assert_eq!(config.git.diff_renames, true);
 	assert_eq!(config.git.diff_copies, true);
 }
 
 #[test]
 fn config_git_diff_renames_copies() {
-	let config = load_with_config_file("diff-renames", "copies.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.renames", "copies").unwrap();
+	});
 	assert_eq!(config.git.diff_renames, true);
 	assert_eq!(config.git.diff_copies, true);
 }
 
 #[test]
 fn config_git_diff_renames_mixed_case() {
-	let config = load_with_config_file("diff-renames", "mixed-case.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("diff.renames", "cOpIeS").unwrap();
+	});
 	assert_eq!(config.git.diff_renames, true);
 	assert_eq!(config.git.diff_copies, true);
 }
@@ -413,7 +548,9 @@ fn config_git_diff_renames_mixed_case() {
 #[test]
 fn config_git_diff_renames_invalid() {
 	assert_eq!(
-		load_error_with_config_file("diff-renames", "invalid.gitconfig"),
+		load_error(|git_config| {
+			git_config.set_str("diff.renames", "invalid").unwrap();
+		}),
 		"\"diff.renames\" is not valid: \"invalid\" does not match one of \"true\", \"false\", \"copy\" or \"copies\""
 	);
 }
@@ -423,7 +560,7 @@ fn config_git_diff_renames_invalid() {
 fn config_git_editor_default_no_env() {
 	remove_var("VISUAL");
 	remove_var("EDITOR");
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.editor, "vi");
 }
 
@@ -432,7 +569,7 @@ fn config_git_editor_default_no_env() {
 fn config_git_editor_default_visual_env() {
 	remove_var("EDITOR");
 	set_var("VISUAL", "visual-editor");
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.editor, "visual-editor");
 }
 
@@ -441,7 +578,7 @@ fn config_git_editor_default_visual_env() {
 fn config_git_editor_default_editor_env() {
 	remove_var("VISUAL");
 	set_var("EDITOR", "editor");
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.git.editor, "editor");
 }
 
@@ -450,253 +587,80 @@ fn config_git_editor_default_editor_env() {
 fn config_git_editor() {
 	remove_var("VISUAL");
 	remove_var("EDITOR");
-	let config = load_with_config_file("editor", ".gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("core.editor", "custom").unwrap();
+	});
 	assert_eq!(config.git.editor, "custom");
 }
 
 #[test]
 #[serial]
+#[allow(unsafe_code)]
 fn config_git_editor_invalid() {
 	remove_var("VISUAL");
 	remove_var("EDITOR");
 	assert_eq!(
-		load_error_with_config_file("editor", "invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str("core.editor", String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str())
+				.unwrap();
+		}),
 		"\"core.editor\" is not valid: configuration value is not valid utf8"
 	);
 }
 
-#[test]
-fn config_key_bindings_key_mixed_case() {
-	let config = load_with_config_file("key-bindings", "key-mixed-case.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Backspace");
+#[rstest(
+	binding,
+	expected,
+	case::backspace("backspace", "Backspace"),
+	case::backtab("backtab", "BackTab"),
+	case::delete("delete", "Delete"),
+	case::down("down", "Down"),
+	case::end("end", "End"),
+	case::home("home", "Home"),
+	case::insert("insert", "Insert"),
+	case::left("left", "Left"),
+	case::pagedown("pagedown", "PageDown"),
+	case::pageup("pageup", "PageUp"),
+	case::right("right", "Right"),
+	case::tab("tab", "Tab"),
+	case::up("up", "Up"),
+	case::f1("f1", "F1"),
+	case::f255("f255", "F255"),
+	case::modifier_character_lowercase("Control+a", "Controla"),
+	case::modifier_character_uppercase("Control+A", "ControlA"),
+	case::modifier_character_number("Control+1", "Control1"),
+	case::modifier_character_special("Control++", "Control+"),
+	case::modifier_character("Control+a", "Controla"),
+	case::modifier_special("Control+End", "ControlEnd"),
+	case::modifier_function("Control+F32", "ControlF32"),
+	case::modifier_control_alt_shift_out_of_order_1("Alt+Shift+Control+End", "ShiftControlAltEnd"),
+	case::modifier_control_alt_shift_out_of_order_2("Shift+Control+Alt+End", "ShiftControlAltEnd"),
+	case::modifier_only_shift("Shift+End", "ShiftEnd"),
+	case::modifier_only_control("Control+End", "ControlEnd"),
+	case::modifier_only_control("Alt+End", "AltEnd")
+)]
+fn config_key_bindings(binding: &str, expected: &str) {
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputAbort", binding)
+			.unwrap();
+	});
+	assert_eq!(config.key_bindings.abort, expected);
 }
 
 #[test]
-fn config_key_bindings_key_backspace() {
-	let config = load_with_config_file("key-bindings", "key-backspace.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Backspace");
-}
-
-#[test]
-fn config_key_bindings_key_delete() {
-	let config = load_with_config_file("key-bindings", "key-delete.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Delete");
-}
-
-#[test]
-fn config_key_bindings_key_down() {
-	let config = load_with_config_file("key-bindings", "key-down.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Down");
-}
-
-#[test]
-fn config_key_bindings_key_end() {
-	let config = load_with_config_file("key-bindings", "key-end.gitconfig");
-	assert_eq!(config.key_bindings.abort, "End");
-}
-
-#[test]
-fn config_key_bindings_key_enter() {
-	let config = load_with_config_file("key-bindings", "key-enter.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Enter");
-}
-
-#[test]
-fn config_key_bindings_key_f0() {
-	let config = load_with_config_file("key-bindings", "key-f0.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F0");
-}
-
-#[test]
-fn config_key_bindings_key_f1() {
-	let config = load_with_config_file("key-bindings", "key-f1.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F1");
-}
-
-#[test]
-fn config_key_bindings_key_f2() {
-	let config = load_with_config_file("key-bindings", "key-f2.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F2");
-}
-
-#[test]
-fn config_key_bindings_key_f3() {
-	let config = load_with_config_file("key-bindings", "key-f3.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F3");
-}
-
-#[test]
-fn config_key_bindings_key_f4() {
-	let config = load_with_config_file("key-bindings", "key-f4.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F4");
-}
-
-#[test]
-fn config_key_bindings_key_f5() {
-	let config = load_with_config_file("key-bindings", "key-f5.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F5");
-}
-
-#[test]
-fn config_key_bindings_key_f6() {
-	let config = load_with_config_file("key-bindings", "key-f6.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F6");
-}
-
-#[test]
-fn config_key_bindings_key_f7() {
-	let config = load_with_config_file("key-bindings", "key-f7.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F7");
-}
-
-#[test]
-fn config_key_bindings_key_f8() {
-	let config = load_with_config_file("key-bindings", "key-f8.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F8");
-}
-
-#[test]
-fn config_key_bindings_key_f9() {
-	let config = load_with_config_file("key-bindings", "key-f9.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F9");
-}
-
-#[test]
-fn config_key_bindings_key_f10() {
-	let config = load_with_config_file("key-bindings", "key-f10.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F10");
-}
-
-#[test]
-fn config_key_bindings_key_f11() {
-	let config = load_with_config_file("key-bindings", "key-f11.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F11");
-}
-
-#[test]
-fn config_key_bindings_key_f12() {
-	let config = load_with_config_file("key-bindings", "key-f12.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F12");
-}
-
-#[test]
-fn config_key_bindings_key_f13() {
-	let config = load_with_config_file("key-bindings", "key-f13.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F13");
-}
-
-#[test]
-fn config_key_bindings_key_f14() {
-	let config = load_with_config_file("key-bindings", "key-f14.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F14");
-}
-
-#[test]
-fn config_key_bindings_key_f15() {
-	let config = load_with_config_file("key-bindings", "key-f15.gitconfig");
-	assert_eq!(config.key_bindings.abort, "F15");
-}
-
-#[test]
-fn config_key_bindings_key_home() {
-	let config = load_with_config_file("key-bindings", "key-home.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Home");
-}
-
-#[test]
-fn config_key_bindings_key_insert() {
-	let config = load_with_config_file("key-bindings", "key-insert.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Insert");
-}
-
-#[test]
-fn config_key_bindings_key_left() {
-	let config = load_with_config_file("key-bindings", "key-left.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Left");
-}
-
-#[test]
-fn config_key_bindings_key_pagedown() {
-	let config = load_with_config_file("key-bindings", "key-pagedown.gitconfig");
-	assert_eq!(config.key_bindings.abort, "PageDown");
-}
-
-#[test]
-fn config_key_bindings_key_pageup() {
-	let config = load_with_config_file("key-bindings", "key-pageup.gitconfig");
-	assert_eq!(config.key_bindings.abort, "PageUp");
-}
-
-#[test]
-fn config_key_bindings_key_right() {
-	let config = load_with_config_file("key-bindings", "key-right.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Right");
-}
-
-#[test]
-fn config_key_bindings_key_shift_delete() {
-	let config = load_with_config_file("key-bindings", "key-shift-delete.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftDelete");
-}
-
-#[test]
-fn config_key_bindings_key_shift_down() {
-	let config = load_with_config_file("key-bindings", "key-shift-down.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftDown");
-}
-
-#[test]
-fn config_key_bindings_key_shift_end() {
-	let config = load_with_config_file("key-bindings", "key-shift-end.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftEnd");
-}
-
-#[test]
-fn config_key_bindings_key_shift_home() {
-	let config = load_with_config_file("key-bindings", "key-shift-home.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftHome");
-}
-
-#[test]
-fn config_key_bindings_key_shift_left() {
-	let config = load_with_config_file("key-bindings", "key-shift-left.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftLeft");
-}
-
-#[test]
-fn config_key_bindings_key_shift_right() {
-	let config = load_with_config_file("key-bindings", "key-shift-right.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftRight");
-}
-
-#[test]
-fn config_key_bindings_key_shift_tab() {
-	let config = load_with_config_file("key-bindings", "key-shift-tab.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftTab");
-}
-
-#[test]
-fn config_key_bindings_key_shift_up() {
-	let config = load_with_config_file("key-bindings", "key-shift-up.gitconfig");
-	assert_eq!(config.key_bindings.abort, "ShiftUp");
-}
-
-#[test]
-fn config_key_bindings_key_tab() {
-	let config = load_with_config_file("key-bindings", "key-tab.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Tab");
-}
-
-#[test]
-fn config_key_bindings_key_up() {
-	let config = load_with_config_file("key-bindings", "key-up.gitconfig");
-	assert_eq!(config.key_bindings.abort, "Up");
-}
-
-#[test]
+#[allow(unsafe_code)]
 fn config_key_bindings_invalid() {
 	assert_eq!(
-		load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"interactive-rebase-tool.inputAbort",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.inputAbort\" is not valid: configuration value is not valid utf8"
 	);
 }
@@ -704,581 +668,791 @@ fn config_key_bindings_invalid() {
 #[test]
 fn config_key_bindings_key_multiple_characters() {
 	assert_eq!(
-		load_error_with_config_file("key-bindings", "key-multiple-characters.gitconfig"),
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.inputAbort", "abcd")
+				.unwrap();
+		}),
 		"Error reading git config: interactive-rebase-tool.inputAbort must contain only one character"
 	);
 }
 
 #[test]
+fn config_key_bindings_key_invalid_function_index() {
+	assert_eq!(
+		load_error(|git_config| {
+			git_config
+				.set_str("interactive-rebase-tool.inputAbort", "F256")
+				.unwrap();
+		}),
+		"Error reading git config: interactive-rebase-tool.inputAbort must contain only one character"
+	);
+}
+
+#[test]
+#[allow(unsafe_code)]
 fn config_key_bindings_key_invalid() {
 	assert_eq!(
-		load_error_with_config_file("key-bindings", "key-invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"interactive-rebase-tool.inputAbort",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.inputAbort\" is not valid: configuration value is not valid utf8"
 	);
 }
 
 #[test]
 fn config_key_bindings_abort_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.abort, "q");
 }
 
 #[test]
 fn config_key_bindings_abort() {
-	let config = load_with_config_file("key-bindings", "abort.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.inputAbort", "X").unwrap();
+	});
 	assert_eq!(config.key_bindings.abort, "X");
 }
 
 #[test]
 fn config_key_bindings_action_break_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_break, "b");
 }
 
 #[test]
 fn config_key_bindings_action_break() {
-	let config = load_with_config_file("key-bindings", "action-break.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionBreak", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_break, "X");
 }
 
 #[test]
 fn config_key_bindings_action_drop_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_drop, "d");
 }
 
 #[test]
 fn config_key_bindings_action_drop() {
-	let config = load_with_config_file("key-bindings", "action-drop.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionDrop", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_drop, "X");
 }
 
 #[test]
 fn config_key_bindings_action_edit_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_edit, "e");
 }
 
 #[test]
 fn config_key_bindings_action_edit() {
-	let config = load_with_config_file("key-bindings", "action-edit.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionEdit", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_edit, "X");
 }
 
 #[test]
 fn config_key_bindings_action_fixup_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_fixup, "f");
 }
 
 #[test]
 fn config_key_bindings_action_fixup() {
-	let config = load_with_config_file("key-bindings", "action-fixup.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionFixup", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_fixup, "X");
 }
 
 #[test]
 fn config_key_bindings_action_pick_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_pick, "p");
 }
 
 #[test]
 fn config_key_bindings_action_pick() {
-	let config = load_with_config_file("key-bindings", "action-pick.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionPick", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_pick, "X");
 }
 
 #[test]
 fn config_key_bindings_action_reword_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_reword, "r");
 }
 
 #[test]
 fn config_key_bindings_action_reword() {
-	let config = load_with_config_file("key-bindings", "action-reword.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionReword", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_reword, "X");
 }
 
 #[test]
 fn config_key_bindings_action_squash_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.action_squash, "s");
 }
 
 #[test]
 fn config_key_bindings_action_squash() {
-	let config = load_with_config_file("key-bindings", "action-squash.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputActionSquash", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.action_squash, "X");
 }
 
 #[test]
 fn config_key_bindings_confirm_no_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.confirm_no, "n");
 }
 
 #[test]
 fn config_key_bindings_confirm_no() {
-	let config = load_with_config_file("key-bindings", "confirm-no.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputConfirmNo", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.confirm_no, "X");
 }
 
 #[test]
 fn config_key_bindings_confirm_yes_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.confirm_yes, "y");
 }
 
 #[test]
 fn config_key_bindings_confirm_yes() {
-	let config = load_with_config_file("key-bindings", "confirm-yes.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputConfirmYes", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.confirm_yes, "X");
 }
 
 #[test]
 fn config_key_bindings_edit_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.edit, "E");
 }
 
 #[test]
 fn config_key_bindings_confirm_edit() {
-	let config = load_with_config_file("key-bindings", "edit.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.inputEdit", "X").unwrap();
+	});
 	assert_eq!(config.key_bindings.edit, "X");
 }
 
 #[test]
 fn config_key_bindings_force_abort_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.force_abort, "Q");
 }
 
 #[test]
 fn config_key_bindings_force_abort() {
-	let config = load_with_config_file("key-bindings", "force-abort.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputForceAbort", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.force_abort, "X");
 }
 
 #[test]
 fn config_key_bindings_force_rebase_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.force_rebase, "W");
 }
 
 #[test]
 fn config_key_bindings_force_rebase() {
-	let config = load_with_config_file("key-bindings", "force-rebase.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputForceRebase", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.force_rebase, "X");
 }
 
 #[test]
 fn config_key_bindings_help_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.help, "?");
 }
 
 #[test]
 fn config_key_bindings_help() {
-	let config = load_with_config_file("key-bindings", "help.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.inputHelp", "X").unwrap();
+	});
 	assert_eq!(config.key_bindings.help, "X");
 }
 
 #[test]
 fn config_key_bindings_move_down_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_down, "Down");
 }
 
 #[test]
 fn config_key_bindings_move_down() {
-	let config = load_with_config_file("key-bindings", "move-down.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveDown", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_down, "X");
 }
 
 #[test]
 fn config_key_bindings_move_left_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_left, "Left");
 }
 
 #[test]
 fn config_key_bindings_move_left() {
-	let config = load_with_config_file("key-bindings", "move-left.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveLeft", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_left, "X");
 }
 
 #[test]
 fn config_key_bindings_move_right_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_right, "Right");
 }
 
 #[test]
 fn config_key_bindings_move_right() {
-	let config = load_with_config_file("key-bindings", "move-right.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveRight", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_right, "X");
 }
 
 #[test]
 fn config_key_bindings_move_step_up_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_up_step, "PageUp");
 }
 
 #[test]
 fn config_key_bindings_move_step_up() {
-	let config = load_with_config_file("key-bindings", "move-step-up.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveStepUp", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_up_step, "X");
 }
 
 #[test]
 fn config_key_bindings_move_step_down_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_down_step, "PageDown");
 }
 
 #[test]
 fn config_key_bindings_move_step_down() {
-	let config = load_with_config_file("key-bindings", "move-step-down.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveStepDown", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_down_step, "X");
 }
 
 #[test]
 fn config_key_bindings_move_selection_down_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_selection_down, "j");
 }
 
 #[test]
 fn config_key_bindings_move_selection_down() {
-	let config = load_with_config_file("key-bindings", "move-selection-down.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveSelectionDown", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_selection_down, "X");
 }
 
 #[test]
 fn config_key_bindings_move_selection_up_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_selection_up, "k");
 }
 
 #[test]
 fn config_key_bindings_move_selection_up() {
-	let config = load_with_config_file("key-bindings", "move-selection-up.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputMoveSelectionUp", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.move_selection_up, "X");
 }
 
 #[test]
 fn config_key_bindings_move_up_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.move_up, "Up");
 }
 
 #[test]
 fn config_key_bindings_move_up() {
-	let config = load_with_config_file("key-bindings", "move-up.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.inputMoveUp", "X").unwrap();
+	});
 	assert_eq!(config.key_bindings.move_up, "X");
 }
 
 #[test]
 fn config_key_bindings_open_in_external_editor_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.open_in_external_editor, "!");
 }
 
 #[test]
 fn config_key_bindings_open_in_external_editor() {
-	let config = load_with_config_file("key-bindings", "open-in-external-editor.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputOpenInExternalEditor", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.open_in_external_editor, "X");
 }
 
 #[test]
 fn config_key_bindings_rebase_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.rebase, "w");
 }
 
 #[test]
 fn config_key_bindings_rebase() {
-	let config = load_with_config_file("key-bindings", "rebase.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.inputRebase", "X").unwrap();
+	});
 	assert_eq!(config.key_bindings.rebase, "X");
 }
 
 #[test]
 fn config_key_bindings_show_commit_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.show_commit, "c");
 }
 
 #[test]
 fn config_key_bindings_show_commit() {
-	let config = load_with_config_file("key-bindings", "show-commit.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputShowCommit", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.show_commit, "X");
 }
 
 #[test]
 fn config_key_bindings_show_diff_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.show_diff, "d");
 }
 
 #[test]
 fn config_key_bindings_show_diff() {
-	let config = load_with_config_file("key-bindings", "show-diff.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputShowDiff", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.show_diff, "X");
 }
 
 #[test]
 fn config_key_bindings_toggle_visual_mode_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.key_bindings.toggle_visual_mode, "v");
 }
 
 #[test]
 fn config_key_bindings_toggle_visual_mode() {
-	let config = load_with_config_file("key-bindings", "toggle-visual-mode.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.inputToggleVisualMode", "X")
+			.unwrap();
+	});
 	assert_eq!(config.key_bindings.toggle_visual_mode, "X");
 }
 
 #[test]
 fn config_theme_character_vertical_spacing_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.character_vertical_spacing, "~");
 }
 
 #[test]
 fn config_theme_character_vertical_spacing() {
-	let config = load_with_config_file("theme", "character-vertical-spacing.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.verticalSpacingCharacter", "X")
+			.unwrap();
+	});
 	assert_eq!(config.theme.character_vertical_spacing, "X");
 }
 
 #[test]
 fn config_theme_color_action_break_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_break, Color::LightWhite);
 }
 
 #[test]
 fn config_theme_color_action_break() {
-	let config = load_with_config_file("theme", "color-action-break.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.breakColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_break, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_drop_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_drop, Color::LightRed);
 }
 
 #[test]
 fn config_theme_color_action_drop() {
-	let config = load_with_config_file("theme", "color-action-drop.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.dropColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_drop, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_edit_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_edit, Color::LightBlue);
 }
 
 #[test]
 fn config_theme_color_action_edit() {
-	let config = load_with_config_file("theme", "color-action-edit.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.editColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_edit, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_exec_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_exec, Color::LightWhite);
 }
 
 #[test]
 fn config_theme_color_action_exec() {
-	let config = load_with_config_file("theme", "color-action-exec.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.execColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_exec, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_fixup_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_fixup, Color::LightMagenta);
 }
 
 #[test]
 fn config_theme_color_action_fixup() {
-	let config = load_with_config_file("theme", "color-action-fixup.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.fixupColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_fixup, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_pick_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_pick, Color::LightGreen);
 }
 
 #[test]
 fn config_theme_color_action_pick() {
-	let config = load_with_config_file("theme", "color-action-pick.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.pickColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_pick, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_reword_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_reword, Color::LightYellow);
 }
 
 #[test]
 fn config_theme_color_action_reword() {
-	let config = load_with_config_file("theme", "color-action-reword.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.rewordColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_reword, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_action_squash_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_action_squash, Color::LightCyan);
 }
 
 #[test]
 fn config_theme_color_action_squash() {
-	let config = load_with_config_file("theme", "color-action-squash.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.squashColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_squash, Color::Index(10));
 }
 
 #[test]
+fn config_theme_color_action_label_default() {
+	let config = load(|_| {});
+	assert_eq!(config.theme.color_action_label, Color::DarkYellow);
+}
+
+#[test]
 fn config_theme_color_action_label() {
-	let config = load_with_config_file("theme", "color-action-label.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.labelColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_label, Color::Index(10));
 }
 
 #[test]
+fn config_theme_color_action_reset_default() {
+	let config = load(|_| {});
+	assert_eq!(config.theme.color_action_reset, Color::DarkYellow);
+}
+
+#[test]
 fn config_theme_color_action_reset() {
-	let config = load_with_config_file("theme", "color-action-reset.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.resetColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_reset, Color::Index(10));
 }
 
 #[test]
+fn config_theme_color_action_merge_default() {
+	let config = load(|_| {});
+	assert_eq!(config.theme.color_action_merge, Color::DarkYellow);
+}
+
+#[test]
 fn config_theme_color_action_merge() {
-	let config = load_with_config_file("theme", "color-action-merge.gitconfig");
+	let config = load(|git_config| {
+		git_config.set_str("interactive-rebase-tool.mergeColor", "10").unwrap();
+	});
 	assert_eq!(config.theme.color_action_merge, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_background_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_background, Color::Default);
 }
 
 #[test]
 fn config_theme_color_background() {
-	let config = load_with_config_file("theme", "color-background.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.backgroundColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_background, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_diff_add_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_diff_add, Color::LightGreen);
 }
 
 #[test]
 fn config_theme_color_diff_add() {
-	let config = load_with_config_file("theme", "color-diff-add.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffAddColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_diff_add, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_diff_change_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_diff_change, Color::LightYellow);
 }
 
 #[test]
 fn config_theme_color_diff_change() {
-	let config = load_with_config_file("theme", "color-diff-change.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffChangeColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_diff_change, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_diff_context_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_diff_context, Color::LightWhite);
 }
 
 #[test]
 fn config_theme_color_diff_context() {
-	let config = load_with_config_file("theme", "color-diff-context.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffContextColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_diff_context, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_diff_remove_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_diff_remove, Color::LightRed);
 }
 
 #[test]
 fn config_theme_color_diff_remove() {
-	let config = load_with_config_file("theme", "color-diff-remove.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffRemoveColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_diff_remove, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_diff_whitespace_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_diff_whitespace, Color::LightBlack);
 }
 
 #[test]
 fn config_theme_color_diff_whitespace() {
-	let config = load_with_config_file("theme", "color-diff-whitespace.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.diffWhitespace", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_diff_whitespace, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_foreground_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_foreground, Color::Default);
 }
 
 #[test]
 fn config_theme_color_foreground() {
-	let config = load_with_config_file("theme", "color-foreground.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.foregroundColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_foreground, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_indicator_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_indicator, Color::LightCyan);
 }
 
 #[test]
 fn config_theme_color_indicator() {
-	let config = load_with_config_file("theme", "color-indicator.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.indicatorColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_indicator, Color::Index(10));
 }
 
 #[test]
 fn config_theme_color_selected_background_default() {
-	let config = load_with_config_file("empty", ".gitconfig");
+	let config = load(|_| {});
 	assert_eq!(config.theme.color_selected_background, Color::Index(237));
 }
 
 #[test]
 fn config_theme_color_selected() {
-	let config = load_with_config_file("theme", "color-selected-background.gitconfig");
+	let config = load(|git_config| {
+		git_config
+			.set_str("interactive-rebase-tool.selectedBackgroundColor", "10")
+			.unwrap();
+	});
 	assert_eq!(config.theme.color_selected_background, Color::Index(10));
 }
 
 #[test]
+#[allow(unsafe_code)]
 fn config_theme_color_invalid() {
 	assert_eq!(
-		load_error_with_config_file("theme", "color-invalid.gitconfig"),
+		load_error(|git_config| unsafe {
+			git_config
+				.set_str(
+					"interactive-rebase-tool.breakColor",
+					String::from_utf8_unchecked(vec![0xC3, 0x28]).as_str(),
+				)
+				.unwrap();
+		}),
 		"\"interactive-rebase-tool.breakColor\" is not valid: configuration value is not valid utf8"
 	);
 }
@@ -1286,7 +1460,9 @@ fn config_theme_color_invalid() {
 #[test]
 fn config_theme_color_invalid_range_under() {
 	assert_eq!(
-		load_error_with_config_file("theme", "color-invalid-range-under.gitconfig"),
+		load_error(|git_config| {
+			git_config.set_str("interactive-rebase-tool.breakColor", "-2").unwrap();
+		}),
 		"\"interactive-rebase-tool.breakColor\" is not valid: \"-2\" is not a valid color index. Index must be \
 		 between 0-255."
 	);
@@ -1295,7 +1471,9 @@ fn config_theme_color_invalid_range_under() {
 #[test]
 fn config_theme_color_invalid_range_above() {
 	assert_eq!(
-		load_error_with_config_file("theme", "color-invalid-range-above.gitconfig"),
+		load_error(|git_config| {
+			git_config.set_str("interactive-rebase-tool.breakColor", "256").unwrap();
+		}),
 		"\"interactive-rebase-tool.breakColor\" is not valid: \"256\" is not a valid color index. Index must be \
 		 between 0-255."
 	);

--- a/test/fixtures/config/README.md
+++ b/test/fixtures/config/README.md
@@ -1,1 +1,0 @@
-Some of the files in this directory contain invalid character sequences that might not open in some editors.

--- a/test/fixtures/config/auto-select-next/false.gitconfig
+++ b/test/fixtures/config/auto-select-next/false.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-autoSelectNext=false

--- a/test/fixtures/config/auto-select-next/invalid.gitconfig
+++ b/test/fixtures/config/auto-select-next/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-autoSelectNext=invalid

--- a/test/fixtures/config/auto-select-next/true.gitconfig
+++ b/test/fixtures/config/auto-select-next/true.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-autoSelectNext=true

--- a/test/fixtures/config/comment-char/.gitconfig
+++ b/test/fixtures/config/comment-char/.gitconfig
@@ -1,2 +1,0 @@
-[core]
-commentChar=";"

--- a/test/fixtures/config/comment-char/auto.gitconfig
+++ b/test/fixtures/config/comment-char/auto.gitconfig
@@ -1,2 +1,0 @@
-[core]
-commentChar="auto"

--- a/test/fixtures/config/comment-char/invalid.gitconfig
+++ b/test/fixtures/config/comment-char/invalid.gitconfig
@@ -1,2 +1,0 @@
-[core]
-commentChar=€¿

--- a/test/fixtures/config/diff-context/.gitconfig
+++ b/test/fixtures/config/diff-context/.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-context=5

--- a/test/fixtures/config/diff-context/invalid-range.gitconfig
+++ b/test/fixtures/config/diff-context/invalid-range.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-context=-100

--- a/test/fixtures/config/diff-context/invalid.gitconfig
+++ b/test/fixtures/config/diff-context/invalid.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-context=invalid

--- a/test/fixtures/config/diff-ignore-whitespace/all.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/all.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=all

--- a/test/fixtures/config/diff-ignore-whitespace/change.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/change.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=change

--- a/test/fixtures/config/diff-ignore-whitespace/false.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/false.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=false

--- a/test/fixtures/config/diff-ignore-whitespace/invalid.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=invalid

--- a/test/fixtures/config/diff-ignore-whitespace/mixed-case.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/mixed-case.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=ChAnGe

--- a/test/fixtures/config/diff-ignore-whitespace/none.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/none.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=none

--- a/test/fixtures/config/diff-ignore-whitespace/off.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/off.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=off

--- a/test/fixtures/config/diff-ignore-whitespace/on.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/on.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=on

--- a/test/fixtures/config/diff-ignore-whitespace/true.gitconfig
+++ b/test/fixtures/config/diff-ignore-whitespace/true.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffIgnoreWhitespace=true

--- a/test/fixtures/config/diff-renames/copies.gitconfig
+++ b/test/fixtures/config/diff-renames/copies.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=cOpIeS

--- a/test/fixtures/config/diff-renames/copy.gitconfig
+++ b/test/fixtures/config/diff-renames/copy.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=copy

--- a/test/fixtures/config/diff-renames/false.gitconfig
+++ b/test/fixtures/config/diff-renames/false.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=false

--- a/test/fixtures/config/diff-renames/invalid.gitconfig
+++ b/test/fixtures/config/diff-renames/invalid.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=invalid

--- a/test/fixtures/config/diff-renames/mixed-case.gitconfig
+++ b/test/fixtures/config/diff-renames/mixed-case.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=copies

--- a/test/fixtures/config/diff-renames/true.gitconfig
+++ b/test/fixtures/config/diff-renames/true.gitconfig
@@ -1,2 +1,0 @@
-[diff]
-renames=true

--- a/test/fixtures/config/diff-show-whitespace/both.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/both.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=both

--- a/test/fixtures/config/diff-show-whitespace/false.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/false.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=false

--- a/test/fixtures/config/diff-show-whitespace/invalid.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=invalid

--- a/test/fixtures/config/diff-show-whitespace/leading.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/leading.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=leading

--- a/test/fixtures/config/diff-show-whitespace/mixed-case.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/mixed-case.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=TrAiLiNg

--- a/test/fixtures/config/diff-show-whitespace/none.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/none.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=none

--- a/test/fixtures/config/diff-show-whitespace/off.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/off.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=off

--- a/test/fixtures/config/diff-show-whitespace/on.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/on.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=on

--- a/test/fixtures/config/diff-show-whitespace/trailing.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/trailing.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=trailing

--- a/test/fixtures/config/diff-show-whitespace/true.gitconfig
+++ b/test/fixtures/config/diff-show-whitespace/true.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffShowWhitespace=true

--- a/test/fixtures/config/diff-space-symbol/.gitconfig
+++ b/test/fixtures/config/diff-space-symbol/.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffSpaceSymbol=-

--- a/test/fixtures/config/diff-space-symbol/invalid.gitconfig
+++ b/test/fixtures/config/diff-space-symbol/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffSpaceSymbol=€¿

--- a/test/fixtures/config/diff-tab-symbol/.gitconfig
+++ b/test/fixtures/config/diff-tab-symbol/.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffTabSymbol=|

--- a/test/fixtures/config/diff-tab-symbol/invalid.gitconfig
+++ b/test/fixtures/config/diff-tab-symbol/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffTabSymbol=€¿

--- a/test/fixtures/config/diff-tab-width/.gitconfig
+++ b/test/fixtures/config/diff-tab-width/.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffTabWidth=14

--- a/test/fixtures/config/diff-tab-width/invalid-range.gitconfig
+++ b/test/fixtures/config/diff-tab-width/invalid-range.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffTabWidth=-100

--- a/test/fixtures/config/diff-tab-width/invalid.gitconfig
+++ b/test/fixtures/config/diff-tab-width/invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffTabWidth=invalid

--- a/test/fixtures/config/editor/.gitconfig
+++ b/test/fixtures/config/editor/.gitconfig
@@ -1,2 +1,0 @@
-[core]
-editor=custom

--- a/test/fixtures/config/editor/invalid.gitconfig
+++ b/test/fixtures/config/editor/invalid.gitconfig
@@ -1,2 +1,0 @@
-[core]
-editor=€¿

--- a/test/fixtures/config/key-bindings/abort.gitconfig
+++ b/test/fixtures/config/key-bindings/abort.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=X

--- a/test/fixtures/config/key-bindings/action-break.gitconfig
+++ b/test/fixtures/config/key-bindings/action-break.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionBreak=X

--- a/test/fixtures/config/key-bindings/action-drop.gitconfig
+++ b/test/fixtures/config/key-bindings/action-drop.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionDrop=X

--- a/test/fixtures/config/key-bindings/action-edit.gitconfig
+++ b/test/fixtures/config/key-bindings/action-edit.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionEdit=X

--- a/test/fixtures/config/key-bindings/action-fixup.gitconfig
+++ b/test/fixtures/config/key-bindings/action-fixup.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionFixup=X

--- a/test/fixtures/config/key-bindings/action-pick.gitconfig
+++ b/test/fixtures/config/key-bindings/action-pick.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionPick=X

--- a/test/fixtures/config/key-bindings/action-reword.gitconfig
+++ b/test/fixtures/config/key-bindings/action-reword.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionReword=X

--- a/test/fixtures/config/key-bindings/action-squash.gitconfig
+++ b/test/fixtures/config/key-bindings/action-squash.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputActionSquash=X

--- a/test/fixtures/config/key-bindings/confirm-no.gitconfig
+++ b/test/fixtures/config/key-bindings/confirm-no.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputConfirmNo=X

--- a/test/fixtures/config/key-bindings/confirm-yes.gitconfig
+++ b/test/fixtures/config/key-bindings/confirm-yes.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputConfirmYes=X

--- a/test/fixtures/config/key-bindings/edit.gitconfig
+++ b/test/fixtures/config/key-bindings/edit.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputEdit=X

--- a/test/fixtures/config/key-bindings/force-abort.gitconfig
+++ b/test/fixtures/config/key-bindings/force-abort.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputForceAbort=X

--- a/test/fixtures/config/key-bindings/force-rebase.gitconfig
+++ b/test/fixtures/config/key-bindings/force-rebase.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputForceRebase=X

--- a/test/fixtures/config/key-bindings/help.gitconfig
+++ b/test/fixtures/config/key-bindings/help.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputHelp=X

--- a/test/fixtures/config/key-bindings/key-backspace.gitconfig
+++ b/test/fixtures/config/key-bindings/key-backspace.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=backspace

--- a/test/fixtures/config/key-bindings/key-delete.gitconfig
+++ b/test/fixtures/config/key-bindings/key-delete.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=delete

--- a/test/fixtures/config/key-bindings/key-down.gitconfig
+++ b/test/fixtures/config/key-bindings/key-down.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=down

--- a/test/fixtures/config/key-bindings/key-end.gitconfig
+++ b/test/fixtures/config/key-bindings/key-end.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=end

--- a/test/fixtures/config/key-bindings/key-enter.gitconfig
+++ b/test/fixtures/config/key-bindings/key-enter.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=enter

--- a/test/fixtures/config/key-bindings/key-f0.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f0.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f0

--- a/test/fixtures/config/key-bindings/key-f1.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f1.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f1

--- a/test/fixtures/config/key-bindings/key-f10.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f10.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f10

--- a/test/fixtures/config/key-bindings/key-f11.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f11.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f11

--- a/test/fixtures/config/key-bindings/key-f12.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f12.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f12

--- a/test/fixtures/config/key-bindings/key-f13.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f13.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f13

--- a/test/fixtures/config/key-bindings/key-f14.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f14.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f14

--- a/test/fixtures/config/key-bindings/key-f15.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f15.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f15

--- a/test/fixtures/config/key-bindings/key-f2.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f2.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f2

--- a/test/fixtures/config/key-bindings/key-f3.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f3.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f3

--- a/test/fixtures/config/key-bindings/key-f4.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f4.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f4

--- a/test/fixtures/config/key-bindings/key-f5.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f5.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f5

--- a/test/fixtures/config/key-bindings/key-f6.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f6.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f6

--- a/test/fixtures/config/key-bindings/key-f7.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f7.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f7

--- a/test/fixtures/config/key-bindings/key-f8.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f8.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f8

--- a/test/fixtures/config/key-bindings/key-f9.gitconfig
+++ b/test/fixtures/config/key-bindings/key-f9.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=f9

--- a/test/fixtures/config/key-bindings/key-home.gitconfig
+++ b/test/fixtures/config/key-bindings/key-home.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=home

--- a/test/fixtures/config/key-bindings/key-insert.gitconfig
+++ b/test/fixtures/config/key-bindings/key-insert.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=insert

--- a/test/fixtures/config/key-bindings/key-invalid.gitconfig
+++ b/test/fixtures/config/key-bindings/key-invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=€¿

--- a/test/fixtures/config/key-bindings/key-left.gitconfig
+++ b/test/fixtures/config/key-bindings/key-left.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=left

--- a/test/fixtures/config/key-bindings/key-mixed-case.gitconfig
+++ b/test/fixtures/config/key-bindings/key-mixed-case.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=bAcKsPaCe

--- a/test/fixtures/config/key-bindings/key-multiple-characters.gitconfig
+++ b/test/fixtures/config/key-bindings/key-multiple-characters.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=abcd

--- a/test/fixtures/config/key-bindings/key-pagedown.gitconfig
+++ b/test/fixtures/config/key-bindings/key-pagedown.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=pagedown

--- a/test/fixtures/config/key-bindings/key-pageup.gitconfig
+++ b/test/fixtures/config/key-bindings/key-pageup.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=pageup

--- a/test/fixtures/config/key-bindings/key-right.gitconfig
+++ b/test/fixtures/config/key-bindings/key-right.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=right

--- a/test/fixtures/config/key-bindings/key-shift-delete.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-delete.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+delete

--- a/test/fixtures/config/key-bindings/key-shift-down.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-down.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+down

--- a/test/fixtures/config/key-bindings/key-shift-end.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-end.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+end

--- a/test/fixtures/config/key-bindings/key-shift-home.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-home.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+home

--- a/test/fixtures/config/key-bindings/key-shift-left.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-left.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+left

--- a/test/fixtures/config/key-bindings/key-shift-right.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-right.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+right

--- a/test/fixtures/config/key-bindings/key-shift-tab.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-tab.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+tab

--- a/test/fixtures/config/key-bindings/key-shift-up.gitconfig
+++ b/test/fixtures/config/key-bindings/key-shift-up.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=shift+up

--- a/test/fixtures/config/key-bindings/key-tab.gitconfig
+++ b/test/fixtures/config/key-bindings/key-tab.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=tab

--- a/test/fixtures/config/key-bindings/key-up.gitconfig
+++ b/test/fixtures/config/key-bindings/key-up.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputAbort=up

--- a/test/fixtures/config/key-bindings/move-down.gitconfig
+++ b/test/fixtures/config/key-bindings/move-down.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveDown=X

--- a/test/fixtures/config/key-bindings/move-left.gitconfig
+++ b/test/fixtures/config/key-bindings/move-left.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveLeft=X

--- a/test/fixtures/config/key-bindings/move-right.gitconfig
+++ b/test/fixtures/config/key-bindings/move-right.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveRight=X

--- a/test/fixtures/config/key-bindings/move-selection-down.gitconfig
+++ b/test/fixtures/config/key-bindings/move-selection-down.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveSelectionDown=X

--- a/test/fixtures/config/key-bindings/move-selection-up.gitconfig
+++ b/test/fixtures/config/key-bindings/move-selection-up.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveSelectionUp=X

--- a/test/fixtures/config/key-bindings/move-step-down.gitconfig
+++ b/test/fixtures/config/key-bindings/move-step-down.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveStepDown=X

--- a/test/fixtures/config/key-bindings/move-step-up.gitconfig
+++ b/test/fixtures/config/key-bindings/move-step-up.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveStepUp=X

--- a/test/fixtures/config/key-bindings/move-up.gitconfig
+++ b/test/fixtures/config/key-bindings/move-up.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputMoveUp=X

--- a/test/fixtures/config/key-bindings/open-in-external-editor.gitconfig
+++ b/test/fixtures/config/key-bindings/open-in-external-editor.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputOpenInExternalEditor=X

--- a/test/fixtures/config/key-bindings/rebase.gitconfig
+++ b/test/fixtures/config/key-bindings/rebase.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputRebase=X

--- a/test/fixtures/config/key-bindings/show-commit.gitconfig
+++ b/test/fixtures/config/key-bindings/show-commit.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputShowCommit=X

--- a/test/fixtures/config/key-bindings/show-diff.gitconfig
+++ b/test/fixtures/config/key-bindings/show-diff.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputShowDiff=X

--- a/test/fixtures/config/key-bindings/toggle-visual-mode.gitconfig
+++ b/test/fixtures/config/key-bindings/toggle-visual-mode.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-inputToggleVisualMode=X

--- a/test/fixtures/config/theme/character-vertical-spacing.gitconfig
+++ b/test/fixtures/config/theme/character-vertical-spacing.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-verticalSpacingCharacter=X

--- a/test/fixtures/config/theme/color-action-break.gitconfig
+++ b/test/fixtures/config/theme/color-action-break.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-breakColor=10

--- a/test/fixtures/config/theme/color-action-drop.gitconfig
+++ b/test/fixtures/config/theme/color-action-drop.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-dropColor=10

--- a/test/fixtures/config/theme/color-action-edit.gitconfig
+++ b/test/fixtures/config/theme/color-action-edit.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-editColor=10

--- a/test/fixtures/config/theme/color-action-exec.gitconfig
+++ b/test/fixtures/config/theme/color-action-exec.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-execColor=10

--- a/test/fixtures/config/theme/color-action-fixup.gitconfig
+++ b/test/fixtures/config/theme/color-action-fixup.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-fixupColor=10

--- a/test/fixtures/config/theme/color-action-label.gitconfig
+++ b/test/fixtures/config/theme/color-action-label.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-labelColor=10

--- a/test/fixtures/config/theme/color-action-merge.gitconfig
+++ b/test/fixtures/config/theme/color-action-merge.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-mergeColor=10

--- a/test/fixtures/config/theme/color-action-pick.gitconfig
+++ b/test/fixtures/config/theme/color-action-pick.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-pickColor=10

--- a/test/fixtures/config/theme/color-action-reset.gitconfig
+++ b/test/fixtures/config/theme/color-action-reset.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-resetColor=10

--- a/test/fixtures/config/theme/color-action-reword.gitconfig
+++ b/test/fixtures/config/theme/color-action-reword.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-rewordColor=10

--- a/test/fixtures/config/theme/color-action-squash.gitconfig
+++ b/test/fixtures/config/theme/color-action-squash.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-squashColor=10

--- a/test/fixtures/config/theme/color-background.gitconfig
+++ b/test/fixtures/config/theme/color-background.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-backgroundColor=10

--- a/test/fixtures/config/theme/color-diff-add.gitconfig
+++ b/test/fixtures/config/theme/color-diff-add.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffAddColor=10

--- a/test/fixtures/config/theme/color-diff-change.gitconfig
+++ b/test/fixtures/config/theme/color-diff-change.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffChangeColor=10

--- a/test/fixtures/config/theme/color-diff-context.gitconfig
+++ b/test/fixtures/config/theme/color-diff-context.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffContextColor=10

--- a/test/fixtures/config/theme/color-diff-remove.gitconfig
+++ b/test/fixtures/config/theme/color-diff-remove.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffRemoveColor=10

--- a/test/fixtures/config/theme/color-diff-whitespace.gitconfig
+++ b/test/fixtures/config/theme/color-diff-whitespace.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-diffWhitespace=10

--- a/test/fixtures/config/theme/color-foreground.gitconfig
+++ b/test/fixtures/config/theme/color-foreground.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-foregroundColor=10

--- a/test/fixtures/config/theme/color-indicator.gitconfig
+++ b/test/fixtures/config/theme/color-indicator.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-indicatorColor=10

--- a/test/fixtures/config/theme/color-invalid-range-above.gitconfig
+++ b/test/fixtures/config/theme/color-invalid-range-above.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-breakColor=256

--- a/test/fixtures/config/theme/color-invalid-range-under.gitconfig
+++ b/test/fixtures/config/theme/color-invalid-range-under.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-breakColor=-2

--- a/test/fixtures/config/theme/color-invalid.gitconfig
+++ b/test/fixtures/config/theme/color-invalid.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-breakColor=€¿

--- a/test/fixtures/config/theme/color-selected-background.gitconfig
+++ b/test/fixtures/config/theme/color-selected-background.gitconfig
@@ -1,2 +1,0 @@
-[interactive-rebase-tool]
-selectedBackgroundColor=10


### PR DESCRIPTION
# Description

Almost all the modifiers with keybindings did not function as intended. This updates the config parsing for keybindings to support all modifiers. As a side effect, the modifiers can now be provided in any
order. Also, since the tests for this were fragile and required a config file per test case, they have been refactored to generate a git configuration as needed instead.