### PR TITLE
Remove RenderContext from input handling

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -15,12 +15,7 @@ impl ProcessModule for ConfirmAbort {
 		self.dialog.get_view_data()
 	}
 
-	fn handle_events(
-		&mut self,
-		event_handler: &EventHandler,
-		_: &RenderContext,
-		rebase_todo: &mut TodoFile,
-	) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, rebase_todo: &mut TodoFile) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);
 		let mut result = ProcessResult::from(event);
 		match confirmed {

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -15,7 +15,7 @@ impl ProcessModule for ConfirmRebase {
 		self.dialog.get_view_data()
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);
 		let mut result = ProcessResult::from(event);
 		match confirmed {

--- a/src/external_editor/mod.rs
+++ b/src/external_editor/mod.rs
@@ -72,12 +72,7 @@ impl ProcessModule for ExternalEditor {
 		}
 	}
 
-	fn handle_events(
-		&mut self,
-		event_handler: &EventHandler,
-		_: &RenderContext,
-		todo_file: &mut TodoFile,
-	) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, todo_file: &mut TodoFile) -> ProcessResult {
 		let mut result = ProcessResult::new();
 		match self.state {
 			ExternalEditorState::Active => {

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -34,12 +34,7 @@ impl ProcessModule for Insert {
 		}
 	}
 
-	fn handle_events(
-		&mut self,
-		event_handler: &EventHandler,
-		_: &RenderContext,
-		rebase_todo: &mut TodoFile,
-	) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, rebase_todo: &mut TodoFile) -> ProcessResult {
 		match self.state {
 			InsertState::Prompt => {
 				let (choice, event) = self.action_choices.handle_event(event_handler);

--- a/src/list/tests.rs
+++ b/src/list/tests.rs
@@ -123,7 +123,7 @@ fn move_cursor_down_1() {
 		ViewState {
 			size: Size::new(120, 4),
 		},
-		&[Event::from(MetaEvent::MoveCursorDown)],
+		&[Event::Resize(120, 4), Event::from(MetaEvent::MoveCursorDown)],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
@@ -154,7 +154,11 @@ fn move_cursor_down_view_end() {
 		ViewState {
 			size: Size::new(120, 4),
 		},
-		&[Event::from(MetaEvent::MoveCursorDown); 2],
+		&[
+			Event::Resize(120, 4),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
@@ -185,7 +189,12 @@ fn move_cursor_down_scroll_1() {
 		ViewState {
 			size: Size::new(120, 4),
 		},
-		&[Event::from(MetaEvent::MoveCursorDown); 3],
+		&[
+			Event::Resize(120, 4),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
@@ -216,7 +225,13 @@ fn move_cursor_down_scroll_bottom() {
 		ViewState {
 			size: Size::new(120, 4),
 		},
-		&[Event::from(MetaEvent::MoveCursorDown); 4],
+		&[
+			Event::Resize(120, 4),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+			Event::from(MetaEvent::MoveCursorDown),
+		],
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
@@ -395,6 +410,7 @@ fn move_cursor_page_up_from_one_page_down() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageUp),
@@ -402,7 +418,7 @@ fn move_cursor_page_up_from_one_page_down() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 2);
+			test_context.handle_n_events(&mut module, 3);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -433,6 +449,7 @@ fn move_cursor_page_up_from_one_page_down_plus_1() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
@@ -441,7 +458,7 @@ fn move_cursor_page_up_from_one_page_down_plus_1() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 3);
+			test_context.handle_n_events(&mut module, 4);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -472,6 +489,7 @@ fn move_cursor_page_up_from_one_page_down_minus_1() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageUp),
@@ -479,7 +497,7 @@ fn move_cursor_page_up_from_one_page_down_minus_1() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 2);
+			test_context.handle_n_events(&mut module, 3);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -510,6 +528,7 @@ fn move_cursor_page_up_from_bottom() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
@@ -520,7 +539,7 @@ fn move_cursor_page_up_from_bottom() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 5);
+			test_context.handle_n_events(&mut module, 6);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -649,6 +668,7 @@ fn move_cursor_page_down_one_from_bottom() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(100, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
@@ -658,7 +678,7 @@ fn move_cursor_page_down_one_from_bottom() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 4);
+			test_context.handle_n_events(&mut module, 5);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -689,6 +709,7 @@ fn move_cursor_page_down_one_page_from_bottom() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(100, 4),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
@@ -697,7 +718,7 @@ fn move_cursor_page_down_one_page_from_bottom() {
 		|mut test_context: TestContext<'_>| {
 			let mut module = List::new(test_context.config);
 			test_context.update_view_data_size(&mut module);
-			test_context.handle_n_events(&mut module, 3);
+			test_context.handle_n_events(&mut module, 4);
 			test_context.build_view_data(&mut module);
 			test_context.handle_event(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -801,6 +822,7 @@ fn visual_mode_start_cursor_down_one() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorDown),
 		],
@@ -836,6 +858,7 @@ fn visual_mode_start_move_down_below_view() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorDown),
@@ -874,6 +897,7 @@ fn visual_mode_start_cursor_page_down() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
@@ -910,6 +934,7 @@ fn visual_mode_start_cursor_page_down_below_view() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorPageDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
@@ -947,6 +972,7 @@ fn visual_mode_start_cursor_from_bottom_move_up() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorPageDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
@@ -985,6 +1011,7 @@ fn visual_mode_start_cursor_from_bottom_to_top() {
 			size: Size::new(120, 4),
 		},
 		&[
+			Event::Resize(120, 4),
 			Event::from(MetaEvent::MoveCursorPageDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
 			Event::from(MetaEvent::MoveCursorPageDown),

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -33,7 +33,7 @@ impl ProcessModule for Error {
 		&mut self.view_data
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 		let mut result = ProcessResult::from(event);
 		if handle_view_data_scroll(event, &mut self.view_data).is_none() {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -62,12 +62,7 @@ impl<'r> Process<'r> {
 				self.exit_status = Some(ExitStatus::StateError);
 				continue;
 			}
-			let result = modules.handle_input(
-				self.state,
-				&self.event_handler,
-				&self.render_context,
-				&mut self.rebase_todo,
-			);
+			let result = modules.handle_input(self.state, &self.event_handler, &mut self.rebase_todo);
 			self.handle_process_result(&mut modules, &result);
 		}
 		if self.view.end().is_err() {
@@ -160,6 +155,11 @@ impl<'r> Process<'r> {
 
 	fn activate(&mut self, modules: &mut Modules<'r>, previous_state: State) {
 		let result = modules.activate(self.state, &self.rebase_todo, previous_state);
+		// always trigger a resize on activate, for modules that track size
+		self.event_handler.push_event(Event::Resize(
+			self.render_context.width() as u16,
+			self.render_context.height() as u16,
+		));
 		self.handle_process_result(modules, &result);
 	}
 }

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -77,11 +77,9 @@ impl<'m> Modules<'m> {
 		&mut self,
 		state: State,
 		event_handler: &EventHandler,
-		render_context: &RenderContext,
 		rebase_todo: &mut TodoFile,
 	) -> ProcessResult {
-		self.get_mut_module(state)
-			.handle_events(event_handler, render_context, rebase_todo)
+		self.get_mut_module(state).handle_events(event_handler, rebase_todo)
 	}
 
 	pub fn set_error_message(&mut self, error: &anyhow::Error) {
@@ -127,7 +125,6 @@ mod tests {
 				modules.handle_input(
 					state,
 					&test_context.event_handler_context.event_handler,
-					&test_context.render_context,
 					&mut test_context.rebase_todo_file,
 				);
 				modules.build_view_data(state, &test_context.render_context, &test_context.rebase_todo_file);

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -14,10 +14,5 @@ pub trait ProcessModule {
 
 	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &mut ViewData;
 
-	fn handle_events(
-		&mut self,
-		_event_handler: &EventHandler,
-		_render_context: &RenderContext,
-		_rebase_todo: &mut TodoFile,
-	) -> ProcessResult;
+	fn handle_events(&mut self, _event_handler: &EventHandler, _rebase_todo: &mut TodoFile) -> ProcessResult;
 }

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -51,21 +51,13 @@ impl<'t> TestContext<'t> {
 	}
 
 	pub fn handle_event(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
-		module.handle_events(
-			&self.event_handler_context.event_handler,
-			&self.render_context,
-			&mut self.rebase_todo_file,
-		)
+		module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file)
 	}
 
 	pub fn handle_n_events(&mut self, module: &'_ mut dyn ProcessModule, n: usize) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..n {
-			results.push(module.handle_events(
-				&self.event_handler_context.event_handler,
-				&self.render_context,
-				&mut self.rebase_todo_file,
-			));
+			results.push(module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file));
 		}
 		results
 	}
@@ -73,11 +65,7 @@ impl<'t> TestContext<'t> {
 	pub fn handle_all_events(&mut self, module: &'_ mut dyn ProcessModule) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..self.event_handler_context.number_events {
-			results.push(module.handle_events(
-				&self.event_handler_context.event_handler,
-				&self.render_context,
-				&mut self.rebase_todo_file,
-			));
+			results.push(module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file));
 		}
 		results
 	}

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -52,16 +52,12 @@ impl ProcessModule for WindowSizeError {
 		&mut self.view_data
 	}
 
-	fn handle_events(
-		&mut self,
-		event_handler: &EventHandler,
-		render_context: &RenderContext,
-		_: &mut TodoFile,
-	) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 		let mut result = ProcessResult::from(event);
 
-		if let Event::Resize(..) = event {
+		if let Event::Resize(width, height) = event {
+			let render_context = RenderContext::new(width, height);
 			if !render_context.is_window_too_small() {
 				result = result.state(self.return_state);
 			}

--- a/src/show_commit/mod.rs
+++ b/src/show_commit/mod.rs
@@ -128,7 +128,7 @@ impl<'s> ProcessModule for ShowCommit<'s> {
 		}
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &RenderContext, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
 		if self.help.is_active() {
 			return ProcessResult::from(self.help.handle_event(event_handler));
 		}


### PR DESCRIPTION
# Description

Remove the remaining cases of the RenderContext from the input handling functions and remove the parameter.
