### PR TITLE
Refactor external editor command running

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::EventHandler,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData},
 };
 
 pub struct ConfirmAbort {
@@ -18,7 +18,7 @@ impl ProcessModule for ConfirmAbort {
 	fn handle_events(
 		&mut self,
 		event_handler: &EventHandler,
-		_: &mut View<'_>,
+		_: &RenderContext,
 		rebase_todo: &mut TodoFile,
 	) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::EventHandler,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData},
 };
 
 pub struct ConfirmRebase {
@@ -15,7 +15,7 @@ impl ProcessModule for ConfirmRebase {
 		self.dialog.get_view_data()
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);
 		let mut result = ProcessResult::from(event);
 		match confirmed {

--- a/src/external_editor/tests.rs
+++ b/src/external_editor/tests.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use super::*;
 use crate::{
 	assert_process_result,
@@ -7,26 +5,6 @@ use crate::{
 	input::{Event, KeyCode},
 	process::testutil::{process_module_test, TestContext, ViewState},
 };
-
-fn get_external_editor(content: &str, exit_code: &str) -> String {
-	format!(
-		"{} \"{}\" % \"{}\"",
-		Path::new(env!("CARGO_MANIFEST_DIR"))
-			.join("test")
-			.join("write-content.sh")
-			.to_str()
-			.unwrap(),
-		content,
-		exit_code
-	)
-}
-
-#[macro_export]
-macro_rules! assert_external_editor_state_eq {
-	($actual:expr, $expected:expr) => {
-		assert_external_editor_state_eq(&$actual, &$expected);
-	};
-}
 
 fn assert_external_editor_state_eq(actual: &ExternalEditorState, expected: &ExternalEditorState) {
 	let actual_state = match *actual {
@@ -59,20 +37,39 @@ fn assert_external_editor_state_eq(actual: &ExternalEditorState, expected: &Exte
 	}
 }
 
+#[macro_export]
+macro_rules! assert_external_editor_state_eq {
+	($actual:expr, $expected:expr) => {
+		assert_external_editor_state_eq(&$actual, &$expected);
+	};
+}
+
 #[test]
 fn activate() {
 	process_module_test(
 		&["pick aaa comment1", "drop bbb comment2"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
+		&[],
 		|test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
+			let mut module = ExternalEditor::new("editor");
+			assert_process_result!(
+				test_context.activate(&mut module, State::List),
+				external_command = (String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			);
 			assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![
 				Line::new("pick aaa comment1").unwrap(),
 				Line::new("drop bbb comment2").unwrap()
 			]);
+			assert!(!module.lines.is_empty());
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
+			assert_eq!(
+				module.external_command,
+				(String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			)
 		},
 	);
 }
@@ -82,10 +79,10 @@ fn activate_write_file_fail() {
 	process_module_test(
 		&["pick aaa comment"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
+		&[],
 		|test_context: TestContext<'_>| {
 			let todo_path = test_context.get_todo_file_path();
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "0").as_str());
+			let mut module = ExternalEditor::new("editor");
 			test_context.set_todo_file_readonly();
 			assert_process_result!(
 				test_context.activate(&mut module, State::List),
@@ -97,13 +94,28 @@ fn activate_write_file_fail() {
 }
 
 #[test]
+fn activate_file_placement_marker() {
+	process_module_test(&[], ViewState::default(), &[], |test_context: TestContext<'_>| {
+		let mut module = ExternalEditor::new("editor a % b");
+		assert_process_result!(
+			test_context.activate(&mut module, State::List),
+			external_command = (String::from("editor"), vec![
+				String::from("a"),
+				String::from(test_context.rebase_todo_file.get_filepath()),
+				String::from("b")
+			])
+		);
+	});
+}
+
+#[test]
 fn deactivate() {
 	process_module_test(
 		&["pick aaa comment", "drop bbb comment2"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
+		&[],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "0").as_str());
+			let mut module = ExternalEditor::new("editor");
 			test_context.deactivate(&mut module);
 			assert_eq!(module.lines, vec![]);
 		},
@@ -115,13 +127,21 @@ fn edit_success() {
 	process_module_test(
 		&["pick aaa comment"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
+		&[],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
+			test_context
+				.event_handler_context
+				.event_handler
+				.push_event(Event::from(MetaEvent::ExternalCommandSuccess));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(view_data, "{TITLE}", "{LEADING}", "{Normal}Editing...");
-			assert_process_result!(test_context.handle_event(&mut module), state = State::List);
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from(MetaEvent::ExternalCommandSuccess),
+				state = State::List
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 		},
 	);
@@ -134,9 +154,18 @@ fn empty_edit_error() {
 		ViewState::default(),
 		&[Event::from('1')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
+			test_context
+				.event_handler_context
+				.event_handler
+				.push_event(Event::from(MetaEvent::ExternalCommandSuccess));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			test_context.rebase_todo_file.set_lines(vec![]);
+			test_context.rebase_todo_file.write_file().unwrap();
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from(MetaEvent::ExternalCommandSuccess)
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Empty);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -163,11 +192,9 @@ fn empty_edit_abort_rebase() {
 		ViewState::default(),
 		&[Event::from('1')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(module.state, ExternalEditorState::Empty);
-			test_context.build_view_data(&mut module);
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Empty;
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from('1'),
@@ -184,12 +211,16 @@ fn empty_edit_re_edit_rebase_file() {
 		ViewState::default(),
 		&[Event::from('2')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(module.state, ExternalEditorState::Empty);
-			test_context.build_view_data(&mut module);
-			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('2'));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Empty;
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from('2'),
+				external_command = (String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 		},
 	);
@@ -202,12 +233,16 @@ fn empty_edit_undo_and_edit() {
 		ViewState::default(),
 		&[Event::from('3')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(module.state, ExternalEditorState::Empty);
-			test_context.build_view_data(&mut module);
-			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('3'));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Empty;
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from('3'),
+				external_command = (String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 			assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![
 				Line::new("pick aaa comment").unwrap(),
@@ -222,12 +257,12 @@ fn empty_edit_noop() {
 	process_module_test(
 		&["pick aaa comment"],
 		ViewState::default(),
-		&[Event::from('1')],
+		&[],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("noop", "0").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(module.state, ExternalEditorState::Empty);
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Empty;
+			test_context.rebase_todo_file.set_lines(vec![]);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -251,75 +286,13 @@ fn no_editor_set() {
 	process_module_test(
 		&["pick aaa comment"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
-		|mut test_context: TestContext<'_>| {
+		&[],
+		|test_context: TestContext<'_>| {
 			let mut module = ExternalEditor::new("");
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(
-				module.state,
-				ExternalEditorState::Error(
-					anyhow!("Please see the git \"core.editor\" configuration for details")
-						.context(anyhow!("No editor configured"))
-				)
-			);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal}No editor configured",
-				"{Normal}Please see the git \"core.editor\" configuration for details",
-				"",
-				"{BODY}",
-				"{Normal}1) Abort rebase",
-				"{Normal}2) Edit rebase file",
-				"{Normal}3) Restore rebase file and abort edit",
-				"{Normal}4) Undo modifications and edit rebase file",
-				"",
-				"{IndicatorColor}Please choose an option."
-			);
-		},
-	);
-}
-
-#[test]
-fn invalid_editor_set() {
-	process_module_test(
-		&["pick aaa comment"],
-		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(
-				Path::new(env!("CARGO_MANIFEST_DIR"))
-					.join("test")
-					.join("not-executable.sh")
-					.to_str()
-					.unwrap(),
-			);
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			assert_external_editor_state_eq!(
-				module.state,
-				ExternalEditorState::Error(
-					anyhow!("Permission denied (os error 13)").context(anyhow!("Unable to run editor"))
-				)
-			);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal}Unable to run editor",
-				"{Normal}Permission denied (os error 13)",
-				"",
-				"{BODY}",
-				"{Normal}1) Abort rebase",
-				"{Normal}2) Edit rebase file",
-				"{Normal}3) Restore rebase file and abort edit",
-				"{Normal}4) Undo modifications and edit rebase file",
-				"",
-				"{IndicatorColor}Please choose an option."
+			assert_process_result!(
+				test_context.activate(&mut module, State::List),
+				state = State::List,
+				error = anyhow!("No editor configured: Please see the git \"core.editor\" configuration for details")
 			);
 		},
 	);
@@ -330,11 +303,18 @@ fn editor_non_zero_exit() {
 	process_module_test(
 		&["pick aaa comment"],
 		ViewState::default(),
-		&[Event::from(KeyCode::Up)],
+		&[],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "1").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
+			let mut module = ExternalEditor::new("editor");
+			test_context
+				.event_handler_context
+				.event_handler
+				.push_event(Event::from(MetaEvent::ExternalCommandError));
+			test_context.activate(&mut module, State::List);
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from(MetaEvent::ExternalCommandError)
+			);
 			assert_external_editor_state_eq!(
 				module.state,
 				ExternalEditorState::Error(anyhow!("Editor returned a non-zero exit status"))
@@ -366,10 +346,17 @@ fn editor_reload_error() {
 		&[Event::from(KeyCode::Up)],
 		|mut test_context: TestContext<'_>| {
 			let todo_path = test_context.get_todo_file_path();
-			let mut module = ExternalEditor::new("true");
-			assert_process_result!(test_context.activate(&mut module, State::List));
+			let mut module = ExternalEditor::new("editor");
+			test_context
+				.event_handler_context
+				.event_handler
+				.push_event(Event::from(MetaEvent::ExternalCommandSuccess));
+			test_context.activate(&mut module, State::List);
 			test_context.delete_todo_file();
-			assert_process_result!(test_context.handle_event(&mut module));
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from(MetaEvent::ExternalCommandSuccess)
+			);
 			assert_external_editor_state_eq!(
 				module.state,
 				ExternalEditorState::Error(
@@ -403,10 +390,9 @@ fn error_abort_rebase() {
 		ViewState::default(),
 		&[Event::from('1')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "1").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			test_context.build_view_data(&mut module);
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Error(anyhow!("Error!"));
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from('1'),
@@ -424,11 +410,16 @@ fn error_edit_rebase() {
 		ViewState::default(),
 		&[Event::from('2')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("pick aaa comment", "1").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			test_context.build_view_data(&mut module);
-			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('2'));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Error(anyhow!("Error!"));
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from('2'),
+				external_command = (String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 		},
 	);
@@ -441,10 +432,9 @@ fn error_restore_and_abort() {
 		ViewState::default(),
 		&[Event::from('3')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("drop aaa comment", "1").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			test_context.build_view_data(&mut module);
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Error(anyhow!("Error!"));
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from('3'),
@@ -465,11 +455,16 @@ fn error_undo_modifications_and_reedit() {
 		ViewState::default(),
 		&[Event::from('4')],
 		|mut test_context: TestContext<'_>| {
-			let mut module = ExternalEditor::new(get_external_editor("rdop aaa comment", "1").as_str());
-			assert_process_result!(test_context.activate(&mut module, State::List));
-			assert_process_result!(test_context.handle_event(&mut module));
-			test_context.build_view_data(&mut module);
-			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('4'));
+			let mut module = ExternalEditor::new("editor");
+			test_context.activate(&mut module, State::List);
+			module.state = ExternalEditorState::Error(anyhow!("Error!"));
+			assert_process_result!(
+				test_context.handle_event(&mut module),
+				event = Event::from('4'),
+				external_command = (String::from("editor"), vec![String::from(
+					test_context.rebase_todo_file.get_filepath()
+				)])
+			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 			assert_eq!(test_context.rebase_todo_file.get_lines_owned(), vec![Line::new(
 				"pick aaa comment"

--- a/src/input/meta_event.rs
+++ b/src/input/meta_event.rs
@@ -43,4 +43,6 @@ pub enum MetaEvent {
 	ToggleVisualMode,
 	Undo,
 	Yes,
+	ExternalCommandSuccess,
+	ExternalCommandError,
 }

--- a/src/input/testutil.rs
+++ b/src/input/testutil.rs
@@ -75,6 +75,8 @@ fn map_event_to_crossterm(event: Event) -> crossterm::event::Event {
 					}
 				},
 				MetaEvent::Yes => KeyEvent::from(KeyCode::Char('y')),
+				MetaEvent::ExternalCommandSuccess => KeyEvent::from(KeyCode::Null),
+				MetaEvent::ExternalCommandError => KeyEvent::from(KeyCode::Null),
 			};
 			crossterm::event::Event::Key(key_event)
 		},

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 	insert::{insert_state::InsertState, line_type::LineType},
 	process::{process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::{line::Line, TodoFile},
-	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
 };
 
 pub struct Insert {
@@ -42,7 +42,7 @@ impl ProcessModule for Insert {
 	fn handle_events(
 		&mut self,
 		event_handler: &EventHandler,
-		_: &mut View<'_>,
+		_: &RenderContext,
 		rebase_todo: &mut TodoFile,
 	) -> ProcessResult {
 		match self.state {

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -11,7 +11,6 @@ use crate::{
 		render_context::RenderContext,
 		view_data::ViewData,
 		view_line::ViewLine,
-		View,
 	},
 };
 
@@ -34,7 +33,7 @@ impl ProcessModule for Error {
 		&mut self.view_data
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 		let mut result = ProcessResult::from(event);
 		if handle_view_data_scroll(event, &mut self.view_data).is_none() {

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -15,7 +15,7 @@ use crate::{
 	},
 	show_commit::ShowCommit,
 	todo_file::TodoFile,
-	view::{view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData},
 };
 
 pub struct Modules<'m> {
@@ -64,20 +64,24 @@ impl<'m> Modules<'m> {
 		self.get_mut_module(state).deactivate();
 	}
 
-	pub fn build_view_data(&mut self, state: State, view: &View<'_>, rebase_todo: &TodoFile) -> &mut ViewData {
-		let render_context = view.get_render_context();
-		self.get_mut_module(state).build_view_data(&render_context, rebase_todo)
+	pub fn build_view_data(
+		&mut self,
+		state: State,
+		render_context: &RenderContext,
+		rebase_todo: &TodoFile,
+	) -> &mut ViewData {
+		self.get_mut_module(state).build_view_data(render_context, rebase_todo)
 	}
 
-	pub fn handle_input<'r>(
+	pub fn handle_input(
 		&mut self,
 		state: State,
 		event_handler: &EventHandler,
-		view: &mut View<'r>,
+		render_context: &RenderContext,
 		rebase_todo: &mut TodoFile,
 	) -> ProcessResult {
 		self.get_mut_module(state)
-			.handle_events(event_handler, view, rebase_todo)
+			.handle_events(event_handler, render_context, rebase_todo)
 	}
 
 	pub fn set_error_message(&mut self, error: &anyhow::Error) {
@@ -94,7 +98,6 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		assert_process_result,
 		input::Event,
 		process::testutil::{process_module_test, TestContext, ViewState},
 	};
@@ -120,14 +123,14 @@ mod tests {
 				test_context.set_git_directory_environment();
 				let config = test_context.config.clone();
 				let mut modules = Modules::new(&config);
-				assert_process_result!(modules.activate(state, &test_context.rebase_todo_file, State::List));
+				modules.activate(state, &test_context.rebase_todo_file, State::List);
 				modules.handle_input(
 					state,
 					&test_context.event_handler_context.event_handler,
-					&mut test_context.view,
+					&test_context.render_context,
 					&mut test_context.rebase_todo_file,
 				);
-				modules.build_view_data(state, &test_context.view, &test_context.rebase_todo_file);
+				modules.build_view_data(state, &test_context.render_context, &test_context.rebase_todo_file);
 				modules.deactivate(state);
 			},
 		);

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -2,7 +2,7 @@ use crate::{
 	input::EventHandler,
 	process::{process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData, View},
+	view::{render_context::RenderContext, view_data::ViewData},
 };
 
 pub trait ProcessModule {
@@ -17,7 +17,7 @@ pub trait ProcessModule {
 	fn handle_events(
 		&mut self,
 		_event_handler: &EventHandler,
-		_view: &mut View<'_>,
+		_render_context: &RenderContext,
 		_rebase_todo: &mut TodoFile,
 	) -> ProcessResult;
 }

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -4,7 +4,7 @@ use crate::{
 	input::{Event, EventHandler, InputOptions},
 	process::{process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, View},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
 };
 
 const HEIGHT_ERROR_MESSAGE: &str = "Window too small, increase height to continue";
@@ -50,12 +50,17 @@ impl ProcessModule for WindowSizeError {
 		&mut self.view_data
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, view: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(
+		&mut self,
+		event_handler: &EventHandler,
+		render_context: &RenderContext,
+		_: &mut TodoFile,
+	) -> ProcessResult {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 		let mut result = ProcessResult::from(event);
 
 		if let Event::Resize(..) = event {
-			if !view.get_render_context().is_window_too_small() {
+			if !render_context.is_window_too_small() {
 				result = result.state(self.return_state);
 			}
 		}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -39,7 +39,6 @@ use crate::{
 		render_context::RenderContext,
 		view_data::ViewData,
 		view_line::ViewLine,
-		View,
 	},
 };
 
@@ -138,7 +137,7 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		&mut self.view_data
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut View<'_>, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
 		if self.help.is_active() {
 			return ProcessResult::from(self.help.handle_event(event_handler));
 		}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -12,8 +12,8 @@ use anyhow::Result;
 pub use util::handle_view_data_scroll;
 
 use crate::{
-	display::{display_color::DisplayColor, Display},
-	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
+	display::{display_color::DisplayColor, size::Size, Display},
+	view::{view_data::ViewData, view_line::ViewLine},
 	Config,
 };
 
@@ -39,13 +39,12 @@ impl<'v> View<'v> {
 		self.display.end()
 	}
 
-	pub(crate) fn get_render_context(&self) -> RenderContext {
-		let size = self.display.get_window_size();
-		RenderContext::new(size.width(), size.height())
+	pub(crate) fn get_view_size(&self) -> Size {
+		self.display.get_window_size()
 	}
 
 	pub(crate) fn render(&mut self, view_data: &mut ViewData) -> Result<()> {
-		let view_size = self.display.get_window_size();
+		let view_size = self.get_view_size();
 		let window_height = view_size.height();
 		view_data.set_view_size(view_size.width(), window_height);
 

--- a/src/view/render_context.rs
+++ b/src/view/render_context.rs
@@ -9,8 +9,16 @@ pub struct RenderContext {
 }
 
 impl RenderContext {
-	pub const fn new(width: usize, height: usize) -> Self {
-		Self { height, width }
+	pub const fn new(width: u16, height: u16) -> Self {
+		Self {
+			height: height as usize,
+			width: width as usize,
+		}
+	}
+
+	pub fn update(&mut self, width: u16, height: u16) {
+		self.width = width as usize;
+		self.height = height as usize;
 	}
 
 	pub const fn width(&self) -> usize {
@@ -41,6 +49,14 @@ impl RenderContext {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn update() {
+		let mut context = RenderContext { width: 10, height: 20 };
+		context.update(100, 200);
+		assert_eq!(context.width(), 100);
+		assert_eq!(context.height(), 200);
+	}
 
 	#[test]
 	fn is_window_too_small_width_too_small() {

--- a/test/write-content.sh
+++ b/test/write-content.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-echo "$1" > "$2"
-exit "$3"


### PR DESCRIPTION
# Description

Move the triggering of the external command to the process module and refactor external editor to use it instead. This also allows the view to be removed from all modules.
