### PR TITLE
Avoid view_data resize in modules

### DIFF
--- a/src/display/testutil.rs
+++ b/src/display/testutil.rs
@@ -90,11 +90,11 @@ pub fn _create_mouse_event(kind: MouseEventKind, column: u16, row: u16, modifier
 #[macro_export]
 macro_rules! create_mouse_event {
 	($kind:expr) => {
-		Event::Mouse(MouseEvent {
-			kind: $kind,
-			column: 0,
-			row: 0,
-			modifiers: KeyModifiers::NONE,
-		})
+		crate::display::testutil::_create_mouse_event($kind, 0, 0, &[])
+	};
+	($kind:expr, $($modifiers:expr),*) => {
+		{
+			crate::display::testutil::_create_mouse_event($kind, 0, 0, &[$( String::from($modifiers))*])
+		}
 	};
 }

--- a/src/input/event_handler.rs
+++ b/src/input/event_handler.rs
@@ -1,0 +1,241 @@
+use crate::display::{CrossTerm, Event, KeyCode, KeyModifiers, MouseEventKind};
+
+pub struct EventHandler {}
+
+impl EventHandler {
+	pub fn poll_event() -> String {
+		loop {
+			if let Ok(input) = CrossTerm::read_event() {
+				let normalized_input = Self::normalize_input(input);
+				// this is a hack to work around unhandled mouse events, input handling needs to be changed
+				// to properly handle dynamic inputs like mouse events
+				// TODO remove hack
+				if normalized_input != "Ignore" {
+					return normalized_input;
+				}
+			}
+			else {
+				return String::from("Other");
+			}
+		}
+	}
+
+	fn modifiers_to_string(modifiers: KeyModifiers, code: Option<KeyCode>) -> String {
+		let mut result = vec![];
+
+		if modifiers.contains(KeyModifiers::SHIFT) {
+			if let Some(KeyCode::Char(k)) = code {
+				if k == '\t' || k == '\n' || k == '\u{7f}' {
+					result.push(String::from("Shift"));
+				}
+			}
+			else {
+				result.push(String::from("Shift"));
+			}
+		}
+		if modifiers.contains(KeyModifiers::CONTROL) {
+			result.push(String::from("Control"));
+		}
+		if modifiers.contains(KeyModifiers::ALT) {
+			result.push(String::from("Alt"));
+		}
+		result.join("")
+	}
+
+	pub(crate) fn normalize_input(event: Event) -> String {
+		match event {
+			Event::Key(event) => {
+				let code = format!(
+					"{}{}",
+					Self::modifiers_to_string(event.modifiers, Some(event.code)),
+					match event.code {
+						KeyCode::Backspace => String::from("Backspace"),
+						KeyCode::BackTab => String::from("BackTab"),
+						KeyCode::Delete => String::from("Delete"),
+						KeyCode::Down => String::from("Down"),
+						KeyCode::End => String::from("End"),
+						KeyCode::Enter => String::from("Enter"),
+						KeyCode::Esc => String::from("Esc"),
+						KeyCode::F(i) => format!("F{}", i),
+						KeyCode::Home => String::from("Home"),
+						KeyCode::Insert => String::from("Insert"),
+						KeyCode::Left => String::from("Left"),
+						KeyCode::Null => String::from("Other"),
+						KeyCode::PageDown => String::from("PageDown"),
+						KeyCode::PageUp => String::from("PageUp"),
+						KeyCode::Right => String::from("Right"),
+						KeyCode::Tab => String::from("Tab"),
+						KeyCode::Up => String::from("Up"),
+						KeyCode::Char(c) if c == '\t' => String::from("Tab"),
+						KeyCode::Char(c) if c == '\n' => String::from("Enter"),
+						KeyCode::Char(c) if c == '\u{7f}' => String::from("Backspace"),
+						KeyCode::Char(c) => String::from(c),
+					}
+				);
+
+				match code.as_str() {
+					"Controlc" => String::from("Kill"),
+					"Controld" => String::from("Exit"),
+					_ => code,
+				}
+			},
+			Event::Mouse(event) => {
+				let kind = match event.kind {
+					MouseEventKind::ScrollDown => String::from("Down"),
+					MouseEventKind::ScrollUp => String::from("Up"),
+					_ => return String::from("Ignore"), // early return to ignore modifiers
+				};
+				format!("{}{}", kind, Self::modifiers_to_string(event.modifiers, None),)
+			},
+			Event::Resize(..) => String::from("Resize"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	use super::*;
+	use crate::{create_key_event, create_mouse_event};
+
+	#[test]
+	#[serial_test::serial]
+	fn read_event_success() {
+		CrossTerm::set_inputs(vec![create_key_event!('z')]);
+		assert_eq!(EventHandler::poll_event(), "z");
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn read_event_fail() {
+		CrossTerm::set_inputs(vec![]);
+		assert_eq!(EventHandler::poll_event(), "Other");
+	}
+
+	#[test]
+	#[serial_test::serial]
+	fn read_event_ignore_hack() {
+		CrossTerm::set_inputs(vec![create_mouse_event!(MouseEventKind::Moved), create_key_event!('z')]);
+		assert_eq!(EventHandler::poll_event(), "z");
+	}
+
+	#[test]
+	fn modifiers_to_string_no_modifiers() {
+		assert_eq!(EventHandler::modifiers_to_string(KeyModifiers::NONE, None), "");
+	}
+
+	#[test]
+	fn modifiers_to_string_alt() {
+		assert_eq!(EventHandler::modifiers_to_string(KeyModifiers::ALT, None), "Alt");
+	}
+
+	#[test]
+	fn modifiers_to_string_control() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::CONTROL, None),
+			"Control"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_shift() {
+		assert_eq!(EventHandler::modifiers_to_string(KeyModifiers::SHIFT, None), "Shift");
+	}
+
+	#[test]
+	fn modifiers_to_string_combined() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::all(), None),
+			"ShiftControlAlt"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_char() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('A'))),
+			""
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_char_tab() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\t'))),
+			"Shift"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_newline() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\n'))),
+			"Shift"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_backspace() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\u{7f}'))),
+			"Shift"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_other() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Enter)),
+			"Shift"
+		);
+	}
+
+	#[test]
+	fn modifiers_to_string_with_code_alphabetic_combined() {
+		assert_eq!(
+			EventHandler::modifiers_to_string(KeyModifiers::all(), Some(KeyCode::Char('A'))),
+			"ControlAlt"
+		);
+	}
+
+	#[rstest(
+		event,
+		expected,
+		case::key_event_abort(create_key_event!(code KeyCode::Backspace), "Backspace"),
+		case::key_event_abort(create_key_event!(code KeyCode::BackTab), "BackTab"),
+		case::key_event_backspace(create_key_event!(code KeyCode::Backspace), "Backspace"),
+		case::key_event_back_tab(create_key_event!(code KeyCode::BackTab), "BackTab"),
+		case::key_event_delete(create_key_event!(code KeyCode::Delete), "Delete"),
+		case::key_event_down(create_key_event!(code KeyCode::Down), "Down"),
+		case::key_event_end(create_key_event!(code KeyCode::End), "End"),
+		case::key_event_enter(create_key_event!(code KeyCode::Enter), "Enter"),
+		case::key_event_esc(create_key_event!(code KeyCode::Esc), "Esc"),
+		case::key_event_f0(create_key_event!(code KeyCode::F(0)),"F0"),
+		case::key_event_f255(create_key_event!(code KeyCode::F(255)),"F255"),
+		case::key_event_home(create_key_event!(code KeyCode::Home), "Home"),
+		case::key_event_insert(create_key_event!(code KeyCode::Insert), "Insert"),
+		case::key_event_left(create_key_event!(code KeyCode::Left), "Left"),
+		case::key_event_null(create_key_event!(code KeyCode::Null), "Other"),
+		case::key_event_page_down(create_key_event!(code KeyCode::PageDown), "PageDown"),
+		case::key_event_page_up(create_key_event!(code KeyCode::PageUp), "PageUp"),
+		case::key_event_right(create_key_event!(code KeyCode::Right), "Right"),
+		case::key_event_tab(create_key_event!(code KeyCode::Tab), "Tab"),
+		case::key_event_up(create_key_event!(code KeyCode::Up), "Up"),
+		case::key_event_tab_character(create_key_event!('\t'), "Tab"),
+		case::key_event_enter_character(create_key_event!('\n'), "Enter"),
+		case::key_event_backspace_character(create_key_event!('\u{7f}'), "Backspace"),
+		case::key_event_character(create_key_event!('x'), "x"),
+		case::key_event_modifiers(create_key_event!('x', "Control"), "Controlx"),
+		case::key_event_kill(create_key_event!('c', "Control"), "Kill"),
+		case::key_event_exit(create_key_event!('d', "Control"), "Exit"),
+		case::mouse_event_scroll_down(create_mouse_event!(MouseEventKind::ScrollDown), "Down"),
+		case::mouse_event_scroll_up(create_mouse_event!(MouseEventKind::ScrollUp), "Up"),
+		case::mouse_event_other(create_mouse_event!(MouseEventKind::Moved, "Control"), "Ignore"),
+		case::mouse_event_other(create_mouse_event!(MouseEventKind::Moved), "Ignore"),
+		case::resize(Event::Resize(0, 0), "Resize")
+	)]
+	fn normalize_input(event: Event, expected: &str) {
+		assert_eq!(EventHandler::normalize_input(event), String::from(expected));
+	}
+}

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -1,30 +1,4 @@
-use crate::{
-	config::key_bindings::KeyBindings,
-	display::{Event, KeyCode, KeyModifiers, MouseEventKind},
-	input::Input,
-};
-
-fn modifiers_to_string(modifiers: KeyModifiers, code: Option<KeyCode>) -> String {
-	let mut result = vec![];
-
-	if modifiers.contains(KeyModifiers::SHIFT) {
-		if let Some(KeyCode::Char(k)) = code {
-			if k == '\t' || k == '\n' || k == '\u{7f}' {
-				result.push(String::from("Shift"));
-			}
-		}
-		else {
-			result.push(String::from("Shift"));
-		}
-	}
-	if modifiers.contains(KeyModifiers::CONTROL) {
-		result.push(String::from("Control"));
-	}
-	if modifiers.contains(KeyModifiers::ALT) {
-		result.push(String::from("Alt"));
-	}
-	result.join("")
-}
+use crate::{config::key_bindings::KeyBindings, input::Input};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum InputMode {
@@ -44,60 +18,7 @@ impl<'i> InputHandler<'i> {
 		Self { key_bindings }
 	}
 
-	pub(crate) fn get_input(&self, mode: InputMode, event: Event) -> Input {
-		let input = match event {
-			Event::Key(event) => {
-				let code = format!(
-					"{}{}",
-					modifiers_to_string(event.modifiers, Some(event.code)),
-					match event.code {
-						KeyCode::Backspace => String::from("Backspace"),
-						KeyCode::BackTab => String::from("BackTab"),
-						KeyCode::Delete => String::from("Delete"),
-						KeyCode::Down => String::from("Down"),
-						KeyCode::End => String::from("End"),
-						KeyCode::Enter => String::from("Enter"),
-						KeyCode::Esc => String::from("Esc"),
-						KeyCode::F(i) => format!("F{}", i),
-						KeyCode::Home => String::from("Home"),
-						KeyCode::Insert => String::from("Insert"),
-						KeyCode::Left => String::from("Left"),
-						KeyCode::Null => String::from("Other"),
-						KeyCode::PageDown => String::from("PageDown"),
-						KeyCode::PageUp => String::from("PageUp"),
-						KeyCode::Right => String::from("Right"),
-						KeyCode::Tab => String::from("Tab"),
-						KeyCode::Up => String::from("Up"),
-						KeyCode::Char(c) if c == '\t' => String::from("Tab"),
-						KeyCode::Char(c) if c == '\n' => String::from("Enter"),
-						KeyCode::Char(c) if c == '\u{7f}' => String::from("Backspace"),
-						KeyCode::Char(c) => String::from(c),
-					}
-				);
-
-				match code.as_str() {
-					"Controlc" => String::from("Kill"),
-					"Controld" => String::from("Exit"),
-					_ => code,
-				}
-			},
-			Event::Mouse(event) => {
-				format!("{}{}", modifiers_to_string(event.modifiers, None), match event.kind {
-					MouseEventKind::ScrollDown => String::from("Down"),
-					MouseEventKind::ScrollUp => String::from("Up"),
-					_ => String::from("Ignore"),
-				})
-			},
-			Event::Resize(..) => String::from("Resize"),
-		};
-
-		// this is a hack to work around unhandled mouse events, input handling needs to be changed
-		// to properly handle dynamic inputs like mouse events
-		// TODO remove hack
-		if input == "Ignore" {
-			return Input::Ignore;
-		}
-
+	pub(crate) fn get_input(&self, mode: InputMode, input: String) -> Input {
 		match mode {
 			InputMode::Confirm => self.get_confirm(input.as_str()),
 			InputMode::Default => Self::get_default_input(input.as_str()),
@@ -226,11 +147,10 @@ impl<'i> InputHandler<'i> {
 mod tests {
 	use std::{env::set_var, path::Path};
 
-	use crossterm::event::MouseEvent;
 	use rstest::rstest;
 
 	use super::*;
-	use crate::{config::Config, create_key_event, create_mouse_event};
+	use crate::config::Config;
 
 	fn input_handler_test<G, C>(config_setup: G, callback: C)
 	where
@@ -252,122 +172,38 @@ mod tests {
 		callback(&input_handler);
 	}
 
-	#[test]
-	fn modifiers_to_string_no_modifiers() {
-		assert_eq!(modifiers_to_string(KeyModifiers::NONE, None), "");
-	}
-
-	#[test]
-	fn modifiers_to_string_alt() {
-		assert_eq!(modifiers_to_string(KeyModifiers::ALT, None), "Alt");
-	}
-
-	#[test]
-	fn modifiers_to_string_control() {
-		assert_eq!(modifiers_to_string(KeyModifiers::CONTROL, None), "Control");
-	}
-
-	#[test]
-	fn modifiers_to_string_shift() {
-		assert_eq!(modifiers_to_string(KeyModifiers::SHIFT, None), "Shift");
-	}
-
-	#[test]
-	fn modifiers_to_string_combined() {
-		assert_eq!(modifiers_to_string(KeyModifiers::all(), None), "ShiftControlAlt");
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_char() {
-		assert_eq!(modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('A'))), "");
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_char_tab() {
-		assert_eq!(
-			modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\t'))),
-			"Shift"
-		);
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_newline() {
-		assert_eq!(
-			modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\n'))),
-			"Shift"
-		);
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_backspace() {
-		assert_eq!(
-			modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Char('\u{7f}'))),
-			"Shift"
-		);
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_other() {
-		assert_eq!(modifiers_to_string(KeyModifiers::SHIFT, Some(KeyCode::Enter)), "Shift");
-	}
-
-	#[test]
-	fn modifiers_to_string_with_code_alphabetic_combined() {
-		assert_eq!(
-			modifiers_to_string(KeyModifiers::all(), Some(KeyCode::Char('A'))),
-			"ControlAlt"
-		);
-	}
-
-	#[test]
-	#[serial_test::serial]
-	fn ignore_hack() {
-		input_handler_test(
-			|_| {},
-			|input_handler: &InputHandler<'_>| {
-				assert_eq!(
-					input_handler.get_input(
-						InputMode::Confirm,
-						Event::Mouse(MouseEvent {
-							kind: MouseEventKind::Moved,
-							column: 0,
-							row: 0,
-							modifiers: KeyModifiers::NONE
-						})
-					),
-					Input::Ignore
-				);
-			},
-		);
-	}
 	#[rstest(
 		input,
 		expected,
-		case::yes_lower(create_key_event!('y'), Input::Yes),
-		case::yes_upper(create_key_event!('Y'), Input::Yes),
-		case::no_n_lower(create_key_event!('n'), Input::No),
-		case::no_n_upper(create_key_event!('N'), Input::No),
-		case::no_other(create_key_event!(code KeyCode::Null), Input::No),
-		case::standard_resize(Event::Resize(0, 0), Input::Resize),
-		case::standard_move_up(create_key_event!(code KeyCode::Up), Input::ScrollUp),
-		case::standard_move_down(create_key_event!(code KeyCode::Down), Input::ScrollDown),
-		case::standard_move_left(create_key_event!(code KeyCode::Left), Input::ScrollLeft),
-		case::standard_move_right(create_key_event!(code KeyCode::Right), Input::ScrollRight),
-		case::standard_move_jump_up(create_key_event!(code KeyCode::PageUp), Input::ScrollJumpUp),
-		case::standard_move_jump_down(create_key_event!(code KeyCode::PageDown), Input::ScrollJumpDown),
-		case::standard_exit(create_key_event!('d', "Control"), Input::Exit),
-		case::standard_kill(create_key_event!('c', "Control"), Input::Kill),
-		case::exit(create_key_event!('d', "Control"), Input::Exit),
-		case::multiple_bindings(create_key_event!('7'), Input::Yes)
+		case::yes_lower("y", Input::Yes),
+		case::yes_upper("Y", Input::Yes),
+		case::no_n_lower("n", Input::No),
+		case::no_n_upper("N", Input::No),
+		case::no_other("x", Input::No),
+		case::multiple_bindings("7", Input::Yes),
+		case::standard_resize("Resize", Input::Resize),
+		case::standard_move_up("Up", Input::ScrollUp),
+		case::standard_move_down("Down", Input::ScrollDown),
+		case::standard_move_left("Left", Input::ScrollLeft),
+		case::standard_move_right("Right", Input::ScrollRight),
+		case::standard_move_jump_up("PageUp", Input::ScrollJumpUp),
+		case::standard_move_jump_down("PageDown", Input::ScrollJumpDown),
+		case::standard_move_end("End", Input::ScrollBottom),
+		case::standard_move_home("Home", Input::ScrollTop),
+		case::standard_exit("Exit", Input::Exit),
+		case::standard_kill("Kill", Input::Kill)
 	)]
 	#[serial_test::serial]
-	fn confirm_mode(input: Event, expected: Input) {
+	fn confirm_mode(input: &str, expected: Input) {
 		input_handler_test(
 			|config| {
 				config.key_bindings.confirm_yes = vec![String::from('y'), String::from('7')];
 			},
 			|input_handler: &InputHandler<'_>| {
-				assert_eq!(input_handler.get_input(InputMode::Confirm, input), expected);
+				assert_eq!(
+					input_handler.get_input(InputMode::Confirm, String::from(input)),
+					expected
+				);
 			},
 		);
 	}
@@ -375,34 +211,37 @@ mod tests {
 	#[rstest(
 		input,
 		expected,
-		case::character(create_key_event!('a'), Input::Character('a')),
-		case::tab_character(create_key_event!('\t'), Input::Tab),
-		case::tab_key_code(create_key_event!(code KeyCode::Tab), Input::Tab),
-		case::backspace_key(create_key_event!(code KeyCode::Backspace), Input::Backspace),
-		case::backspace_character(create_key_event!('\u{7f}'), Input::Backspace),
-		case::enter(create_key_event!(code KeyCode::Enter), Input::Enter),
-		case::newline(create_key_event!('\n'), Input::Enter),
-		case::other(create_key_event!(code KeyCode::Null), Input::Other),
-		case::standard_resize(Event::Resize(0, 0), Input::Resize),
-		case::standard_move_up(create_key_event!(code KeyCode::Up), Input::ScrollUp),
-		case::standard_move_down(create_key_event!(code KeyCode::Down), Input::ScrollDown),
-		case::standard_move_left(create_key_event!(code KeyCode::Left), Input::ScrollLeft),
-		case::standard_move_right(create_key_event!(code KeyCode::Right), Input::ScrollRight),
-		case::standard_move_jump_up(create_key_event!(code KeyCode::PageUp), Input::ScrollJumpUp),
-		case::standard_move_jump_down(create_key_event!(code KeyCode::PageDown), Input::ScrollJumpDown),
-		case::standard_exit(create_key_event!('d', "Control"), Input::Exit),
-		case::standard_kill(create_key_event!('c', "Control"), Input::Kill),
-		case::esc(create_key_event!(code KeyCode::Esc), Input::Escape),
-		case::mouse_down(create_mouse_event!(MouseEventKind::ScrollDown), Input::ScrollDown),
-		case::mouse_up(create_mouse_event!(MouseEventKind::ScrollUp), Input::ScrollUp)
-
+		case::character("a", Input::Character('a')),
+		case::backspace_key("Backspace", Input::Backspace),
+		case::tab_character("BackTab", Input::BackTab),
+		case::delete("Delete", Input::Delete),
+		case::enter("Enter", Input::Enter),
+		case::escape("Esc", Input::Escape),
+		case::insert("Insert", Input::Insert),
+		case::other_characters("AB", Input::Other),
+		case::other("Other", Input::Other),
+		case::tab_character("Tab", Input::Tab),
+		case::standard_resize("Resize", Input::Resize),
+		case::standard_move_up("Up", Input::ScrollUp),
+		case::standard_move_down("Down", Input::ScrollDown),
+		case::standard_move_left("Left", Input::ScrollLeft),
+		case::standard_move_right("Right", Input::ScrollRight),
+		case::standard_move_jump_up("PageUp", Input::ScrollJumpUp),
+		case::standard_move_jump_down("PageDown", Input::ScrollJumpDown),
+		case::standard_move_end("End", Input::ScrollBottom),
+		case::standard_move_home("Home", Input::ScrollTop),
+		case::standard_exit("Exit", Input::Exit),
+		case::standard_kill("Kill", Input::Kill)
 	)]
 	#[serial_test::serial]
-	fn default_mode(input: Event, expected: Input) {
+	fn default_mode(input: &str, expected: Input) {
 		input_handler_test(
 			|_| {},
 			|input_handler: &InputHandler<'_>| {
-				assert_eq!(input_handler.get_input(InputMode::Default, input), expected);
+				assert_eq!(
+					input_handler.get_input(InputMode::Default, String::from(input)),
+					expected
+				);
 			},
 		);
 	}
@@ -410,50 +249,50 @@ mod tests {
 	#[rstest(
 		input,
 		expected,
-		case::abort(create_key_event!('q'), Input::Abort),
-		case::action_break(create_key_event!('b'), Input::ActionBreak),
-		case::action_drop(create_key_event!('d'), Input::ActionDrop),
-		case::action_edit(create_key_event!('e'), Input::ActionEdit),
-		case::action_fixup(create_key_event!('f'), Input::ActionFixup),
-		case::action_pick(create_key_event!('p'), Input::ActionPick),
-		case::action_reword(create_key_event!('r'), Input::ActionReword),
-		case::action_squash(create_key_event!('s'), Input::ActionSquash),
-		case::edit(create_key_event!('E'), Input::Edit),
-		case::force_abort(create_key_event!('Q'), Input::ForceAbort),
-		case::force_rebase(create_key_event!('W'), Input::ForceRebase),
-		case::help(create_key_event!('?'), Input::Help),
-		case::insert_line(create_key_event!('I'), Input::InsertLine),
-		case::move_down(create_key_event!(code KeyCode::Down), Input::MoveCursorDown),
-		case::move_end(create_key_event!(code KeyCode::End), Input::MoveCursorEnd),
-		case::move_home(create_key_event!(code KeyCode::Home), Input::MoveCursorHome),
-		case::move_left(create_key_event!(code KeyCode::Left), Input::MoveCursorLeft),
-		case::move_page_down(create_key_event!(code KeyCode::PageDown), Input::MoveCursorPageDown),
-		case::move_page_up(create_key_event!(code KeyCode::PageUp), Input::MoveCursorPageUp),
-		case::move_right(create_key_event!(code KeyCode::Right), Input::MoveCursorRight),
-		case::move_up(create_key_event!(code KeyCode::Up), Input::MoveCursorUp),
-		case::open_in_external_editor(create_key_event!('!'), Input::OpenInEditor),
-		case::rebase(create_key_event!('w'), Input::Rebase),
-		case::redo(create_key_event!('y', "Control"), Input::Redo),
-		case::remove_line(create_key_event!(code KeyCode::Delete), Input::Delete),
-		case::show_commit(create_key_event!('c'), Input::ShowCommit),
-		case::swap_selected_down(create_key_event!('j'), Input::SwapSelectedDown),
-		case::swap_selected_up(create_key_event!('k'), Input::SwapSelectedUp),
-		case::toggle_visual_mode(create_key_event!('v'), Input::ToggleVisualMode),
-		case::undo(create_key_event!('z', "Control"), Input::Undo),
-		case::resize(Event::Resize(0, 0), Input::Resize),
-		case::other(create_key_event!('z'), Input::Other),
-		case::exit(create_key_event!('d', "Control"), Input::Exit),
-		case::exit(create_key_event!('c', "Control"), Input::Kill),
-		case::multiple_bindings(create_key_event!('7'), Input::Abort)
+		case::abort("q", Input::Abort),
+		case::action_break("b", Input::ActionBreak),
+		case::action_drop("d", Input::ActionDrop),
+		case::action_edit("e", Input::ActionEdit),
+		case::action_fixup("f", Input::ActionFixup),
+		case::action_pick("p", Input::ActionPick),
+		case::action_reword("r", Input::ActionReword),
+		case::action_squash("s", Input::ActionSquash),
+		case::edit("E", Input::Edit),
+		case::force_abort("Q", Input::ForceAbort),
+		case::force_rebase("W", Input::ForceRebase),
+		case::help("?", Input::Help),
+		case::insert_line("I", Input::InsertLine),
+		case::move_down("Down", Input::MoveCursorDown),
+		case::move_end("End", Input::MoveCursorEnd),
+		case::move_home("Home", Input::MoveCursorHome),
+		case::move_left("Left", Input::MoveCursorLeft),
+		case::move_page_down("PageDown", Input::MoveCursorPageDown),
+		case::move_page_up("PageUp", Input::MoveCursorPageUp),
+		case::move_right("Right", Input::MoveCursorRight),
+		case::move_up("Up", Input::MoveCursorUp),
+		case::open_in_external_editor("!", Input::OpenInEditor),
+		case::rebase("w", Input::Rebase),
+		case::redo("Controly", Input::Redo),
+		case::remove_line("Delete", Input::Delete),
+		case::show_commit("c", Input::ShowCommit),
+		case::swap_selected_down("j", Input::SwapSelectedDown),
+		case::swap_selected_up("k", Input::SwapSelectedUp),
+		case::toggle_visual_mode("v", Input::ToggleVisualMode),
+		case::undo("Controlz", Input::Undo),
+		case::other("z", Input::Other),
+		case::standard_exit("Exit", Input::Exit),
+		case::standard_kill("Kill", Input::Kill),
+		case::standard_resize("Resize", Input::Resize),
+		case::multiple_bindings("7", Input::Abort)
 	)]
 	#[serial_test::serial]
-	fn list_mode(input: Event, expected: Input) {
+	fn list_mode(input: &str, expected: Input) {
 		input_handler_test(
 			|config| {
 				config.key_bindings.abort = vec![String::from('q'), String::from('7')];
 			},
 			|input_handler: &InputHandler<'_>| {
-				assert_eq!(input_handler.get_input(InputMode::List, input), expected);
+				assert_eq!(input_handler.get_input(InputMode::List, String::from(input)), expected);
 			},
 		);
 	}
@@ -461,33 +300,34 @@ mod tests {
 	#[rstest(
 		input,
 		expected,
-		case::backspace_character(create_key_event!(code KeyCode::Backspace), Input::Backspace),
-		case::backtab_key(create_key_event!(code KeyCode::BackTab), Input::BackTab),
-		case::delete_key(create_key_event!(code KeyCode::Delete), Input::Delete),
-		case::down_key(create_key_event!(code KeyCode::Down), Input::Down),
-		case::end_key(create_key_event!(code KeyCode::End), Input::End),
-		case::enter_key(create_key_event!(code KeyCode::Enter), Input::Enter),
-		case::exit_key(create_key_event!('d', "Control"), Input::Exit),
-		case::home_key(create_key_event!(code KeyCode::Home), Input::Home),
-		case::insert_key(create_key_event!(code KeyCode::Insert), Input::Insert),
-		case::kill_key(create_key_event!('c', "Control"), Input::Kill),
-		case::left_key(create_key_event!(code KeyCode::Left), Input::Left),
-		case::other(create_key_event!(code KeyCode::Null), Input::Other),
-		case::page_down_key(create_key_event!(code KeyCode::PageDown), Input::PageDown),
-		case::page_up_key(create_key_event!(code KeyCode::PageUp), Input::PageUp),
-		case::resize_key(Event::Resize(0, 0), Input::Resize),
-		case::right_key(create_key_event!(code KeyCode::Right), Input::Right),
-		case::tab_key(create_key_event!(code KeyCode::Tab), Input::Tab),
-		case::up_key(create_key_event!(code KeyCode::Up), Input::Up),
-		case::character(create_key_event!('a'), Input::Character('a')),
-		case::unknown(create_key_event!(code KeyCode::F(1)), Input::Other)
+		case::backspace_character("Backspace", Input::Backspace),
+		case::backtab_key("BackTab", Input::BackTab),
+		case::delete_key("Delete", Input::Delete),
+		case::down_key("Down", Input::Down),
+		case::end_key("End", Input::End),
+		case::enter_key("Enter", Input::Enter),
+		case::escape_key("Esc", Input::Escape),
+		case::standard_exit("Exit", Input::Exit),
+		case::home_key("Home", Input::Home),
+		case::insert_key("Insert", Input::Insert),
+		case::standard_kill("Kill", Input::Kill),
+		case::left_key("Left", Input::Left),
+		case::other("Other", Input::Other),
+		case::page_down_key("PageDown", Input::PageDown),
+		case::page_up_key("PageUp", Input::PageUp),
+		case::standard_resize("Resize", Input::Resize),
+		case::right_key("Right", Input::Right),
+		case::tab_key("Tab", Input::Tab),
+		case::up_key("Up", Input::Up),
+		case::character("a", Input::Character('a')),
+		case::unknown("F(1)", Input::Other)
 	)]
 	#[serial_test::serial]
-	fn raw_mode(input: Event, expected: Input) {
+	fn raw_mode(input: &str, expected: Input) {
 		input_handler_test(
 			|_| {},
 			|input_handler: &InputHandler<'_>| {
-				assert_eq!(input_handler.get_input(InputMode::Raw, input), expected);
+				assert_eq!(input_handler.get_input(InputMode::Raw, String::from(input)), expected);
 			},
 		);
 	}
@@ -495,29 +335,31 @@ mod tests {
 	#[rstest(
 		input,
 		expected,
-		case::help(create_key_event!('?'), Input::Help),
-		case::show_diff(create_key_event!('d'), Input::ShowDiff),
-		case::other(create_key_event!(code KeyCode::Null), Input::Other),
-		case::standard_resize(Event::Resize(0, 0), Input::Resize),
-		case::standard_move_up(create_key_event!(code KeyCode::Up), Input::ScrollUp),
-		case::standard_move_down(create_key_event!(code KeyCode::Down), Input::ScrollDown),
-		case::standard_move_left(create_key_event!(code KeyCode::Left), Input::ScrollLeft),
-		case::standard_move_right(create_key_event!(code KeyCode::Right), Input::ScrollRight),
-		case::standard_move_jump_up(create_key_event!(code KeyCode::PageUp), Input::ScrollJumpUp),
-		case::standard_move_jump_down(create_key_event!(code KeyCode::PageDown), Input::ScrollJumpDown),
-		case::standard_exit(create_key_event!('d', "Control"), Input::Exit),
-		case::standard_kill(create_key_event!('c', "Control"), Input::Kill),
-		case::multiple_bindings(create_key_event!('7'), Input::ShowDiff),
-
+		case::help("?", Input::Help),
+		case::show_diff("d", Input::ShowDiff),
+		case::other("Null", Input::Other),
+		case::standard_resize("Resize", Input::Resize),
+		case::standard_move_up("Up", Input::ScrollUp),
+		case::standard_move_down("Down", Input::ScrollDown),
+		case::standard_move_left("Left", Input::ScrollLeft),
+		case::standard_move_right("Right", Input::ScrollRight),
+		case::standard_move_jump_up("PageUp", Input::ScrollJumpUp),
+		case::standard_move_jump_down("PageDown", Input::ScrollJumpDown),
+		case::standard_exit("Exit", Input::Exit),
+		case::standard_kill("Kill", Input::Kill),
+		case::multiple_bindings("7", Input::ShowDiff)
 	)]
 	#[serial_test::serial]
-	fn show_commit_mode(input: Event, expected: Input) {
+	fn show_commit_mode(input: &str, expected: Input) {
 		input_handler_test(
 			|config| {
 				config.key_bindings.show_diff = vec![String::from('d'), String::from('7')];
 			},
 			|input_handler: &InputHandler<'_>| {
-				assert_eq!(input_handler.get_input(InputMode::ShowCommit, input), expected);
+				assert_eq!(
+					input_handler.get_input(InputMode::ShowCommit, String::from(input)),
+					expected
+				);
 			},
 		);
 	}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,4 +1,7 @@
+mod event_handler;
 pub mod input_handler;
+
+pub use event_handler::EventHandler;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Input {
@@ -65,7 +68,4 @@ pub enum Input {
 	Right,
 	Tab,
 	Up,
-
-	// some events should be
-	Ignore,
 }

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -246,7 +246,6 @@ fn format_process_result(
 				Input::ForceRebase => String::from("ForceRebase"),
 				Input::Help => String::from("Help"),
 				Input::Home => String::from("Home"),
-				Input::Ignore => String::from("Ignore"),
 				Input::Insert => String::from("Insert"),
 				Input::InsertLine => String::from("InsertLine"),
 				Input::Kill => String::from("Kill"),


### PR DESCRIPTION
# Description

Instead of having every module perform a resize of the view_data, return a mutable reference and have the view do a resize in all cases where possible.