### PR TITLE
Add ViewData updater function

### DIFF
--- a/src/components/choice/mod.rs
+++ b/src/components/choice/mod.rs
@@ -33,43 +33,48 @@ where T: Clone
 				(c, t)
 			})
 			.collect::<HashMap<char, T>>();
-		let mut view_data = ViewData::new();
-		view_data.set_show_title(true);
 		Self {
 			map,
 			options,
-			view_data,
+			view_data: ViewData::new(|updater| {
+				updater.set_show_title(true);
+			}),
 			invalid_selection: false,
 		}
 	}
 
 	pub fn set_prompt(&mut self, prompt_lines: Vec<ViewLine>) {
-		self.view_data.clear();
-		for line in prompt_lines {
-			self.view_data.push_leading_line(line);
-		}
-		self.view_data.push_leading_line(ViewLine::new_empty_line());
+		self.view_data.update_view_data(|updater| {
+			updater.clear();
+			for line in prompt_lines {
+				updater.push_leading_line(line);
+			}
+			updater.push_leading_line(ViewLine::new_empty_line());
+		});
 	}
 
 	pub fn get_view_data(&mut self) -> &mut ViewData {
-		self.view_data.clear_body();
-		for &(_, ref key, ref description) in &self.options {
-			self.view_data
-				.push_line(ViewLine::from(format!("{}) {}", key, description)));
-		}
-		self.view_data.push_line(ViewLine::new_empty_line());
-		if self.invalid_selection {
-			self.view_data.push_line(ViewLine::from(LineSegment::new_with_color(
-				"Invalid option selected. Please choose an option.",
-				DisplayColor::IndicatorColor,
-			)));
-		}
-		else {
-			self.view_data.push_line(ViewLine::from(LineSegment::new_with_color(
-				"Please choose an option.",
-				DisplayColor::IndicatorColor,
-			)));
-		}
+		let options = &self.options;
+		let invalid_selection = self.invalid_selection;
+		self.view_data.update_view_data(|updater| {
+			updater.clear_body();
+			for &(_, ref key, ref description) in options {
+				updater.push_line(ViewLine::from(format!("{}) {}", key, description)));
+			}
+			updater.push_line(ViewLine::new_empty_line());
+			if invalid_selection {
+				updater.push_line(ViewLine::from(LineSegment::new_with_color(
+					"Invalid option selected. Please choose an option.",
+					DisplayColor::IndicatorColor,
+				)));
+			}
+			else {
+				updater.push_line(ViewLine::from(LineSegment::new_with_color(
+					"Please choose an option.",
+					DisplayColor::IndicatorColor,
+				)));
+			}
+		});
 		&mut self.view_data
 	}
 

--- a/src/components/confirm/mod.rs
+++ b/src/components/confirm/mod.rs
@@ -20,14 +20,15 @@ pub struct Confirm {
 
 impl Confirm {
 	pub fn new(prompt: &str, confirm_yes: &[String], confirm_no: &[String]) -> Self {
-		let mut view_data = ViewData::new();
-		view_data.set_show_title(true);
-		view_data.push_line(ViewLine::from(format!(
-			"{} ({}/{})? ",
-			prompt,
-			confirm_yes.join(","),
-			confirm_no.join(",")
-		)));
+		let view_data = ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.push_line(ViewLine::from(format!(
+				"{} ({}/{})? ",
+				prompt,
+				confirm_yes.join(","),
+				confirm_no.join(",")
+			)));
+		});
 		Self { view_data }
 	}
 

--- a/src/components/edit/mod.rs
+++ b/src/components/edit/mod.rs
@@ -25,8 +25,9 @@ pub struct Edit {
 
 impl Edit {
 	pub(crate) fn new() -> Self {
-		let mut view_data = ViewData::new();
-		view_data.set_show_title(true);
+		let view_data = ViewData::new(|updater| {
+			updater.set_show_title(true);
+		});
 		Self {
 			content: String::from(""),
 			cursor_position: 0,
@@ -77,24 +78,23 @@ impl Edit {
 		}
 
 		let description = self.description.as_ref();
-
-		self.view_data.clear();
-		if let Some(description) = description {
-			self.view_data
-				.push_leading_line(ViewLine::from(vec![LineSegment::new_with_color(
+		self.view_data.update_view_data(|updater| {
+			updater.clear();
+			if let Some(description) = description {
+				updater.push_leading_line(ViewLine::from(vec![LineSegment::new_with_color(
 					description.as_str(),
 					DisplayColor::IndicatorColor,
 				)]));
-			self.view_data.push_leading_line(ViewLine::new_empty_line());
-		}
-		self.view_data.push_line(ViewLine::from(segments));
-		self.view_data
-			.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new_with_color(
+				updater.push_leading_line(ViewLine::new_empty_line());
+			}
+			updater.push_line(ViewLine::from(segments));
+			updater.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new_with_color(
 				"Enter to finish",
 				DisplayColor::IndicatorColor,
 			)]));
-		self.view_data.ensure_column_visible(pointer);
-		self.view_data.ensure_line_visible(0);
+			updater.ensure_column_visible(pointer);
+			updater.ensure_line_visible(0);
+		});
 		&mut self.view_data
 	}
 

--- a/src/components/help/mod.rs
+++ b/src/components/help/mod.rs
@@ -33,37 +33,38 @@ impl Help {
 
 	pub fn new_from_keybindings(keybindings: &[(Vec<String>, String)]) -> Self {
 		let max_key_length = Self::get_max_help_key_length(keybindings);
-		let mut view_data = ViewData::new();
-		view_data.set_show_title(true);
-		view_data.push_leading_line(
-			ViewLine::new_pinned(vec![LineSegment::new_with_color_and_style(
-				format!(" {0:width$} Action", "Key", width = max_key_length).as_str(),
-				DisplayColor::Normal,
-				false,
-				true,
-				false,
-			)])
-			.set_padding_color_and_style(DisplayColor::Normal, false, true, false),
-		);
+		let view_data = ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.push_leading_line(
+				ViewLine::new_pinned(vec![LineSegment::new_with_color_and_style(
+					format!(" {0:width$} Action", "Key", width = max_key_length).as_str(),
+					DisplayColor::Normal,
+					false,
+					true,
+					false,
+				)])
+				.set_padding_color_and_style(DisplayColor::Normal, false, true, false),
+			);
 
-		for line in keybindings {
-			view_data.push_line(ViewLine::new_with_pinned_segments(
-				vec![
-					LineSegment::new_with_color(
-						format!(" {0:width$}", line.0.join(", "), width = max_key_length).as_str(),
-						DisplayColor::IndicatorColor,
-					),
-					LineSegment::new_with_color_and_style("|", DisplayColor::Normal, true, false, false),
-					LineSegment::new(line.1.as_str()),
-				],
-				2,
-			));
-		}
+			for line in keybindings {
+				updater.push_line(ViewLine::new_with_pinned_segments(
+					vec![
+						LineSegment::new_with_color(
+							format!(" {0:width$}", line.0.join(", "), width = max_key_length).as_str(),
+							DisplayColor::IndicatorColor,
+						),
+						LineSegment::new_with_color_and_style("|", DisplayColor::Normal, true, false, false),
+						LineSegment::new(line.1.as_str()),
+					],
+					2,
+				));
+			}
 
-		view_data.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new_with_color(
-			"Press any key to close",
-			DisplayColor::IndicatorColor,
-		)]));
+			updater.push_trailing_line(ViewLine::new_pinned(vec![LineSegment::new_with_color(
+				"Press any key to close",
+				DisplayColor::IndicatorColor,
+			)]));
+		});
 		Self {
 			active: false,
 			view_data,

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -51,14 +51,16 @@ impl ProcessModule for ExternalEditor {
 
 	fn deactivate(&mut self) {
 		self.lines.clear();
-		self.view_data.reset();
+		self.view_data.update_view_data(|updater| updater.clear());
 	}
 
 	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
 		match self.state {
 			ExternalEditorState::Active => {
-				self.view_data.clear();
-				self.view_data.push_leading_line(ViewLine::from("Editing..."));
+				self.view_data.update_view_data(|updater| {
+					updater.clear();
+					updater.push_leading_line(ViewLine::from("Editing..."));
+				});
 				&mut self.view_data
 			},
 			ExternalEditorState::Empty => self.empty_choice.get_view_data(),
@@ -150,8 +152,9 @@ impl ProcessModule for ExternalEditor {
 
 impl ExternalEditor {
 	pub(crate) fn new(editor: &str) -> Self {
-		let mut view_data = ViewData::new();
-		view_data.set_show_title(true);
+		let view_data = ViewData::new(|updater| {
+			updater.set_show_title(true);
+		});
 
 		let mut empty_choice = Choice::new(vec![
 			(Action::AbortRebase, '1', String::from("Abort rebase")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::unreachable)]
 #![allow(clippy::missing_panics_doc)]
+#![allow(clippy::redundant_closure_for_method_calls)] // too many false positives
 #![allow(clippy::default_numeric_fallback)]
 
 mod components;

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -46,27 +46,27 @@ impl ProcessModule for Error {
 }
 
 impl Error {
-	pub const fn new() -> Self {
+	pub fn new() -> Self {
 		Self {
 			return_state: State::List,
-			view_data: ViewData::new(),
+			view_data: ViewData::new(|updater| updater.set_show_title(true)),
 		}
 	}
 
 	pub fn set_error_message(&mut self, error: &anyhow::Error) {
-		self.view_data.reset();
-		self.view_data.set_show_title(true);
-		for cause in error.chain() {
-			let error_text = format!("{:#}", cause);
-			for err in error_text.split('\n') {
-				self.view_data.push_line(ViewLine::from(err));
+		self.view_data.update_view_data(|updater| {
+			updater.clear();
+			for cause in error.chain() {
+				let error_text = format!("{:#}", cause);
+				for err in error_text.split('\n') {
+					updater.push_line(ViewLine::from(err));
+				}
 			}
-		}
-		self.view_data
-			.push_trailing_line(ViewLine::from(LineSegment::new_with_color(
+			updater.push_trailing_line(ViewLine::from(LineSegment::new_with_color(
 				"Press any key to continue",
 				DisplayColor::IndicatorColor,
 			)));
+		});
 	}
 }
 

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -45,8 +45,10 @@ impl ProcessModule for WindowSizeError {
 			SHORT_ERROR_MESSAGE
 		};
 
-		self.view_data.clear();
-		self.view_data.push_line(ViewLine::from(message));
+		self.view_data.update_view_data(|updater| {
+			updater.clear();
+			updater.push_line(ViewLine::from(message));
+		});
 		&mut self.view_data
 	}
 
@@ -70,10 +72,10 @@ impl ProcessModule for WindowSizeError {
 }
 
 impl WindowSizeError {
-	pub const fn new() -> Self {
+	pub fn new() -> Self {
 		Self {
 			return_state: State::List,
-			view_data: ViewData::new(),
+			view_data: ViewData::new(|_| {}),
 		}
 	}
 }

--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -1137,7 +1137,9 @@ fn handle_event_toggle_diff_to_overview() {
 		&[Event::from(MetaEvent::ShowDiff)],
 		|mut test_context: TestContext<'_>| {
 			let mut module = ShowCommit::new(test_context.config);
-			module.view_data.push_line(ViewLine::from("foo"));
+			module
+				.view_data
+				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
 			module.state = ShowCommitState::Diff;
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1157,7 +1159,9 @@ fn handle_event_toggle_overview_to_diff() {
 		&[Event::from(MetaEvent::ShowDiff)],
 		|mut test_context: TestContext<'_>| {
 			let mut module = ShowCommit::new(test_context.config);
-			module.view_data.push_line(ViewLine::from("foo"));
+			module
+				.view_data
+				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
 			module.state = ShowCommitState::Overview;
 			assert_process_result!(
 				test_context.handle_event(&mut module),

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -3,14 +3,15 @@ pub mod render_context;
 pub mod scroll_position;
 mod util;
 pub mod view_data;
+mod view_data_updater;
 pub mod view_line;
 
 #[cfg(test)]
 pub mod testutil;
 
 use anyhow::Result;
-pub use util::handle_view_data_scroll;
 
+pub use self::{util::handle_view_data_scroll, view_data_updater::ViewDataUpdater};
 use crate::{
 	display::{display_color::DisplayColor, size::Size, Display},
 	view::{view_data::ViewData, view_line::ViewLine},
@@ -204,7 +205,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_empty() {
 		view_module_test(Size::new(20, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			test_context.view.render(&mut view_data).unwrap();
 			TestContext::assert_output(&["~"; 10]);
 		});
@@ -214,7 +215,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_title_full_width() {
 		view_module_test(Size::new(35, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.set_show_title(true);
 			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Interactive Rebase Tool        "];
@@ -227,7 +228,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_title_short_title() {
 		view_module_test(Size::new(26, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.set_show_title(true);
 			test_context.view.render(&mut view_data).unwrap();
 			let mut expected = vec!["Git Rebase                "];
@@ -240,7 +241,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_title_full_width_with_help() {
 		view_module_test(Size::new(35, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.set_show_title(true);
 			view_data.set_show_help(true);
 			test_context.view.render(&mut view_data).unwrap();
@@ -254,7 +255,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_title_full_width_with_help_enabled_but_not_enough_length() {
 		view_module_test(Size::new(34, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.set_show_title(true);
 			view_data.set_show_help(true);
 			test_context.view.render(&mut view_data).unwrap();
@@ -268,7 +269,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_leading_lines() {
 		view_module_test(Size::new(30, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_leading_line(ViewLine::from("This is a leading line"));
 			view_data.set_view_size(30, 10);
 			test_context.view.render(&mut view_data).unwrap();
@@ -282,7 +283,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_normal_lines() {
 		view_module_test(Size::new(30, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_line(ViewLine::from("This is a line"));
 			view_data.set_view_size(30, 10);
 			test_context.view.render(&mut view_data).unwrap();
@@ -296,7 +297,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_tailing_lines() {
 		view_module_test(Size::new(30, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
 			view_data.set_view_size(30, 10);
 			test_context.view.render(&mut view_data).unwrap();
@@ -310,7 +311,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_all_lines() {
 		view_module_test(Size::new(30, 10), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_leading_line(ViewLine::from("This is a leading line"));
 			view_data.push_line(ViewLine::from("This is a line"));
 			view_data.push_trailing_line(ViewLine::from("This is a trailing line"));
@@ -327,7 +328,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_with_full_screen_data() {
 		view_module_test(Size::new(30, 6), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_leading_line(ViewLine::from("This is a leading line"));
 			view_data.push_line(ViewLine::from("This is line 1"));
 			view_data.push_line(ViewLine::from("This is line 2"));
@@ -352,7 +353,7 @@ mod tests {
 	#[serial_test::serial]
 	fn render_with_scroll_bar() {
 		view_module_test(Size::new(30, 6), |mut test_context| {
-			let mut view_data = ViewData::new();
+			let mut view_data = ViewData::new(|_| {});
 			view_data.push_leading_line(ViewLine::from("This is a leading line"));
 			view_data.push_line(ViewLine::from("This is line 1"));
 			view_data.push_line(ViewLine::from("This is line 2"));

--- a/src/view/util.rs
+++ b/src/view/util.rs
@@ -30,7 +30,7 @@ mod tests {
 		case::scroll_right(MetaEvent::ScrollRight, "34567")
 	)]
 	fn handle_view_data_scroll_horizontal(meta_event: MetaEvent, result: &str) {
-		let mut view_data = ViewData::new();
+		let mut view_data = ViewData::new(|_| {});
 		view_data.push_line(ViewLine::from("012345678"));
 		view_data.set_view_size(5, 10);
 		view_data.scroll_right();
@@ -51,7 +51,7 @@ mod tests {
 		case::jump_up(MetaEvent::ScrollJumpUp, ["0", "1", "2", "3"]),
 	)]
 	fn handle_view_data_scroll_vertical(meta_event: MetaEvent, result: [&str; 4]) {
-		let mut view_data = ViewData::new();
+		let mut view_data = ViewData::new(|_| {});
 		view_data.push_line(ViewLine::from("0"));
 		view_data.push_line(ViewLine::from("1"));
 		view_data.push_line(ViewLine::from("2"));
@@ -81,7 +81,7 @@ mod tests {
 
 	#[test]
 	fn handle_view_data_scroll_other_input() {
-		let mut view_data = ViewData::new();
+		let mut view_data = ViewData::new(|_| {});
 		view_data.push_line(ViewLine::from("012345678"));
 		view_data.set_view_size(5, 10);
 		assert_eq!(handle_view_data_scroll(Event::from('a'), &mut view_data), None);

--- a/src/view/view_data_updater.rs
+++ b/src/view/view_data_updater.rs
@@ -1,0 +1,77 @@
+use super::{view_line::ViewLine, ViewData};
+
+pub struct ViewDataUpdater<'v> {
+	modified: bool,
+	view_data: &'v mut ViewData,
+}
+
+impl<'v> ViewDataUpdater<'v> {
+	pub(super) fn new(view_data: &'v mut ViewData) -> Self {
+		Self {
+			view_data,
+			modified: false,
+		}
+	}
+
+	pub(crate) fn clear(&mut self) {
+		self.modified = true;
+		self.view_data.clear();
+	}
+
+	pub(crate) fn reset(&mut self) {
+		self.modified = true;
+		self.view_data.reset();
+	}
+
+	pub(crate) fn clear_body(&mut self) {
+		self.modified = true;
+		self.view_data.clear_body();
+	}
+
+	pub(crate) fn ensure_line_visible(&mut self, row_index: usize) {
+		self.modified = true;
+		self.view_data.ensure_line_visible(row_index);
+	}
+
+	pub(crate) fn ensure_column_visible(&mut self, column_index: usize) {
+		self.modified = true;
+		self.view_data.ensure_column_visible(column_index);
+	}
+
+	pub(crate) fn set_show_title(&mut self, show: bool) {
+		self.modified = true;
+		self.view_data.set_show_title(show);
+	}
+
+	pub(crate) fn set_show_help(&mut self, show: bool) {
+		self.modified = true;
+		self.view_data.set_show_help(show);
+	}
+
+	pub(crate) fn push_leading_line(&mut self, view_line: ViewLine) {
+		self.modified = true;
+		self.view_data.push_leading_line(view_line);
+	}
+
+	pub(crate) fn push_line(&mut self, view_line: ViewLine) {
+		self.modified = true;
+		self.view_data.push_line(view_line);
+	}
+
+	pub(crate) fn push_trailing_line(&mut self, view_line: ViewLine) {
+		self.modified = true;
+		self.view_data.push_trailing_line(view_line);
+	}
+
+	pub(crate) fn scroll_right(&mut self) {
+		self.view_data.scroll_right();
+	}
+
+	pub(crate) fn scroll_left(&mut self) {
+		self.view_data.scroll_left();
+	}
+
+	pub(super) const fn is_modified(&self) -> bool {
+		self.modified
+	}
+}


### PR DESCRIPTION
# Description

Add a ViewData updater function that will allow the ViewData to be updated as a block. This allows a version field to be added to track when the view_data has been updated. This version can later be used to avoid unneeded recalculation of the view.
