### PR TITLE
Allow external editor from visual mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Modifier keys can now be provided in any order
 - Undo and redo changes to the todo list
 - Support for multiple key bindings per configuration
+- Open external editor from visual mode
 
 ### Fixed
 - Most modifier key combinations could not be used as key bindings

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -310,6 +310,7 @@ impl<'l> List<'l> {
 				self.visual_index_start = None;
 				self.state = ListState::Normal;
 			},
+			Input::OpenInEditor => result = result.state(State::ExternalEditor),
 			Input::Undo => self.undo(rebase_todo),
 			Input::Redo => self.redo(rebase_todo),
 			_ => {},
@@ -2604,6 +2605,25 @@ mod tests {
 				assert_process_result!(test_context.handle_input(&mut module), input = Input::ToggleVisualMode);
 				assert_eq!(module.visual_index_start, None);
 				assert_eq!(module.state, ListState::Normal);
+			},
+		);
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn visual_mode_open_external_editor() {
+		process_module_test(
+			&["pick aaa c1"],
+			ViewState::default(),
+			&[Input::ToggleVisualMode, Input::OpenInEditor],
+			|mut test_context: TestContext<'_>| {
+				let mut module = List::new(test_context.config);
+				test_context.handle_input(&mut module);
+				assert_process_result!(
+					test_context.handle_input(&mut module),
+					input = Input::OpenInEditor,
+					state = State::ExternalEditor
+				);
 			},
 		);
 	}


### PR DESCRIPTION
# Description

Add a key binding to allow the external editor to be opened from visual mode.