### PR TITLE
Use two instances of ViewData in show_commit

### DIFF
--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -9,6 +9,7 @@ use crate::{
 	display::size::Size,
 	process::testutil::{process_module_test, TestContext, ViewState},
 	show_commit::{delta::Delta, diff_line::DiffLine, file_stat::FileStat, origin::Origin, status::Status, user::User},
+	view::view_line::ViewLine,
 };
 
 fn create_minimal_commit() -> Commit {
@@ -1138,14 +1139,14 @@ fn handle_event_toggle_diff_to_overview() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = ShowCommit::new(test_context.config);
 			module
-				.view_data
+				.diff_view_data
 				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
 			module.state = ShowCommitState::Diff;
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ShowDiff)
 			);
-			assert!(module.view_data.is_empty());
+			assert!(module.diff_view_data.is_empty());
 			assert_eq!(module.state, ShowCommitState::Overview);
 		},
 	);
@@ -1160,14 +1161,14 @@ fn handle_event_toggle_overview_to_diff() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = ShowCommit::new(test_context.config);
 			module
-				.view_data
+				.overview_view_data
 				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
 			module.state = ShowCommitState::Overview;
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ShowDiff)
 			);
-			assert!(module.view_data.is_empty());
+			assert!(module.diff_view_data.is_empty());
 			assert_eq!(module.state, ShowCommitState::Diff);
 		},
 	);

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -65,6 +65,26 @@ impl ViewBuilder {
 		s.replace("\n", "")
 	}
 
+	fn build_leading_summary(commit: &Commit, is_full_width: bool) -> ViewLine {
+		ViewLine::from(vec![
+			LineSegment::new_with_color(
+				if is_full_width { "Commit: " } else { "" },
+				DisplayColor::IndicatorColor,
+			),
+			LineSegment::new(
+				if is_full_width {
+					commit.get_hash().to_owned()
+				}
+				else {
+					let hash = commit.get_hash();
+					let max_index = hash.len().min(8);
+					format!("{:8}", hash[0..max_index].to_owned())
+				}
+				.as_str(),
+			),
+		])
+	}
+
 	#[allow(clippy::unused_self)]
 	pub(super) fn build_view_data_for_overview(
 		&self,
@@ -72,6 +92,7 @@ impl ViewBuilder {
 		commit: &Commit,
 		is_full_width: bool,
 	) {
+		updater.push_leading_line(Self::build_leading_summary(commit, is_full_width));
 		updater.push_line(ViewLine::from(vec![
 			LineSegment::new_with_color(
 				if is_full_width { "Date: " } else { "D: " },
@@ -196,6 +217,7 @@ impl ViewBuilder {
 	}
 
 	pub(super) fn build_view_data_diff(&self, updater: &mut ViewDataUpdater<'_>, commit: &Commit, is_full_width: bool) {
+		updater.push_leading_line(Self::build_leading_summary(commit, is_full_width));
 		updater.push_leading_line(get_files_changed_summary(commit, is_full_width));
 		updater.push_line(ViewLine::new_empty_line().set_padding_character("―"));
 


### PR DESCRIPTION
# Description

The show_commit module was using a shared ViewData instance for the overview and diff views. This removes this shared instance and adds independent instances for both overview and diff states.
