### PR TITLE
Skip adding empty line segments

### DIFF
--- a/src/components/edit/mod.rs
+++ b/src/components/edit/mod.rs
@@ -58,25 +58,20 @@ impl Edit {
 				false,
 			));
 		}
-		segments.push(LineSegment::new(start.as_str()));
-		segments.push(LineSegment::new_with_color_and_style(
-			indicator.as_str(),
-			DisplayColor::Normal,
-			false,
-			true,
-			false,
-		));
-		segments.push(LineSegment::new(end.as_str()));
-		if indicator.is_empty() {
-			segments.push(LineSegment::new_with_color_and_style(
-				" ",
-				DisplayColor::Normal,
-				false,
-				true,
-				false,
-			));
+		if !start.is_empty() {
+			segments.push(LineSegment::new(start.as_str()));
 		}
-
+		segments.push(
+			if indicator.is_empty() {
+				LineSegment::new_with_color_and_style(" ", DisplayColor::Normal, false, true, false)
+			}
+			else {
+				LineSegment::new_with_color_and_style(indicator.as_str(), DisplayColor::Normal, false, true, false)
+			},
+		);
+		if !end.is_empty() {
+			segments.push(LineSegment::new(end.as_str()));
+		}
 		let description = self.description.as_ref();
 		self.view_data.update_view_data(|updater| {
 			updater.clear();

--- a/src/list/utils.rs
+++ b/src/list/utils.rs
@@ -236,7 +236,10 @@ pub(super) fn get_todo_line_segments(
 			},
 			Action::Exec | Action::Label | Action::Reset | Action::Merge | Action::Break | Action::Noop => {},
 		}
-		segments.push(LineSegment::new(line.get_content()));
+		let content = line.get_content();
+		if !content.is_empty() {
+			segments.push(LineSegment::new(line.get_content()));
+		}
 	}
 	else {
 		segments.push(LineSegment::new_with_color_and_style(
@@ -261,7 +264,10 @@ pub(super) fn get_todo_line_segments(
 			},
 			Action::Exec | Action::Label | Action::Reset | Action::Merge | Action::Break | Action::Noop => {},
 		}
-		segments.push(LineSegment::new(line.get_content()));
+		let content = line.get_content();
+		if !content.is_empty() {
+			segments.push(LineSegment::new(line.get_content()));
+		}
 	}
 	segments
 }

--- a/src/show_commit/view_builder.rs
+++ b/src/show_commit/view_builder.rs
@@ -66,23 +66,22 @@ impl ViewBuilder {
 	}
 
 	fn build_leading_summary(commit: &Commit, is_full_width: bool) -> ViewLine {
-		ViewLine::from(vec![
-			LineSegment::new_with_color(
-				if is_full_width { "Commit: " } else { "" },
-				DisplayColor::IndicatorColor,
-			),
-			LineSegment::new(
-				if is_full_width {
-					commit.get_hash().to_owned()
-				}
-				else {
-					let hash = commit.get_hash();
-					let max_index = hash.len().min(8);
-					format!("{:8}", hash[0..max_index].to_owned())
-				}
-				.as_str(),
-			),
-		])
+		let mut segments = vec![];
+		if is_full_width {
+			segments.push(LineSegment::new_with_color("Commit: ", DisplayColor::IndicatorColor));
+		}
+		segments.push(LineSegment::new(
+			if is_full_width {
+				commit.get_hash().to_owned()
+			}
+			else {
+				let hash = commit.get_hash();
+				let max_index = hash.len().min(8);
+				format!("{:8}", hash[0..max_index].to_owned())
+			}
+			.as_str(),
+		));
+		ViewLine::from(segments)
 	}
 
 	#[allow(clippy::unused_self)]
@@ -185,22 +184,28 @@ impl ViewBuilder {
 				)
 			};
 
-			line_segments.push(LineSegment::new_with_color(
-				leading.as_str(),
-				DisplayColor::DiffWhitespaceColor,
-			));
-			line_segments.push(LineSegment::new_with_color(
-				content.as_str(),
-				match *diff_line.origin() {
-					Origin::Addition => DisplayColor::DiffAddColor,
-					Origin::Deletion => DisplayColor::DiffRemoveColor,
-					Origin::Context => DisplayColor::DiffContextColor,
-				},
-			));
-			line_segments.push(LineSegment::new_with_color(
-				trailing.as_str(),
-				DisplayColor::DiffWhitespaceColor,
-			));
+			if !leading.is_empty() {
+				line_segments.push(LineSegment::new_with_color(
+					leading.as_str(),
+					DisplayColor::DiffWhitespaceColor,
+				));
+			}
+			if !content.is_empty() {
+				line_segments.push(LineSegment::new_with_color(
+					content.as_str(),
+					match *diff_line.origin() {
+						Origin::Addition => DisplayColor::DiffAddColor,
+						Origin::Deletion => DisplayColor::DiffRemoveColor,
+						Origin::Context => DisplayColor::DiffContextColor,
+					},
+				));
+			}
+			if !trailing.is_empty() {
+				line_segments.push(LineSegment::new_with_color(
+					trailing.as_str(),
+					DisplayColor::DiffWhitespaceColor,
+				));
+			}
 		}
 		else {
 			line_segments.push(LineSegment::new_with_color(


### PR DESCRIPTION
# Description

In a few places, empty line segments are being added that do not change the final rendered output, but do take time to process and require handling in tests. This change conditionally adds those segments only when they contain content.