### PR TITLE
Avoid view_data resize in modules

### DIFF
--- a/src/components/choice/mod.rs
+++ b/src/components/choice/mod.rs
@@ -46,8 +46,7 @@ where T: Clone
 		self.view_data.push_leading_line(ViewLine::new_empty_line());
 	}
 
-	pub fn get_view_data(&mut self, view_width: usize, view_height: usize) -> &ViewData {
-		self.view_data.set_view_size(view_width, view_height);
+	pub fn get_view_data(&mut self) -> &mut ViewData {
 		self.view_data.clear_body();
 		for &(_, ref key, ref description) in &self.options {
 			self.view_data
@@ -66,8 +65,7 @@ where T: Clone
 				DisplayColor::IndicatorColor,
 			)));
 		}
-		self.view_data.rebuild();
-		&self.view_data
+		&mut self.view_data
 	}
 
 	pub fn handle_input(&mut self, input: Input) -> Option<&T> {

--- a/src/components/choice/tests.rs
+++ b/src/components/choice/tests.rs
@@ -22,7 +22,7 @@ fn create_choices() -> Vec<(TestAction, char, String)> {
 fn render_options_no_prompt() {
 	let mut module = Choice::new(create_choices());
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",
 		"{Normal}a) Description A",
@@ -38,7 +38,7 @@ fn render_options_prompt() {
 	let mut module = Choice::new(create_choices());
 	module.set_prompt(vec![ViewLine::from("Prompt")]);
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{LEADING}",
 		"{Normal}Prompt",
@@ -57,7 +57,7 @@ fn invalid_selection_character() {
 	let mut module = Choice::new(create_choices());
 	assert!(module.handle_input(Input::Character('z')).is_none());
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",
 		"{Normal}a) Description A",
@@ -73,7 +73,7 @@ fn invalid_selection_other() {
 	let mut module = Choice::new(create_choices());
 	assert!(module.handle_input(Input::Other).is_none());
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",
 		"{Normal}a) Description A",
@@ -89,7 +89,7 @@ fn valid_selection() {
 	let mut module = Choice::new(create_choices());
 	assert_eq!(module.handle_input(Input::Character('b')).unwrap(), &TestAction::B);
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",
 		"{Normal}a) Description A",

--- a/src/components/confirm/mod.rs
+++ b/src/components/confirm/mod.rs
@@ -24,9 +24,8 @@ impl Confirm {
 		Self { view_data }
 	}
 
-	pub fn get_view_data(&mut self, view_width: usize, view_height: usize) -> &ViewData {
-		self.view_data.set_view_size(view_width, view_height);
-		&self.view_data
+	pub fn get_view_data(&mut self) -> &mut ViewData {
+		&mut self.view_data
 	}
 
 	pub fn handle_input(&mut self, input: Input) -> Option<bool> {

--- a/src/components/confirm/tests.rs
+++ b/src/components/confirm/tests.rs
@@ -10,7 +10,7 @@ fn render() {
 		String::from("X"),
 	]);
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",
 		"{Normal}Prompt message (y,Z/n,X)? "

--- a/src/components/edit/mod.rs
+++ b/src/components/edit/mod.rs
@@ -76,7 +76,6 @@ impl Edit {
 			"Enter to finish",
 			DisplayColor::IndicatorColor,
 		)]));
-		view_data.rebuild();
 		view_data.ensure_column_visible(pointer);
 		view_data.ensure_line_visible(0);
 	}

--- a/src/components/edit/tests.rs
+++ b/src/components/edit/tests.rs
@@ -8,7 +8,6 @@ fn with_description() {
 	module.set_description("Description");
 	module.handle_input(Input::Right);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -29,7 +28,6 @@ fn with_label() {
 	module.set_label("Label: ");
 	module.handle_input(Input::Right);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -48,7 +46,6 @@ fn with_label_and_description() {
 	module.set_label("Label: ");
 	module.handle_input(Input::Right);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -68,7 +65,6 @@ fn move_cursor_end() {
 	module.set_content("foobar");
 	module.handle_input(Input::Right);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -85,7 +81,6 @@ fn move_cursor_1_left() {
 	module.set_content("foobar");
 	module.handle_input(Input::Left);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -103,7 +98,6 @@ fn move_cursor_2_from_start() {
 	module.handle_input(Input::Left);
 	module.handle_input(Input::Left);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -122,7 +116,6 @@ fn move_cursor_1_from_start() {
 		module.handle_input(Input::Left);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -141,7 +134,6 @@ fn move_cursor_to_start() {
 		module.handle_input(Input::Left);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -158,7 +150,6 @@ fn move_cursor_to_home() {
 	module.set_content("foobar");
 	module.handle_input(Input::Home);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -178,7 +169,6 @@ fn move_cursor_to_end() {
 	}
 	module.handle_input(Input::End);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -197,7 +187,6 @@ fn move_cursor_on_empty_content() {
 	module.handle_input(Input::End);
 	module.handle_input(Input::Home);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -216,7 +205,6 @@ fn move_cursor_attempt_past_start() {
 		module.handle_input(Input::Left);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -235,7 +223,6 @@ fn move_cursor_attempt_past_end() {
 		module.handle_input(Input::Right);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -254,7 +241,6 @@ fn multiple_width_unicode_single_width() {
 		module.handle_input(Input::Left);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -273,7 +259,6 @@ fn multiple_width_unicode_emoji() {
 		module.handle_input(Input::Left);
 	}
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -290,7 +275,6 @@ fn add_character_end() {
 	module.set_content("abcd");
 	module.handle_input(Input::Character('x'));
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -308,7 +292,6 @@ fn add_character_one_from_end() {
 	module.handle_input(Input::Left);
 	module.handle_input(Input::Character('x'));
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -328,7 +311,6 @@ fn add_character_one_from_start() {
 	}
 	module.handle_input(Input::Character('x'));
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -348,7 +330,6 @@ fn add_character_at_start() {
 	}
 	module.handle_input(Input::Character('x'));
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -365,7 +346,6 @@ fn backspace_at_end() {
 	module.set_content("abcd");
 	module.handle_input(Input::Backspace);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -383,7 +363,6 @@ fn backspace_one_from_end() {
 	module.handle_input(Input::Left);
 	module.handle_input(Input::Backspace);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -403,7 +382,6 @@ fn backspace_one_from_start() {
 	}
 	module.handle_input(Input::Backspace);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -423,7 +401,6 @@ fn backspace_at_start() {
 	}
 	module.handle_input(Input::Backspace);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -440,7 +417,6 @@ fn delete_at_end() {
 	module.set_content("abcd");
 	module.handle_input(Input::Delete);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -458,7 +434,6 @@ fn delete_last_character() {
 	module.handle_input(Input::Left);
 	module.handle_input(Input::Delete);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -478,7 +453,6 @@ fn delete_second_character() {
 	}
 	module.handle_input(Input::Delete);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,
@@ -498,7 +472,6 @@ fn delete_first_character() {
 	}
 	module.handle_input(Input::Delete);
 	let view_data = &mut ViewData::new();
-	view_data.set_view_size(500, 30);
 	module.update_view_data(view_data);
 	assert_rendered_output!(
 		view_data,

--- a/src/components/help/mod.rs
+++ b/src/components/help/mod.rs
@@ -66,10 +66,8 @@ impl Help {
 		}
 	}
 
-	pub fn get_view_data(&mut self, view_width: usize, view_height: usize) -> &ViewData {
-		self.view_data.set_view_size(view_width, view_height);
-		self.view_data.rebuild();
-		&self.view_data
+	pub fn get_view_data(&mut self) -> &mut ViewData {
+		&mut self.view_data
 	}
 
 	pub fn handle_input(&mut self, input: Input) {

--- a/src/components/help/tests.rs
+++ b/src/components/help/tests.rs
@@ -8,10 +8,10 @@ use crate::assert_rendered_output;
 fn empty() {
 	let mut module = Help::new_from_keybindings(&[]);
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{LEADING}",
-		"{Normal,Underline} Key Action{Normal,Underline}{Pad  ,89}",
+		"{Normal,Underline} Key Action{Normal,Underline}{Pad  }",
 		"{TRAILING}",
 		"{IndicatorColor}Press any key to close"
 	);
@@ -25,10 +25,10 @@ fn from_key_bindings() {
 		(vec![String::from("b")], String::from("Description B")),
 	]);
 	assert_rendered_output!(
-		module.get_view_data(100, 100),
+		module.get_view_data(),
 		"{TITLE}",
 		"{LEADING}",
-		"{Normal,Underline} Key Action{Normal,Underline}{Pad  ,89}",
+		"{Normal,Underline} Key Action{Normal,Underline}{Pad  }",
 		"{BODY}",
 		"{IndicatorColor} a{Normal,Dimmed}|{Normal}Description A",
 		"{IndicatorColor} b{Normal,Dimmed}|{Normal}Description B",

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -11,9 +11,8 @@ pub struct ConfirmAbort {
 }
 
 impl ProcessModule for ConfirmAbort {
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
-		let view_size = view.get_view_size();
-		self.dialog.get_view_data(view_size.width(), view_size.height())
+	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+		self.dialog.get_view_data()
 	}
 
 	fn handle_input(&mut self, view: &mut View<'_>, rebase_todo: &mut TodoFile) -> ProcessResult {

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -11,9 +11,8 @@ pub struct ConfirmRebase {
 }
 
 impl ProcessModule for ConfirmRebase {
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
-		let view_size = view.get_view_size();
-		self.dialog.get_view_data(view_size.width(), view_size.height())
+	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+		self.dialog.get_view_data()
 	}
 
 	fn handle_input(&mut self, view: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -48,23 +48,18 @@ impl ProcessModule for ExternalEditor {
 		self.view_data.reset();
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
-		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
-
+	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
 		match self.state {
 			ExternalEditorState::Active => {
 				self.view_data.clear();
 				self.view_data.push_leading_line(ViewLine::from("Editing..."));
-				self.view_data.set_view_size(view_width, view_height);
-				self.view_data.rebuild();
-				&self.view_data
+				&mut self.view_data
 			},
-			ExternalEditorState::Empty => self.empty_choice.get_view_data(view_width, view_height),
+			ExternalEditorState::Empty => self.empty_choice.get_view_data(),
 			ExternalEditorState::Error(ref error) => {
 				self.error_choice
 					.set_prompt(error.chain().map(|c| ViewLine::from(format!("{:#}", c))).collect());
-				self.error_choice.get_view_data(view_width, view_height)
+				self.error_choice.get_view_data()
 			},
 		}
 	}

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -28,17 +28,13 @@ impl ProcessModule for Insert {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
-		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
-
+	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
 		match self.state {
-			InsertState::Prompt => self.action_choices.get_view_data(view_width, view_height),
+			InsertState::Prompt => self.action_choices.get_view_data(),
 			InsertState::Edit => {
 				self.edit_view_data.clear();
-				self.edit_view_data.set_view_size(view_width, view_height);
 				self.edit.update_view_data(&mut self.edit_view_data);
-				&self.edit_view_data
+				&mut self.edit_view_data
 			},
 		}
 	}

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -34,18 +34,15 @@ pub struct List<'l> {
 }
 
 impl<'l> ProcessModule for List<'l> {
-	fn build_view_data(&mut self, view: &View<'_>, todo_file: &TodoFile) -> &ViewData {
-		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
+	fn build_view_data(&mut self, view: &View<'_>, todo_file: &TodoFile) -> &mut ViewData {
 		self.view_data.clear();
-		self.view_data.set_view_size(view_width, view_height);
 
 		match self.state {
 			ListState::Normal => self.get_normal_mode_view_data(todo_file, view),
 			ListState::Visual => self.get_visual_mode_view_data(todo_file, view),
 			ListState::Edit => {
 				self.edit.update_view_data(&mut self.view_data);
-				&self.view_data
+				&mut self.view_data
 			},
 		}
 	}
@@ -103,9 +100,8 @@ impl<'l> List<'l> {
 		}
 	}
 
-	fn update_list_view_data(&mut self, todo_file: &TodoFile, view_width: usize, view_height: usize) {
+	fn update_list_view_data(&mut self, todo_file: &TodoFile, view_width: usize) {
 		self.view_data.clear();
-		self.view_data.set_view_size(view_width, view_height);
 		let is_visual_mode = self.state == ListState::Visual;
 		let selected_index = todo_file.get_selected_line_index();
 		let visual_index = self.visual_index_start.unwrap_or(selected_index);
@@ -131,36 +127,33 @@ impl<'l> List<'l> {
 				);
 			}
 		}
-		self.view_data.rebuild();
 		if let Some(visual_index) = self.visual_index_start {
 			self.view_data.ensure_line_visible(visual_index);
 		}
 		self.view_data.ensure_line_visible(selected_index);
 	}
 
-	fn get_visual_mode_view_data(&mut self, todo_file: &TodoFile, view: &View<'_>) -> &ViewData {
+	fn get_visual_mode_view_data(&mut self, todo_file: &TodoFile, view: &View<'_>) -> &mut ViewData {
 		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
 
 		if self.visual_mode_help.is_active() {
-			self.visual_mode_help.get_view_data(view_width, view_height)
+			self.visual_mode_help.get_view_data()
 		}
 		else {
-			self.update_list_view_data(todo_file, view_width, view_height);
-			&self.view_data
+			self.update_list_view_data(todo_file, view_width);
+			&mut self.view_data
 		}
 	}
 
-	fn get_normal_mode_view_data(&mut self, todo_file: &TodoFile, view: &View<'_>) -> &ViewData {
+	fn get_normal_mode_view_data(&mut self, todo_file: &TodoFile, view: &View<'_>) -> &mut ViewData {
 		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
 
 		if self.normal_mode_help.is_active() {
-			self.normal_mode_help.get_view_data(view_width, view_height)
+			self.normal_mode_help.get_view_data()
 		}
 		else {
-			self.update_list_view_data(todo_file, view_width, view_height);
-			&self.view_data
+			self.update_list_view_data(todo_file, view_width);
+			&mut self.view_data
 		}
 	}
 

--- a/src/list/tests.rs
+++ b/src/list/tests.rs
@@ -86,7 +86,6 @@ fn render_compact() {
 		],
 		ViewState {
 			size: Size::new(30, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -126,11 +125,11 @@ fn move_cursor_down_1() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -158,11 +157,11 @@ fn move_cursor_down_view_end() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown; 2],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -190,11 +189,11 @@ fn move_cursor_down_scroll_1() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown; 3],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -222,11 +221,11 @@ fn move_cursor_down_scroll_bottom() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown; 4],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -248,7 +247,6 @@ fn move_cursor_down_scroll_bottom_move_up_one() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -259,6 +257,7 @@ fn move_cursor_down_scroll_bottom_move_up_one() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 4);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -282,7 +281,6 @@ fn move_cursor_down_scroll_bottom_move_up_top() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -295,6 +293,7 @@ fn move_cursor_down_scroll_bottom_move_up_top() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 4);
 			test_context.build_view_data(&mut module);
 			test_context.handle_n_inputs(&mut module, 3);
@@ -318,11 +317,11 @@ fn move_cursor_up_attempt_above_top() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorUp, Input::MoveCursorUp],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -344,11 +343,11 @@ fn move_cursor_down_attempt_below_bottom() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown; 4],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -370,11 +369,11 @@ fn move_cursor_page_up_from_top() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorPageUp],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -403,11 +402,11 @@ fn move_cursor_page_up_from_one_page_down() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown, Input::MoveCursorDown, Input::MoveCursorPageUp],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 2);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -438,7 +437,6 @@ fn move_cursor_page_up_from_one_page_down_plus_1() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -448,6 +446,7 @@ fn move_cursor_page_up_from_one_page_down_plus_1() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 3);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -478,11 +477,11 @@ fn move_cursor_page_up_from_one_page_down_minus_1() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown, Input::MoveCursorDown, Input::MoveCursorPageUp],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 2);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -513,7 +512,6 @@ fn move_cursor_page_up_from_bottom() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -525,6 +523,7 @@ fn move_cursor_page_up_from_bottom() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 5);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -550,6 +549,7 @@ fn move_cursor_page_home() {
 		&[Input::MoveCursorEnd],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 5);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -581,6 +581,7 @@ fn move_cursor_page_end() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 5);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -612,7 +613,6 @@ fn move_cursor_page_down_from_bottom() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -624,6 +624,7 @@ fn move_cursor_page_down_from_bottom() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 5);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -654,7 +655,6 @@ fn move_cursor_page_down_one_from_bottom() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -665,6 +665,7 @@ fn move_cursor_page_down_one_from_bottom() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 4);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -695,7 +696,6 @@ fn move_cursor_page_down_one_page_from_bottom() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorDown,
@@ -705,6 +705,7 @@ fn move_cursor_page_down_one_page_from_bottom() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_n_inputs(&mut module, 3);
 			test_context.build_view_data(&mut module);
 			test_context.handle_input(&mut module);
@@ -728,7 +729,6 @@ fn visual_mode_start() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ToggleVisualMode],
 		|mut test_context: TestContext<'_>| {
@@ -754,11 +754,11 @@ fn visual_mode_start_cursor_down_one() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ToggleVisualMode, Input::MoveCursorDown],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -787,7 +787,6 @@ fn visual_mode_start_move_down_below_view() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::ToggleVisualMode,
@@ -797,6 +796,7 @@ fn visual_mode_start_move_down_below_view() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -826,11 +826,11 @@ fn visual_mode_start_cursor_page_down() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ToggleVisualMode, Input::MoveCursorPageDown],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -860,7 +860,6 @@ fn visual_mode_start_cursor_page_down_below_view() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::ToggleVisualMode,
@@ -869,6 +868,7 @@ fn visual_mode_start_cursor_page_down_below_view() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -898,7 +898,6 @@ fn visual_mode_start_cursor_from_bottom_move_up() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorPageDown,
@@ -909,6 +908,7 @@ fn visual_mode_start_cursor_from_bottom_move_up() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -937,7 +937,6 @@ fn visual_mode_start_cursor_from_bottom_to_top() {
 		],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[
 			Input::MoveCursorPageDown,
@@ -950,6 +949,7 @@ fn visual_mode_start_cursor_from_bottom_to_top() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -973,7 +973,6 @@ fn change_selected_line_to_drop() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionDrop],
 		|mut test_context: TestContext<'_>| {
@@ -997,7 +996,6 @@ fn change_selected_line_to_edit() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionEdit],
 		|mut test_context: TestContext<'_>| {
@@ -1021,7 +1019,6 @@ fn change_selected_line_to_fixup() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionFixup],
 		|mut test_context: TestContext<'_>| {
@@ -1045,7 +1042,6 @@ fn change_selected_line_to_pick() {
 		&["drop aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionPick],
 		|mut test_context: TestContext<'_>| {
@@ -1069,7 +1065,6 @@ fn change_selected_line_to_reword() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionReword],
 		|mut test_context: TestContext<'_>| {
@@ -1093,7 +1088,6 @@ fn change_selected_line_to_squash() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionSquash],
 		|mut test_context: TestContext<'_>| {
@@ -1117,7 +1111,6 @@ fn change_selected_line_toggle_break_add() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionBreak],
 		|mut test_context: TestContext<'_>| {
@@ -1142,7 +1135,6 @@ fn change_selected_line_toggle_break_remove() {
 		&["pick aaa c1", "break"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::MoveCursorDown, Input::ActionBreak],
 		|mut test_context: TestContext<'_>| {
@@ -1166,7 +1158,6 @@ fn change_selected_line_toggle_break_above_existing() {
 		&["pick aaa c1", "break"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionBreak],
 		|mut test_context: TestContext<'_>| {
@@ -1191,7 +1182,6 @@ fn change_selected_line_auto_select_next_with_next_line() {
 		&["pick aaa c1", "pick aaa c2"],
 		ViewState {
 			size: Size::new(120, 4),
-			..ViewState::default()
 		},
 		&[Input::ActionSquash],
 		|mut test_context: TestContext<'_>| {
@@ -2726,13 +2716,11 @@ fn scroll_right() {
 			"pick bbbbbbbbbbbb this comment needs to be longer than the width of the view",
 			"pick cccccccccccc this comment needs to be longer than the width of the view",
 		],
-		ViewState {
-			size: Size::new(50, 4),
-			..ViewState::default()
-		},
+		ViewState { size: Size::new(50, 4) },
 		&[Input::MoveCursorRight; 3],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
+			test_context.update_view_data_size(&mut module);
 			test_context.build_view_data(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -2758,10 +2746,7 @@ fn scroll_left() {
 			"pick bbbbbbbbbbbb this comment needs to be longer than the width of the view",
 			"pick cccccccccccc this comment needs to be longer than the width of the view",
 		],
-		ViewState {
-			size: Size::new(50, 4),
-			..ViewState::default()
-		},
+		ViewState { size: Size::new(50, 4) },
 		&[
 			Input::MoveCursorRight,
 			Input::MoveCursorRight,
@@ -2770,7 +2755,7 @@ fn scroll_left() {
 		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
-			test_context.build_view_data(&mut module);
+			test_context.update_view_data_size(&mut module);
 			test_context.handle_all_inputs(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -2793,7 +2778,6 @@ fn normal_mode_help() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(200, 100),
-			..ViewState::default()
 		},
 		&[Input::Help],
 		|mut test_context: TestContext<'_>| {
@@ -2805,7 +2789,7 @@ fn normal_mode_help() {
 				view_data,
 				"{TITLE}",
 				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  ,184}",
+				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  }",
 				"{BODY}",
 				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
 				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
@@ -2867,7 +2851,6 @@ fn visual_mode_help() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(200, 100),
-			..ViewState::default()
 		},
 		&[Input::Help],
 		|mut test_context: TestContext<'_>| {
@@ -2879,7 +2862,7 @@ fn visual_mode_help() {
 				view_data,
 				"{TITLE}",
 				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  ,184}",
+				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  }",
 				"{BODY}",
 				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
 				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -22,12 +22,8 @@ impl ProcessModule for Error {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
-		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
-		self.view_data.set_view_size(view_width, view_height);
-		self.view_data.rebuild();
-		&self.view_data
+	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+		&mut self.view_data
 	}
 
 	fn handle_input(&mut self, view: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -63,7 +63,7 @@ impl<'m> Modules<'m> {
 		self.get_mut_module(state).deactivate();
 	}
 
-	pub fn build_view_data(&mut self, state: State, view: &View<'_>, rebase_todo: &TodoFile) -> &ViewData {
+	pub fn build_view_data(&mut self, state: State, view: &View<'_>, rebase_todo: &TodoFile) -> &mut ViewData {
 		self.get_mut_module(state).build_view_data(view, rebase_todo)
 	}
 

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -11,7 +11,7 @@ pub trait ProcessModule {
 
 	fn deactivate(&mut self) {}
 
-	fn build_view_data(&mut self, _view: &View<'_>, _rebase_todo: &TodoFile) -> &ViewData;
+	fn build_view_data(&mut self, _view: &View<'_>, _rebase_todo: &TodoFile) -> &mut ViewData;
 
 	fn handle_input(&mut self, _view: &mut View<'_>, _rebase_todo: &mut TodoFile) -> ProcessResult;
 }

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -12,10 +12,7 @@ use crate::{
 fn window_too_small() {
 	process_module_test(
 		&["pick aaa comment"],
-		ViewState {
-			size: Size::new(1, 1),
-			..ViewState::default()
-		},
+		ViewState { size: Size::new(1, 1) },
 		&[Input::Exit],
 		|test_context: TestContext<'_>| {
 			let mut process = Process::new(test_context.rebase_todo_file, test_context.view);
@@ -102,10 +99,7 @@ fn resize_window_size_okay() {
 fn resize_window_size_too_small() {
 	process_module_test(
 		&["pick aaa comment"],
-		ViewState {
-			size: Size::new(1, 1),
-			..ViewState::default()
-		},
+		ViewState { size: Size::new(1, 1) },
 		&[],
 		|test_context: TestContext<'_>| {
 			let mut process = Process::new(test_context.rebase_todo_file, test_context.view);

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -32,8 +32,17 @@ impl<'t> TestContext<'t> {
 		module.deactivate();
 	}
 
-	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc ViewData {
-		module.build_view_data(&self.view, &self.rebase_todo_file)
+	pub fn update_view_data_size(&self, module: &'_ mut dyn ProcessModule) {
+		let view_data = module.build_view_data(&self.view, &self.rebase_todo_file);
+		let size = self.view.get_view_size();
+		view_data.set_view_size(size.width(), size.height());
+	}
+
+	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc mut ViewData {
+		let view_data = module.build_view_data(&self.view, &self.rebase_todo_file);
+		let size = self.view.get_view_size();
+		view_data.set_view_size(size.width(), size.height());
+		view_data
 	}
 
 	pub fn handle_input(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
@@ -82,14 +91,12 @@ impl<'t> TestContext<'t> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct ViewState {
-	pub position: (u16, u16),
 	pub size: Size,
 }
 
 impl Default for ViewState {
 	fn default() -> Self {
 		Self {
-			position: (0, 0),
 			size: Size::new(500, 30),
 		}
 	}

--- a/src/process/util.rs
+++ b/src/process/util.rs
@@ -35,7 +35,7 @@ mod tests {
 		view_data.scroll_right();
 		view_data.scroll_right();
 		assert_eq!(handle_view_data_scroll(input, &mut view_data), Some(input));
-		assert_rendered_output!(view_data, "{BODY}", format!("{{Normal}}{}", result));
+		assert_rendered_output!(&mut view_data, "{BODY}", format!("{{Normal}}{}", result));
 	}
 
 	#[rstest(
@@ -67,7 +67,7 @@ mod tests {
 		view_data.scroll_down();
 		assert_eq!(handle_view_data_scroll(input, &mut view_data), Some(input));
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{BODY}",
 			format!("{{Normal}}{}", result[0]),
 			format!("{{Normal}}{}", result[1]),
@@ -82,6 +82,6 @@ mod tests {
 		view_data.push_line(ViewLine::from("012345678"));
 		view_data.set_view_size(5, 10);
 		assert_eq!(handle_view_data_scroll(Input::Character('a'), &mut view_data), None);
-		assert_rendered_output!(view_data, "{BODY}", "{Normal}01234");
+		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}01234");
 	}
 }

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -22,7 +22,7 @@ impl ProcessModule for WindowSizeError {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &mut ViewData {
 		let view_width = view.get_view_size().width();
 		let view_height = view.get_view_size().height();
 		let message = if view_width <= MINIMUM_COMPACT_WINDOW_WIDTH {
@@ -49,9 +49,7 @@ impl ProcessModule for WindowSizeError {
 
 		self.view_data.clear();
 		self.view_data.push_line(ViewLine::from(message));
-		self.view_data.set_view_size(view_width, view_height);
-		self.view_data.rebuild();
-		&self.view_data
+		&mut self.view_data
 	}
 
 	fn handle_input(&mut self, view: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {
@@ -146,7 +144,6 @@ mod tests {
 			&[],
 			ViewState {
 				size: Size::new(width, height),
-				..ViewState::default()
 			},
 			&[],
 			|test_context: TestContext<'_>| {
@@ -162,10 +159,7 @@ mod tests {
 	fn input_resize_window_still_small() {
 		process_module_test(
 			&[],
-			ViewState {
-				size: Size::new(1, 1),
-				..ViewState::default()
-			},
+			ViewState { size: Size::new(1, 1) },
 			&[Input::Resize],
 			|mut test_context: TestContext<'_>| {
 				let mut module = WindowSizeError::new();
@@ -182,7 +176,6 @@ mod tests {
 			&[],
 			ViewState {
 				size: Size::new(100, 100),
-				..ViewState::default()
 			},
 			&[Input::Resize],
 			|mut test_context: TestContext<'_>| {
@@ -202,7 +195,7 @@ mod tests {
 	fn input_other_character() {
 		process_module_test(
 			&[],
-			ViewState { ..ViewState::default() },
+			ViewState::default(),
 			&[Input::Character('a')],
 			|mut test_context: TestContext<'_>| {
 				let mut module = WindowSizeError::new();

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -87,11 +87,10 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		}
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &mut ViewData {
 		let view_width = view.get_view_size().width();
-		let view_height = view.get_view_size().height();
 		if self.help.is_active() {
-			return self.help.get_view_data(view_width, view_height);
+			return self.help.get_view_data();
 		}
 
 		if self.view_data.is_empty() {
@@ -127,9 +126,7 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 				},
 			}
 		}
-		self.view_data.set_view_size(view_width, view_height);
-		self.view_data.rebuild();
-		&self.view_data
+		&mut self.view_data
 	}
 
 	fn handle_input(&mut self, view: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {

--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -122,7 +122,6 @@ fn render_overview_minimal_commit_compact() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(33, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -180,7 +179,6 @@ fn render_overview_with_author_compact() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(33, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -240,7 +238,6 @@ fn render_overview_with_committer_compact() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(33, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -345,7 +342,6 @@ fn render_overview_with_file_stats_compact() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(33, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -558,7 +554,6 @@ fn render_diff_minimal_commit() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -575,7 +570,7 @@ fn render_diff_minimal_commit() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}"
+				"{Normal}{Pad ―}"
 			);
 		},
 	);
@@ -588,7 +583,6 @@ fn render_diff_minimal_commit_compact() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(33, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -604,7 +598,7 @@ fn render_diff_minimal_commit_compact() {
 				"{Normal}01234567",
 				"{IndicatorColor}0{Normal} / {DiffAddColor}0{Normal} / {DiffRemoveColor}0",
 				"{BODY}",
-				"{Normal}{Pad ―,99}"
+				"{Normal}{Pad ―}"
 			);
 		},
 	);
@@ -617,7 +611,6 @@ fn render_diff_basic_file_stats() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -644,19 +637,19 @@ fn render_diff_basic_file_stats() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor} renamed: {DiffRemoveColor}file.1b{Normal} → {DiffAddColor}file.1a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffAddColor}   added: {DiffAddColor}file.2a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffRemoveColor} deleted: {DiffRemoveColor}file.3a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffAddColor}  copied: {Normal}file.4b{Normal} → {DiffAddColor}file.4a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.5a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor} changed: {DiffChangeColor}file.6a",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{Normal} unknown: {Normal}file.7a"
 			);
 		},
@@ -670,7 +663,6 @@ fn render_diff_end_new_line_missing() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -692,11 +684,11 @@ fn render_diff_end_new_line_missing() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}  {Normal} {Normal}14{Normal}| {DiffAddColor}new line",
 				"{Normal}       {DiffContextColor}\\ No newline at end of file"
 			);
@@ -711,7 +703,6 @@ fn render_diff_add_line() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -734,11 +725,11 @@ fn render_diff_add_line() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}  {Normal} {Normal}14{Normal}| {DiffAddColor}new line"
 			);
 		},
@@ -752,7 +743,6 @@ fn render_diff_delete_line() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -775,11 +765,11 @@ fn render_diff_delete_line() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}14{Normal} {Normal}  {Normal}| {DiffRemoveColor}old line"
 			);
 		},
@@ -793,7 +783,6 @@ fn render_diff_context_add_remove_lines() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -819,11 +808,11 @@ fn render_diff_context_add_remove_lines() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}13{Normal} {Normal}13{Normal}| {DiffContextColor}context 1",
 				"{Normal}14{Normal} {Normal}  {Normal}| {DiffRemoveColor}old line",
 				"{Normal}  {Normal} {Normal}14{Normal}| {DiffAddColor}new line",
@@ -840,7 +829,6 @@ fn render_diff_add_line_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -863,11 +851,11 @@ fn render_diff_add_line_with_show_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}  {Normal} {Normal}14{Normal}| {DiffAddColor}new line"
 			);
 		},
@@ -881,7 +869,6 @@ fn render_diff_delete_line_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -904,11 +891,11 @@ fn render_diff_delete_line_with_show_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}14{Normal} {Normal}  {Normal}| {DiffRemoveColor}old line"
 			);
 		},
@@ -922,7 +909,6 @@ fn render_diff_context_add_remove_lines_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -948,11 +934,11 @@ fn render_diff_context_add_remove_lines_with_show_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -14,0 +14,1 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}13{Normal} {Normal}13{Normal}| {DiffContextColor}context 1",
 				"{Normal}14{Normal} {Normal}  {Normal}| {DiffRemoveColor}old line",
 				"{Normal}  {Normal} {Normal}14{Normal}| {DiffAddColor}new line",
@@ -992,7 +978,6 @@ fn render_diff_show_both_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -1016,11 +1001,11 @@ fn render_diff_show_both_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}1{Normal} {Normal}1{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    content",
 				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}# # ",
 				"{Normal}3{Normal} {Normal}3{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    \
@@ -1043,7 +1028,6 @@ fn render_diff_show_leading_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -1067,11 +1051,11 @@ fn render_diff_show_leading_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}1{Normal} {Normal}1{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    content",
 				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}    ",
 				"{Normal}3{Normal} {Normal}3{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    \
@@ -1094,7 +1078,6 @@ fn render_diff_show_no_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -1118,11 +1101,11 @@ fn render_diff_show_no_whitespace() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal}1{Normal} {Normal}1{Normal}| {DiffContextColor}    sp tabs    content",
 				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content    ",
 				"{Normal}3{Normal} {Normal}3{Normal}| {DiffContextColor}    sp tabs    content    ",
@@ -1142,7 +1125,6 @@ fn render_diff_show_whitespace_all_spaces() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		ViewState {
 			size: Size::new(50, 100),
-			..ViewState::default()
 		},
 		&[],
 		|test_context: TestContext<'_>| {
@@ -1168,11 +1150,11 @@ fn render_diff_show_whitespace_all_spaces() {
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{BODY}",
-				"{Normal}{Pad ―,150}",
+				"{Normal}{Pad ―}",
 				"{DiffChangeColor}modified: {DiffChangeColor}file.txt",
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
-				"{Normal,Dimmed}{Pad ┈,150}",
+				"{Normal,Dimmed}{Pad ┈}",
 				"{Normal} {Normal} {Normal}1{Normal}| {DiffWhitespaceColor}%%%%"
 			);
 		},
@@ -1236,7 +1218,6 @@ fn render_help() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(200, 100),
-			..ViewState::default()
 		},
 		&[Input::Help],
 		|mut test_context: TestContext<'_>| {
@@ -1247,7 +1228,7 @@ fn render_help() {
 				view_data,
 				"{TITLE}",
 				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  ,184}",
+				"{Normal,Underline} Key      Action{Normal,Underline}{Pad  }",
 				"{BODY}",
 				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Scroll up",
 				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Scroll down",
@@ -1271,7 +1252,6 @@ fn handle_help_input() {
 		&["pick aaa c1"],
 		ViewState {
 			size: Size::new(200, 100),
-			..ViewState::default()
 		},
 		&[Input::Help, Input::ShowDiff],
 		|mut test_context: TestContext<'_>| {

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -41,9 +41,12 @@ impl<'v> View<'v> {
 		self.display.get_window_size()
 	}
 
-	pub(crate) fn render(&mut self, view_data: &ViewData) -> Result<()> {
+	pub(crate) fn render(&mut self, view_data: &mut ViewData) -> Result<()> {
+		let view_size = self.display.get_window_size();
+		let window_height = view_size.height();
+		view_data.set_view_size(view_size.width(), window_height);
+
 		self.display.clear()?;
-		let window_height = self.display.get_window_size().height();
 
 		self.display.ensure_at_line_start()?;
 		if view_data.show_title() {
@@ -215,8 +218,8 @@ mod tests {
 	#[serial_test::serial]
 	fn render_empty() {
 		view_module_test(Size::new(20, 10), |mut test_context| {
-			let view_data = ViewData::new();
-			test_context.view.render(&view_data).unwrap();
+			let mut view_data = ViewData::new();
+			test_context.view.render(&mut view_data).unwrap();
 			TestContext::assert_output(&["~"; 10]);
 		});
 	}
@@ -227,7 +230,7 @@ mod tests {
 		view_module_test(Size::new(35, 10), |mut test_context| {
 			let mut view_data = ViewData::new();
 			view_data.set_show_title(true);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Interactive Rebase Tool        "];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -240,7 +243,7 @@ mod tests {
 		view_module_test(Size::new(26, 10), |mut test_context| {
 			let mut view_data = ViewData::new();
 			view_data.set_show_title(true);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Rebase                "];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -254,7 +257,7 @@ mod tests {
 			let mut view_data = ViewData::new();
 			view_data.set_show_title(true);
 			view_data.set_show_help(true);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Interactive Rebase Tool Help: ?"];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -268,7 +271,7 @@ mod tests {
 			let mut view_data = ViewData::new();
 			view_data.set_show_title(true);
 			view_data.set_show_help(true);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Interactive Rebase Tool       "];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -282,7 +285,7 @@ mod tests {
 			let mut view_data = ViewData::new();
 			view_data.push_leading_line(ViewLine::from("This is a leading line"));
 			view_data.set_view_size(30, 10);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["This is a leading line        "];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -296,7 +299,7 @@ mod tests {
 			let mut view_data = ViewData::new();
 			view_data.push_line(ViewLine::from("This is a line"));
 			view_data.set_view_size(30, 10);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["This is a line                "];
 			expected.extend(vec!["~"; 9]);
 			TestContext::assert_output(&expected);
@@ -310,7 +313,7 @@ mod tests {
 			let mut view_data = ViewData::new();
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
 			view_data.set_view_size(30, 10);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["~"; 9];
 			expected.push("This is a trailing line       ");
 			TestContext::assert_output(&expected);
@@ -326,7 +329,7 @@ mod tests {
 			view_data.push_line(ViewLine::from("This is a line"));
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
 			view_data.set_view_size(30, 10);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["This is a leading line        ", "This is a line                "];
 			expected.extend(vec!["~"; 7]);
 			expected.push("This is a trailing line       ");
@@ -346,7 +349,7 @@ mod tests {
 			view_data.push_line(ViewLine::from("This is line 4"));
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
 			view_data.set_view_size(30, 6);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let expected = vec![
 				"This is a leading line        ",
 				"This is line 1                ",
@@ -372,7 +375,7 @@ mod tests {
 			view_data.push_line(ViewLine::from("This is line 5"));
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
 			view_data.set_view_size(30, 6);
-			test_context.view.render(&view_data).unwrap();
+			test_context.view.render(&mut view_data).unwrap();
 			let expected = vec![
 				"This is a leading line        ",
 				"This is line 1               █",

--- a/src/view/testutil.rs
+++ b/src/view/testutil.rs
@@ -1,5 +1,5 @@
 use crate::{
-	display::display_color::DisplayColor,
+	display::{display_color::DisplayColor, size::Size},
 	view::{view_data::ViewData, view_line::ViewLine},
 };
 
@@ -78,7 +78,7 @@ fn render_view_line(view_line: &ViewLine) -> String {
 		);
 		// only render
 		if is_padding {
-			line.push_str(format!("{{Pad {},{}}}", view_line.padding_character(), content.len()).as_str());
+			line.push_str(format!("{{Pad {}}}", view_line.padding_character()).as_str());
 		}
 		else {
 			line.push_str(segment.get_content());
@@ -87,7 +87,8 @@ fn render_view_line(view_line: &ViewLine) -> String {
 	line
 }
 
-fn render_view_data(view_data: &ViewData) -> Vec<String> {
+fn render_view_data(view_data: &mut ViewData, size: &Size) -> Vec<String> {
+	view_data.set_view_size(size.width(), size.height());
 	let mut lines = vec![];
 	if view_data.show_title() {
 		if view_data.show_help() {
@@ -128,8 +129,15 @@ fn render_view_data(view_data: &ViewData) -> Vec<String> {
 	lines
 }
 
-pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
-	let output = render_view_data(view_data);
+pub fn _assert_rendered_output(view_data: &mut ViewData, expected: &[String]) {
+	let (width, height) = view_data.get_size();
+	let output = render_view_data(
+		view_data,
+		&Size::new(
+			if width == 0 && height == 0 { 500 } else { width },
+			if width == 0 && height == 0 { 100 } else { height },
+		),
+	);
 	let mut mismatch = false;
 	let mut error_output = vec![
 		String::from("\nUnexpected output!"),
@@ -177,10 +185,10 @@ pub fn _assert_rendered_output(view_data: &ViewData, expected: &[String]) {
 macro_rules! assert_rendered_output {
 	($view_data:expr) => {
 		let expected: Vec<String> = vec![];
-		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
+		crate::view::testutil::_assert_rendered_output($view_data, &expected);
 	};
 	($view_data:expr, $($arg:expr),*) => {
 		let expected = vec![$( String::from($arg), )*];
-		crate::view::testutil::_assert_rendered_output(&$view_data, &expected);
+		crate::view::testutil::_assert_rendered_output($view_data, &expected);
 	};
 }

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -122,7 +122,7 @@ impl ViewData {
 		}
 	}
 
-	pub(crate) fn set_view_size(&mut self, view_width: usize, view_height: usize) {
+	pub fn set_view_size(&mut self, view_width: usize, view_height: usize) {
 		if self.height != view_height
 			|| self.width != view_width
 			|| self.leading_lines_cache.is_none()
@@ -284,7 +284,7 @@ impl ViewData {
 	}
 
 	#[allow(clippy::cognitive_complexity)]
-	pub(crate) fn rebuild(&mut self) {
+	fn rebuild(&mut self) {
 		if self.leading_lines_cache.is_none() {
 			self.leading_lines_cache = Some(
 				if self.leading_lines.is_empty() {
@@ -479,6 +479,11 @@ impl ViewData {
 			})
 			.collect::<Vec<ViewLine>>()
 	}
+
+	#[cfg(test)]
+	pub const fn get_size(&self) -> (usize, usize) {
+		(self.width, self.height)
+	}
 }
 
 #[cfg(test)]
@@ -566,8 +571,8 @@ mod tests {
 
 	#[test]
 	fn render_empty() {
-		let view_data = ViewData::new();
-		assert_rendered_output!(view_data, "{EMPTY}");
+		let mut view_data = ViewData::new();
+		assert_rendered_output!(&mut view_data, "{EMPTY}");
 	}
 
 	#[test]
@@ -575,7 +580,7 @@ mod tests {
 		let mut view_data = ViewData::new();
 		view_data.set_show_title(true);
 		view_data.set_show_help(true);
-		assert_rendered_output!(view_data, "{TITLE}{HELP}", "{EMPTY}");
+		assert_rendered_output!(&mut view_data, "{TITLE}{HELP}", "{EMPTY}");
 	}
 
 	#[test]
@@ -583,7 +588,7 @@ mod tests {
 		let mut view_data = ViewData::new();
 		view_data.set_show_title(true);
 		view_data.set_show_help(false);
-		assert_rendered_output!(view_data, "{TITLE}", "{EMPTY}");
+		assert_rendered_output!(&mut view_data, "{TITLE}", "{EMPTY}");
 	}
 
 	#[test]
@@ -593,7 +598,7 @@ mod tests {
 		view_data.scroll_position.scroll_down();
 		view_data.clear();
 
-		assert_rendered_output!(view_data, "{EMPTY}");
+		assert_rendered_output!(&mut view_data, "{EMPTY}");
 		assert_eq!(view_data.scroll_position.get_top_position(), 1);
 	}
 
@@ -604,7 +609,7 @@ mod tests {
 		view_data.clear_body();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -622,7 +627,7 @@ mod tests {
 		view_data.scroll_position.scroll_down();
 		view_data.reset();
 
-		assert_rendered_output!(view_data, "{EMPTY}");
+		assert_rendered_output!(&mut view_data, "{EMPTY}");
 		assert_eq!(view_data.scroll_position.get_top_position(), 0);
 	}
 
@@ -635,7 +640,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{BODY}",
 			"{Normal}Mocked Line",
 			"{TRAILING}",
@@ -652,7 +657,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{TRAILING}",
@@ -669,7 +674,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{BODY}",
@@ -684,7 +689,7 @@ mod tests {
 		view_data.set_view_size(100, 12);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{TITLE}",
 			"{LEADING}",
 			"{Normal}Mocked Line",
@@ -708,7 +713,7 @@ mod tests {
 		view_data.set_view_size(100, 12);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -731,7 +736,7 @@ mod tests {
 		view_data.set_view_size(100, 10);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{TITLE}",
 			"{LEADING}",
 			"{Normal}Mocked Line",
@@ -755,7 +760,7 @@ mod tests {
 		view_data.set_view_size(100, 9);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -777,7 +782,7 @@ mod tests {
 		view_data.set_view_size(100, 8);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -798,7 +803,7 @@ mod tests {
 		view_data.set_view_size(100, 6);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -817,7 +822,7 @@ mod tests {
 		view_data.set_view_size(100, 5);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -834,7 +839,7 @@ mod tests {
 		view_data.set_view_size(100, 4);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -850,7 +855,7 @@ mod tests {
 		view_data.set_view_size(100, 3);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{TRAILING}",
@@ -868,7 +873,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{TITLE}",
 			"{LEADING}",
 			"{Normal}Mocked Line",
@@ -895,7 +900,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{TITLE}",
 			"{LEADING}",
 			"{Normal}Mocked Line",
@@ -922,7 +927,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{TITLE}",
 			"{LEADING}",
 			"{Normal}Mocked Line",
@@ -945,7 +950,12 @@ mod tests {
 		let mut view_data = create_mocked_view_data();
 		view_data.set_view_size(100, 2);
 
-		assert_rendered_output!(view_data, "{TRAILING}", "{Normal}Mocked Line", "{Normal}Mocked Line");
+		assert_rendered_output!(
+			&mut view_data,
+			"{TRAILING}",
+			"{Normal}Mocked Line",
+			"{Normal}Mocked Line"
+		);
 	}
 
 	#[test]
@@ -953,7 +963,7 @@ mod tests {
 		let mut view_data = create_mocked_view_data();
 		view_data.set_view_size(100, 1);
 
-		assert_rendered_output!(view_data, "{TRAILING}", "{Normal}Mocked Line");
+		assert_rendered_output!(&mut view_data, "{TRAILING}", "{Normal}Mocked Line");
 	}
 
 	#[test]
@@ -969,7 +979,7 @@ mod tests {
 		view_data.rebuild();
 
 		// cache should still be empty after rebuild
-		assert_rendered_output!(view_data);
+		assert_rendered_output!(&mut view_data);
 	}
 
 	#[test]
@@ -977,7 +987,7 @@ mod tests {
 		let mut view_data = create_mocked_view_data();
 		view_data.set_view_size(100, 0);
 
-		assert_rendered_output!(view_data);
+		assert_rendered_output!(&mut view_data);
 	}
 
 	#[test]
@@ -986,7 +996,7 @@ mod tests {
 		view_data.set_show_title(true);
 		view_data.set_view_size(100, 1);
 
-		assert_rendered_output!(view_data, "{TITLE}");
+		assert_rendered_output!(&mut view_data, "{TITLE}");
 	}
 
 	#[test]
@@ -1007,7 +1017,7 @@ mod tests {
 		view_data.push_line(ViewLine::from("a").set_selected(true));
 		view_data.rebuild();
 
-		assert_rendered_output!(view_data, "{BODY}", "{Normal(selected)}a");
+		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal(selected)}a");
 	}
 
 	#[test]
@@ -1016,7 +1026,7 @@ mod tests {
 		view_data.scroll_down();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1040,7 +1050,7 @@ mod tests {
 		view_data.scroll_down();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1066,7 +1076,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1092,7 +1102,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1121,7 +1131,7 @@ mod tests {
 		view_data.scroll_up();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1151,7 +1161,7 @@ mod tests {
 		view_data.scroll_up();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1182,7 +1192,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1213,7 +1223,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1237,7 +1247,7 @@ mod tests {
 		view_data.page_down();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1263,7 +1273,7 @@ mod tests {
 		view_data.page_down();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1292,7 +1302,7 @@ mod tests {
 		view_data.page_up();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1323,7 +1333,7 @@ mod tests {
 		view_data.page_up();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1350,7 +1360,7 @@ mod tests {
 		view_data.scroll_left();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}lllllll",
 			"{BODY}",
@@ -1373,7 +1383,7 @@ mod tests {
 		view_data.scroll_right();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}lllllll",
 			"{BODY}",
@@ -1398,7 +1408,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}llllll",
 			"{BODY}",
@@ -1423,7 +1433,7 @@ mod tests {
 		}
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}llllll",
 			"{BODY}",
@@ -1459,7 +1469,7 @@ mod tests {
 			view_data.scroll_down();
 		}
 
-		assert_rendered_output!(view_data, "{BODY}", "{Normal}aaaaa", "{Normal}aaaa", "{Normal}aaa");
+		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}aaaaa", "{Normal}aaaa", "{Normal}aaa");
 	}
 
 	#[test]
@@ -1524,7 +1534,7 @@ mod tests {
 		view_data.rebuild();
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1554,7 +1564,7 @@ mod tests {
 		view_data.ensure_line_visible(1);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1581,7 +1591,7 @@ mod tests {
 		view_data.ensure_line_visible(4);
 
 		assert_rendered_output!(
-			view_data,
+			&mut view_data,
 			"{LEADING}",
 			"{Normal}Mocked Line",
 			"{Normal}Mocked Line",
@@ -1609,7 +1619,7 @@ mod tests {
 		}
 
 		view_data.ensure_column_visible(2);
-		assert_rendered_output!(view_data, "{BODY}", "{Normal}23456");
+		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}23456");
 	}
 
 	#[test]
@@ -1623,7 +1633,7 @@ mod tests {
 		}
 
 		view_data.ensure_column_visible(6);
-		assert_rendered_output!(view_data, "{BODY}", "{Normal}56789");
+		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}56789");
 	}
 
 	#[test]


### PR DESCRIPTION
# Description

Instead of having every module perform a resize of the view_data, return a mutable reference and have the view do a resize in all cases where possible.