### PR TITLE
Remove references from Display and View

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,13 +166,21 @@ fn try_main(filepath: &str) -> Result<ExitStatus, Exit> {
 		});
 	}
 
-	let mut crossterm = CrossTerm::new();
-	let display = Display::new(&mut crossterm, &config.theme);
+	let display = Display::new(CrossTerm::new(), &config.theme);
 	let modules = Modules::new(&config);
 	let mut process = Process::new(
 		todo_file,
 		EventHandler::new(KeyBindings::new(&config.key_bindings)),
-		View::new(display, &config),
+		View::new(
+			display,
+			config.theme.character_vertical_spacing.as_str(),
+			config
+				.key_bindings
+				.help
+				.first()
+				.map_or(String::from("?"), String::from)
+				.as_str(),
+		),
 	);
 	let result = process.run(modules);
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -22,17 +22,17 @@ use crate::{
 	view::{render_context::RenderContext, View},
 };
 
-pub struct Process<'r> {
+pub struct Process {
 	exit_status: Option<ExitStatus>,
 	event_handler: EventHandler,
 	rebase_todo: TodoFile,
 	render_context: RenderContext,
 	state: State,
-	view: View<'r>,
+	view: View,
 }
 
-impl<'r> Process<'r> {
-	pub(crate) fn new(rebase_todo: TodoFile, event_handler: EventHandler, view: View<'r>) -> Self {
+impl Process {
+	pub(crate) fn new(rebase_todo: TodoFile, event_handler: EventHandler, view: View) -> Self {
 		let view_size = view.get_view_size();
 		Self {
 			render_context: RenderContext::new(view_size.width() as u16, view_size.height() as u16),
@@ -44,7 +44,7 @@ impl<'r> Process<'r> {
 		}
 	}
 
-	pub(crate) fn run(&'r mut self, mut modules: Modules<'r>) -> Result<Option<ExitStatus>> {
+	pub(crate) fn run(&mut self, mut modules: Modules<'_>) -> Result<Option<ExitStatus>> {
 		if self.view.start().is_err() {
 			return Ok(Some(ExitStatus::StateError));
 		}
@@ -85,7 +85,7 @@ impl<'r> Process<'r> {
 		Ok(self.exit_status)
 	}
 
-	fn handle_process_result(&mut self, modules: &mut Modules<'r>, result: &ProcessResult) {
+	fn handle_process_result(&mut self, modules: &mut Modules<'_>, result: &ProcessResult) {
 		let previous_state = self.state;
 
 		if let Some(exit_status) = result.exit_status {
@@ -162,7 +162,7 @@ impl<'r> Process<'r> {
 		result
 	}
 
-	fn activate(&mut self, modules: &mut Modules<'r>, previous_state: State) {
+	fn activate(&mut self, modules: &mut Modules<'_>, previous_state: State) {
 		let result = modules.activate(self.state, &self.rebase_todo, previous_state);
 		// always trigger a resize on activate, for modules that track size
 		self.event_handler.push_event(Event::Resize(

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -23,8 +23,8 @@ fn window_too_small() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
 				test_context.event_handler_context.event_handler,
@@ -48,8 +48,8 @@ fn force_abort() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut shadow_rebase_file = test_context.new_todo_file();
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -76,8 +76,8 @@ fn force_rebase() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut shadow_rebase_file = test_context.new_todo_file();
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -107,8 +107,8 @@ fn error_write_todo() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let todo_path = test_context.get_todo_file_path();
 			test_context.set_todo_file_readonly();
 			let mut process = Process::new(
@@ -137,8 +137,8 @@ fn resize_window_size_okay() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
 				test_context.event_handler_context.event_handler,
@@ -162,8 +162,8 @@ fn resize_window_size_too_small() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
 				test_context.event_handler_context.event_handler,
@@ -189,8 +189,8 @@ fn error() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
 				test_context.event_handler_context.event_handler,
@@ -215,8 +215,8 @@ fn handle_exit_event() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -242,8 +242,8 @@ fn handle_kill_event() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -269,8 +269,8 @@ fn other_event() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
 				test_context.event_handler_context.event_handler,
@@ -295,8 +295,8 @@ fn handle_external_command_not_executable() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -344,8 +344,8 @@ fn handle_external_command_executable_not_found() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -393,8 +393,8 @@ fn handle_external_command_status_success() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,
@@ -424,8 +424,8 @@ fn handle_external_command_status_error() {
 				test_context.render_context.width(),
 				test_context.render_context.height(),
 			));
-			let display = Display::new(&mut crossterm, &test_context.config.theme);
-			let view = View::new(display, test_context.config);
+			let display = Display::new(crossterm, &test_context.config.theme);
+			let view = View::new(display, "~", "?");
 			let mut modules = Modules::new(test_context.config);
 			let mut process = Process::new(
 				test_context.rebase_todo_file,


### PR DESCRIPTION
# Description

Move the ownership of Crossterm into the Display struct and inject the config values into View.