### PR TITLE
Add render context 

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::input_handler::InputMode,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData, View},
 };
 
 pub struct ConfirmAbort {
@@ -11,7 +11,7 @@ pub struct ConfirmAbort {
 }
 
 impl ProcessModule for ConfirmAbort {
-	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		self.dialog.get_view_data()
 	}
 

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::input_handler::InputMode,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData, View},
 };
 
 pub struct ConfirmRebase {
@@ -11,7 +11,7 @@ pub struct ConfirmRebase {
 }
 
 impl ProcessModule for ConfirmRebase {
-	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		self.dialog.get_view_data()
 	}
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,12 +4,6 @@ pub const TITLE_SHORT: &str = "Git Rebase";
 pub const TITLE_SHORT_LENGTH: usize = 10;
 pub const TITLE_HELP_INDICATOR_LENGTH: usize = 6;
 
-pub const MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH: usize = 45;
-
-pub const MINIMUM_WINDOW_HEIGHT: usize = 5; // title + pad top + line + pad bottom + help
-pub const MINIMUM_COMPACT_WINDOW_WIDTH: usize = 20; // ">s ccc mmmmmmmmmmmmm".len()
-pub const MINIMUM_FULL_WINDOW_WIDTH: usize = 34; // " > squash cccccccc mmmmmmmmmmmmm %".len()
-
 pub const NAME: &str = "interactive-rebase-tool";
 
 #[cfg(not(feature = "dev"))]

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 	input::{input_handler::InputMode, Input},
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::{line::Line, TodoFile},
-	view::{view_data::ViewData, view_line::ViewLine, View},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
 };
 
 pub struct ExternalEditor {
@@ -48,7 +48,7 @@ impl ProcessModule for ExternalEditor {
 		self.view_data.reset();
 	}
 
-	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		match self.state {
 			ExternalEditorState::Active => {
 				self.view_data.clear();

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 	insert::{insert_state::InsertState, line_type::LineType},
 	process::{process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::{line::Line, TodoFile},
-	view::{view_data::ViewData, view_line::ViewLine, View},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
 };
 
 pub struct Insert {
@@ -28,7 +28,7 @@ impl ProcessModule for Insert {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		match self.state {
 			InsertState::Prompt => self.action_choices.get_view_data(),
 			InsertState::Edit => {

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -2,7 +2,6 @@ use std::cmp;
 
 use crate::{
 	config::key_bindings::KeyBindings,
-	constants::MINIMUM_FULL_WINDOW_WIDTH,
 	display::display_color::DisplayColor,
 	todo_file::{action::Action, line::Line},
 	view::line_segment::LineSegment,
@@ -208,13 +207,13 @@ pub(super) fn get_todo_line_segments(
 	line: &Line,
 	is_cursor_line: bool,
 	selected: bool,
-	view_width: usize,
+	is_full_width: bool,
 ) -> Vec<LineSegment> {
 	let mut segments: Vec<LineSegment> = vec![];
 
 	let action = line.get_action();
 
-	if view_width >= MINIMUM_FULL_WINDOW_WIDTH {
+	if is_full_width {
 		segments.push(LineSegment::new_with_color_and_style(
 			if is_cursor_line || selected { " > " } else { "   " },
 			DisplayColor::Normal,

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -8,7 +8,7 @@ use crate::{
 		util::handle_view_data_scroll,
 	},
 	todo_file::TodoFile,
-	view::{line_segment::LineSegment, view_data::ViewData, view_line::ViewLine, View},
+	view::{line_segment::LineSegment, render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
 };
 
 pub struct Error {
@@ -22,7 +22,7 @@ impl ProcessModule for Error {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, _: &View<'_>, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		&mut self.view_data
 	}
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -16,13 +16,7 @@ use anyhow::Result;
 
 use crate::{
 	input::Input,
-	process::{
-		exit_status::ExitStatus,
-		modules::Modules,
-		process_result::ProcessResult,
-		state::State,
-		window_size_error::WindowSizeError,
-	},
+	process::{exit_status::ExitStatus, modules::Modules, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
 	view::View,
 };
@@ -48,9 +42,7 @@ impl<'r> Process<'r> {
 		if self.view.start().is_err() {
 			return Ok(Some(ExitStatus::StateError));
 		}
-		let view_width = self.view.get_view_size().width();
-		let view_height = self.view.get_view_size().height();
-		if WindowSizeError::is_window_too_small(view_width, view_height) {
+		if self.view.get_render_context().is_window_too_small() {
 			self.handle_process_result(&mut modules, &ProcessResult::new().state(State::WindowSizeError));
 		}
 		self.activate(&mut modules, State::List);
@@ -105,10 +97,7 @@ impl<'r> Process<'r> {
 				self.exit_status = Some(ExitStatus::Kill);
 			},
 			Some(Input::Resize) => {
-				let view_width = self.view.get_view_size().width();
-				let view_height = self.view.get_view_size().height();
-				if self.state != State::WindowSizeError && WindowSizeError::is_window_too_small(view_width, view_height)
-				{
+				if self.state != State::WindowSizeError && self.view.get_render_context().is_window_too_small() {
 					self.state = State::WindowSizeError;
 					self.activate(modules, previous_state);
 				}

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -64,7 +64,8 @@ impl<'m> Modules<'m> {
 	}
 
 	pub fn build_view_data(&mut self, state: State, view: &View<'_>, rebase_todo: &TodoFile) -> &mut ViewData {
-		self.get_mut_module(state).build_view_data(view, rebase_todo)
+		let render_context = view.get_render_context();
+		self.get_mut_module(state).build_view_data(&render_context, rebase_todo)
 	}
 
 	pub fn handle_input(&mut self, state: State, view: &mut View<'_>, rebase_todo: &mut TodoFile) -> ProcessResult {

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -1,7 +1,7 @@
 use crate::{
 	process::{process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData, View},
 };
 
 pub trait ProcessModule {
@@ -11,7 +11,7 @@ pub trait ProcessModule {
 
 	fn deactivate(&mut self) {}
 
-	fn build_view_data(&mut self, _view: &View<'_>, _rebase_todo: &TodoFile) -> &mut ViewData;
+	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &mut ViewData;
 
 	fn handle_input(&mut self, _view: &mut View<'_>, _rebase_todo: &mut TodoFile) -> ProcessResult;
 }

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -23,6 +23,10 @@ pub struct TestContext<'t> {
 }
 
 impl<'t> TestContext<'t> {
+	fn get_build_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc mut ViewData {
+		module.build_view_data(&self.view.get_render_context(), &self.rebase_todo_file)
+	}
+
 	pub fn activate(&self, module: &'_ mut dyn ProcessModule, state: State) -> ProcessResult {
 		module.activate(&self.rebase_todo_file, state)
 	}
@@ -33,15 +37,15 @@ impl<'t> TestContext<'t> {
 	}
 
 	pub fn update_view_data_size(&self, module: &'_ mut dyn ProcessModule) {
-		let view_data = module.build_view_data(&self.view, &self.rebase_todo_file);
-		let size = self.view.get_view_size();
-		view_data.set_view_size(size.width(), size.height());
+		let view_data = self.get_build_data(module);
+		let context = self.view.get_render_context();
+		view_data.set_view_size(context.width(), context.height());
 	}
 
 	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc mut ViewData {
-		let view_data = module.build_view_data(&self.view, &self.rebase_todo_file);
-		let size = self.view.get_view_size();
-		view_data.set_view_size(size.width(), size.height());
+		let view_data = self.get_build_data(module);
+		let context = self.view.get_render_context();
+		view_data.set_view_size(context.width(), context.height());
 		view_data
 	}
 

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -22,7 +22,6 @@ use crate::{
 		diff_show_whitespace_setting::DiffShowWhitespaceSetting,
 		Config,
 	},
-	constants::MINIMUM_FULL_WINDOW_WIDTH,
 	display::display_color::DisplayColor,
 	input::{input_handler::InputMode, Input},
 	process::{
@@ -38,7 +37,7 @@ use crate::{
 		view_builder::{ViewBuilder, ViewBuilderOptions},
 	},
 	todo_file::TodoFile,
-	view::{line_segment::LineSegment, view_data::ViewData, view_line::ViewLine, View},
+	view::{line_segment::LineSegment, render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
 };
 
 pub struct ShowCommit<'s> {
@@ -87,15 +86,14 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		}
 	}
 
-	fn build_view_data(&mut self, view: &View<'_>, _: &TodoFile) -> &mut ViewData {
-		let view_width = view.get_view_size().width();
+	fn build_view_data(&mut self, context: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		if self.help.is_active() {
 			return self.help.get_view_data();
 		}
 
 		if self.view_data.is_empty() {
 			let commit = self.commit.as_ref().unwrap(); // will only fail on programmer error
-			let is_full_width = view_width >= MINIMUM_FULL_WINDOW_WIDTH;
+			let is_full_width = context.is_full_width();
 
 			self.view_data.push_leading_line(ViewLine::from(vec![
 				LineSegment::new_with_color(

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,4 +1,5 @@
 pub mod line_segment;
+pub mod render_context;
 pub mod scroll_position;
 #[cfg(test)]
 pub mod testutil;
@@ -9,9 +10,9 @@ use anyhow::Result;
 
 use crate::{
 	constants::{TITLE, TITLE_HELP_INDICATOR_LENGTH, TITLE_LENGTH, TITLE_SHORT, TITLE_SHORT_LENGTH},
-	display::{display_color::DisplayColor, size::Size, Display},
+	display::{display_color::DisplayColor, Display},
 	input::{input_handler::InputMode, Input},
-	view::{view_data::ViewData, view_line::ViewLine},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
 	Config,
 };
 
@@ -37,8 +38,9 @@ impl<'v> View<'v> {
 		self.display.get_input(mode)
 	}
 
-	pub(crate) fn get_view_size(&self) -> Size {
-		self.display.get_window_size()
+	pub(crate) fn get_render_context(&self) -> RenderContext {
+		let size = self.display.get_window_size();
+		RenderContext::new(size.width(), size.height())
 	}
 
 	pub(crate) fn render(&mut self, view_data: &mut ViewData) -> Result<()> {
@@ -174,7 +176,11 @@ mod tests {
 	use std::{env::set_var, path::Path};
 
 	use super::*;
-	use crate::{config::Config, display::CrossTerm, input::input_handler::InputHandler};
+	use crate::{
+		config::Config,
+		display::{size::Size, CrossTerm},
+		input::input_handler::InputHandler,
+	};
 
 	pub struct TestContext<'t> {
 		pub view: View<'t>,
@@ -204,14 +210,6 @@ mod tests {
 		let display = Display::new(input_handler, &mut crossterm, &config.theme);
 		let view = View::new(display, &config);
 		callback(TestContext { view });
-	}
-
-	#[test]
-	#[serial_test::serial]
-	fn get_view_size() {
-		view_module_test(Size::new(20, 10), |test_context| {
-			assert_eq!(test_context.view.get_view_size(), Size::new(20, 10));
-		});
 	}
 
 	#[test]

--- a/src/view/render_context.rs
+++ b/src/view/render_context.rs
@@ -1,0 +1,80 @@
+const MINIMUM_WINDOW_HEIGHT: usize = 5; // title + pad top + line + pad bottom + help
+const MINIMUM_COMPACT_WINDOW_WIDTH: usize = 20; // ">s ccc mmmmmmmmmmmmm".len()
+const MINIMUM_FULL_WINDOW_WIDTH: usize = 34; // " > squash cccccccc mmmmmmmmmmmmm %".len()
+
+#[derive(Debug)]
+pub struct RenderContext {
+	height: usize,
+	width: usize,
+}
+
+impl RenderContext {
+	pub const fn new(width: usize, height: usize) -> Self {
+		Self { height, width }
+	}
+
+	pub const fn width(&self) -> usize {
+		self.width
+	}
+
+	pub const fn height(&self) -> usize {
+		self.height
+	}
+
+	pub const fn is_minimum_view_width(&self) -> bool {
+		self.width > MINIMUM_COMPACT_WINDOW_WIDTH
+	}
+
+	pub const fn is_minimum_view_height(&self) -> bool {
+		self.height > MINIMUM_WINDOW_HEIGHT
+	}
+
+	pub const fn is_full_width(&self) -> bool {
+		self.width >= MINIMUM_FULL_WINDOW_WIDTH
+	}
+
+	pub const fn is_window_too_small(&self) -> bool {
+		!self.is_minimum_view_width() || !self.is_minimum_view_height()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn is_window_too_small_width_too_small() {
+		let context = RenderContext {
+			width: MINIMUM_COMPACT_WINDOW_WIDTH,
+			height: MINIMUM_WINDOW_HEIGHT + 1,
+		};
+		assert!(context.is_window_too_small());
+	}
+
+	#[test]
+	fn is_window_too_small_height_too_small() {
+		let context = RenderContext {
+			width: MINIMUM_COMPACT_WINDOW_WIDTH + 1,
+			height: MINIMUM_WINDOW_HEIGHT,
+		};
+		assert!(context.is_window_too_small());
+	}
+
+	#[test]
+	fn is_window_too_small_height_and_width_too_small() {
+		let context = RenderContext {
+			width: MINIMUM_COMPACT_WINDOW_WIDTH,
+			height: MINIMUM_WINDOW_HEIGHT,
+		};
+		assert!(context.is_window_too_small());
+	}
+
+	#[test]
+	fn is_window_too_small_width_and_height_large() {
+		let context = RenderContext {
+			width: MINIMUM_COMPACT_WINDOW_WIDTH + 1,
+			height: MINIMUM_WINDOW_HEIGHT + 1,
+		};
+		assert!(!context.is_window_too_small());
+	}
+}


### PR DESCRIPTION
# Description

Add a render context to move towards not passing the view into the modules. The render context currently contains information around the size of the view.