### PR TITLE
Rework process tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "tempfile",
  "unicode-segmentation",
  "unicode-width",
+ "uuid",
  "xi-unicode",
 ]
 
@@ -696,6 +697,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ unicode-segmentation = "1.7.1"
 unicode-width = "0.1.8"
 xi-unicode = "0.3.0"
 
+[dependencies.uuid]
+version = "0.8.1"
+features = ["v4"]
+
 [dependencies.git2]
 version = "0.13.20"
 default-features = false

--- a/src/components/choice/mod.rs
+++ b/src/components/choice/mod.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use crate::{
 	display::display_color::DisplayColor,
 	input::{Event, EventHandler, InputOptions, KeyCode},
-	view::{handle_view_data_scroll, line_segment::LineSegment, view_data::ViewData, view_line::ViewLine},
+	view::{handle_view_data_scroll, line_segment::LineSegment, view_data::ViewData, view_line::ViewLine, ViewSender},
 };
 
 lazy_static! {
@@ -38,6 +38,7 @@ where T: Clone
 			options,
 			view_data: ViewData::new(|updater| {
 				updater.set_show_title(true);
+				updater.set_retain_scroll_position(false);
 			}),
 			invalid_selection: false,
 		}
@@ -53,7 +54,7 @@ where T: Clone
 		});
 	}
 
-	pub fn get_view_data(&mut self) -> &mut ViewData {
+	pub fn get_view_data(&mut self) -> &ViewData {
 		let options = &self.options;
 		let invalid_selection = self.invalid_selection;
 		self.view_data.update_view_data(|updater| {
@@ -75,13 +76,13 @@ where T: Clone
 				)));
 			}
 		});
-		&mut self.view_data
+		&self.view_data
 	}
 
-	pub fn handle_event(&mut self, event_handler: &EventHandler) -> (Option<&T>, Event) {
+	pub fn handle_event(&mut self, event_handler: &EventHandler, view_sender: &ViewSender) -> (Option<&T>, Event) {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 
-		if handle_view_data_scroll(event, &mut self.view_data).is_none() {
+		if handle_view_data_scroll(event, view_sender).is_none() {
 			if let Event::Key(key_event) = event {
 				if let KeyCode::Char(c) = key_event.code {
 					if let Some(v) = self.map.get(&c) {

--- a/src/components/choice/tests.rs
+++ b/src/components/choice/tests.rs
@@ -59,7 +59,7 @@ fn render_options_prompt() {
 fn valid_selection() {
 	with_event_handler(&[Event::from('b')], |context| {
 		let mut module = Choice::new(create_choices());
-		let (choice, event) = module.handle_event(&context.event_handler);
+		let (choice, event) = module.handle_event(&context.event_handler, &context.view_sender);
 		assert_eq!(choice.unwrap(), &TestAction::B);
 		assert_eq!(event, Event::from('b'));
 		assert_rendered_output!(
@@ -79,7 +79,7 @@ fn valid_selection() {
 fn invalid_selection_character() {
 	with_event_handler(&[Event::from('z')], |context| {
 		let mut module = Choice::new(create_choices());
-		let (choice, event) = module.handle_event(&context.event_handler);
+		let (choice, event) = module.handle_event(&context.event_handler, &context.view_sender);
 		assert!(choice.is_none());
 		assert_eq!(event, Event::from('z'));
 		assert_rendered_output!(
@@ -108,7 +108,7 @@ fn invalid_selection_character() {
 fn event_standard(event: Event) {
 	with_event_handler(&[event], |context| {
 		let mut module = Choice::new(create_choices());
-		module.handle_event(&context.event_handler);
+		module.handle_event(&context.event_handler, &context.view_sender);
 		assert!(!module.invalid_selection);
 	});
 }

--- a/src/components/confirm/mod.rs
+++ b/src/components/confirm/mod.rs
@@ -22,6 +22,7 @@ impl Confirm {
 	pub fn new(prompt: &str, confirm_yes: &[String], confirm_no: &[String]) -> Self {
 		let view_data = ViewData::new(|updater| {
 			updater.set_show_title(true);
+			updater.set_retain_scroll_position(false);
 			updater.push_line(ViewLine::from(format!(
 				"{} ({}/{})? ",
 				prompt,
@@ -32,8 +33,8 @@ impl Confirm {
 		Self { view_data }
 	}
 
-	pub fn get_view_data(&mut self) -> &mut ViewData {
-		&mut self.view_data
+	pub fn get_view_data(&mut self) -> &ViewData {
+		&self.view_data
 	}
 
 	#[allow(clippy::unused_self)]

--- a/src/components/edit/mod.rs
+++ b/src/components/edit/mod.rs
@@ -38,7 +38,7 @@ impl Edit {
 		}
 	}
 
-	pub fn get_view_data(&mut self) -> &mut ViewData {
+	pub fn get_view_data(&mut self) -> &ViewData {
 		let line = self.content.as_str();
 		let pointer = self.cursor_position;
 
@@ -90,7 +90,7 @@ impl Edit {
 			updater.ensure_column_visible(pointer);
 			updater.ensure_line_visible(0);
 		});
-		&mut self.view_data
+		&self.view_data
 	}
 
 	pub fn handle_event(&mut self, event_handler: &EventHandler) -> Event {

--- a/src/components/help/mod.rs
+++ b/src/components/help/mod.rs
@@ -6,7 +6,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
 	display::display_color::DisplayColor,
 	input::{Event, EventHandler, InputOptions},
-	view::{handle_view_data_scroll, line_segment::LineSegment, view_data::ViewData, view_line::ViewLine},
+	view::{handle_view_data_scroll, line_segment::LineSegment, view_data::ViewData, view_line::ViewLine, ViewSender},
 };
 
 lazy_static! {
@@ -35,6 +35,7 @@ impl Help {
 		let max_key_length = Self::get_max_help_key_length(keybindings);
 		let view_data = ViewData::new(|updater| {
 			updater.set_show_title(true);
+			updater.set_retain_scroll_position(false);
 			updater.push_leading_line(
 				ViewLine::new_pinned(vec![LineSegment::new_with_color_and_style(
 					format!(" {0:width$} Action", "Key", width = max_key_length).as_str(),
@@ -71,14 +72,14 @@ impl Help {
 		}
 	}
 
-	pub fn get_view_data(&mut self) -> &mut ViewData {
-		&mut self.view_data
+	pub fn get_view_data(&mut self) -> &ViewData {
+		&self.view_data
 	}
 
-	pub fn handle_event(&mut self, event_handler: &EventHandler) -> Event {
+	pub fn handle_event(&mut self, event_handler: &EventHandler, view_sender: &ViewSender) -> Event {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 
-		if handle_view_data_scroll(event, &mut self.view_data).is_none() {
+		if handle_view_data_scroll(event, view_sender).is_none() {
 			if let Event::Key(_) = event {
 				self.active = false;
 			}

--- a/src/components/help/tests.rs
+++ b/src/components/help/tests.rs
@@ -52,7 +52,7 @@ fn input_continue_active(event: Event) {
 	with_event_handler(&[event], |context| {
 		let mut module = Help::new_from_keybindings(&[]);
 		module.set_active();
-		module.handle_event(&context.event_handler);
+		module.handle_event(&context.event_handler, &context.view_sender);
 		assert!(module.is_active());
 	});
 }
@@ -62,7 +62,7 @@ fn input_other() {
 	with_event_handler(&[Event::from('a')], |context| {
 		let mut module = Help::new_from_keybindings(&[]);
 		module.set_active();
-		module.handle_event(&context.event_handler);
+		module.handle_event(&context.event_handler, &context.view_sender);
 		assert!(!module.is_active());
 	});
 }

--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::EventHandler,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData},
+	view::{render_context::RenderContext, view_data::ViewData, ViewSender},
 };
 
 pub struct ConfirmAbort {
@@ -11,11 +11,16 @@ pub struct ConfirmAbort {
 }
 
 impl ProcessModule for ConfirmAbort {
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
 		self.dialog.get_view_data()
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, rebase_todo: &mut TodoFile) -> ProcessResult {
+	fn handle_events(
+		&mut self,
+		event_handler: &EventHandler,
+		_: &ViewSender,
+		rebase_todo: &mut TodoFile,
+	) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);
 		let mut result = ProcessResult::from(event);
 		match confirmed {

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 	input::EventHandler,
 	process::{exit_status::ExitStatus, process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData},
+	view::{render_context::RenderContext, view_data::ViewData, ViewSender},
 };
 
 pub struct ConfirmRebase {
@@ -11,11 +11,11 @@ pub struct ConfirmRebase {
 }
 
 impl ProcessModule for ConfirmRebase {
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
 		self.dialog.get_view_data()
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &ViewSender, _: &mut TodoFile) -> ProcessResult {
 		let (confirmed, event) = self.dialog.handle_event(event_handler);
 		let mut result = ProcessResult::from(event);
 		match confirmed {

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 	insert::{insert_state::InsertState, line_type::LineType},
 	process::{process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::{line::Line, TodoFile},
-	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, ViewSender},
 };
 
 pub struct Insert {
@@ -27,17 +27,22 @@ impl ProcessModule for Insert {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
 		match self.state {
 			InsertState::Prompt => self.action_choices.get_view_data(),
 			InsertState::Edit => self.edit.get_view_data(),
 		}
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, rebase_todo: &mut TodoFile) -> ProcessResult {
+	fn handle_events(
+		&mut self,
+		event_handler: &EventHandler,
+		view_sender: &ViewSender,
+		rebase_todo: &mut TodoFile,
+	) -> ProcessResult {
 		match self.state {
 			InsertState::Prompt => {
-				let (choice, event) = self.action_choices.handle_event(event_handler);
+				let (choice, event) = self.action_choices.handle_event(event_handler, view_sender);
 				let mut result = ProcessResult::from(event);
 				if let Some(action) = choice {
 					if action == &LineType::Cancel {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 #[cfg(test)]
 pub mod testutil;
 
-use std::process::Command;
+use std::{process::Command, thread};
 
 use anyhow::{anyhow, Result};
 
@@ -19,35 +19,44 @@ use crate::{
 	input::{Event, EventHandler, MetaEvent},
 	process::{exit_status::ExitStatus, modules::Modules, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, View},
+	view::{render_context::RenderContext, spawn_view_thread, View, ViewSender},
 };
 
 pub struct Process {
-	exit_status: Option<ExitStatus>,
 	event_handler: EventHandler,
+	exit_status: Option<ExitStatus>,
 	rebase_todo: TodoFile,
 	render_context: RenderContext,
 	state: State,
-	view: View,
+	threads: Vec<thread::JoinHandle<()>>,
+	view_sender: ViewSender,
 }
 
 impl Process {
 	pub(crate) fn new(rebase_todo: TodoFile, event_handler: EventHandler, view: View) -> Self {
 		let view_size = view.get_view_size();
+		let mut threads = vec![];
+
+		let (view_sender, view_thread) = spawn_view_thread(view);
+		threads.push(view_thread);
+
 		Self {
-			render_context: RenderContext::new(view_size.width() as u16, view_size.height() as u16),
-			exit_status: None,
 			event_handler,
+			exit_status: None,
 			rebase_todo,
+			render_context: RenderContext::new(view_size.width() as u16, view_size.height() as u16),
 			state: State::List,
-			view,
+			threads,
+			view_sender,
 		}
 	}
 
 	pub(crate) fn run(&mut self, mut modules: Modules<'_>) -> Result<Option<ExitStatus>> {
-		if self.view.start().is_err() {
-			return Ok(Some(ExitStatus::StateError));
+		if self.view_sender.start().is_err() {
+			self.exit_status = Some(ExitStatus::StateError);
+			return Ok(self.exit_status);
 		}
+
 		self.handle_process_result(
 			&mut modules,
 			&ProcessResult::new().event(Event::Resize(
@@ -58,13 +67,21 @@ impl Process {
 		self.activate(&mut modules, State::List);
 		while self.exit_status.is_none() {
 			let view_data = modules.build_view_data(self.state, &self.render_context, &self.rebase_todo);
-			if self.view.render(view_data).is_err() {
+			if self.view_sender.render(view_data).is_err() {
 				self.exit_status = Some(ExitStatus::StateError);
 				continue;
 			}
-
 			loop {
-				let result = modules.handle_input(self.state, &self.event_handler, &mut self.rebase_todo);
+				if self.view_sender.is_poisoned() {
+					self.exit_status = Some(ExitStatus::StateError);
+					break;
+				}
+				let result = modules.handle_input(
+					self.state,
+					&self.event_handler,
+					&self.view_sender,
+					&mut self.rebase_todo,
+				);
 
 				if let Some(event) = result.event {
 					if event != Event::None {
@@ -74,7 +91,7 @@ impl Process {
 				}
 			}
 		}
-		if self.view.end().is_err() {
+		if self.view_sender.stop().is_err() {
 			return Ok(Some(ExitStatus::StateError));
 		}
 		if let Some(status) = self.exit_status {
@@ -82,6 +99,17 @@ impl Process {
 				self.rebase_todo.write_file()?;
 			}
 		}
+
+		if self.view_sender.end().is_err() {
+			return Ok(Some(ExitStatus::StateError));
+		}
+
+		while let Some(handle) = self.threads.pop() {
+			if handle.join().is_err() {
+				return Ok(Some(ExitStatus::StateError));
+			}
+		}
+
 		Ok(self.exit_status)
 	}
 
@@ -113,6 +141,7 @@ impl Process {
 				self.exit_status = Some(ExitStatus::Kill);
 			},
 			Some(Event::Resize(width, height)) => {
+				self.view_sender.resize(width, height);
 				self.render_context.update(width, height);
 				if self.state != State::WindowSizeError && self.render_context.is_window_too_small() {
 					self.state = State::WindowSizeError;
@@ -140,7 +169,7 @@ impl Process {
 	}
 
 	fn run_command(&mut self, external_command: &(String, Vec<String>)) -> Result<MetaEvent> {
-		self.view.end()?;
+		self.view_sender.stop()?;
 
 		let mut cmd = Command::new(external_command.0.clone());
 		cmd.args(external_command.1.clone());
@@ -157,7 +186,7 @@ impl Process {
 			})
 			.map_err(|err| anyhow!(err));
 
-		self.view.start()?;
+		self.view_sender.stop()?;
 
 		result
 	}

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -15,7 +15,7 @@ use crate::{
 	},
 	show_commit::ShowCommit,
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData},
+	view::{render_context::RenderContext, view_data::ViewData, ViewSender},
 };
 
 pub struct Modules<'m> {
@@ -69,7 +69,7 @@ impl<'m> Modules<'m> {
 		state: State,
 		render_context: &RenderContext,
 		rebase_todo: &TodoFile,
-	) -> &mut ViewData {
+	) -> &ViewData {
 		self.get_mut_module(state).build_view_data(render_context, rebase_todo)
 	}
 
@@ -77,9 +77,11 @@ impl<'m> Modules<'m> {
 		&mut self,
 		state: State,
 		event_handler: &EventHandler,
+		view_sender: &ViewSender,
 		rebase_todo: &mut TodoFile,
 	) -> ProcessResult {
-		self.get_mut_module(state).handle_events(event_handler, rebase_todo)
+		self.get_mut_module(state)
+			.handle_events(event_handler, view_sender, rebase_todo)
 	}
 
 	pub fn set_error_message(&mut self, error: &anyhow::Error) {
@@ -125,6 +127,7 @@ mod tests {
 				modules.handle_input(
 					state,
 					&test_context.event_handler_context.event_handler,
+					&test_context.event_handler_context.view_sender,
 					&mut test_context.rebase_todo_file,
 				);
 				modules.build_view_data(state, &test_context.render_context, &test_context.rebase_todo_file);

--- a/src/process/process_module.rs
+++ b/src/process/process_module.rs
@@ -2,7 +2,7 @@ use crate::{
 	input::EventHandler,
 	process::{process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData},
+	view::{render_context::RenderContext, view_data::ViewData, ViewSender},
 };
 
 pub trait ProcessModule {
@@ -12,7 +12,12 @@ pub trait ProcessModule {
 
 	fn deactivate(&mut self) {}
 
-	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &mut ViewData;
+	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &ViewData;
 
-	fn handle_events(&mut self, _event_handler: &EventHandler, _rebase_todo: &mut TodoFile) -> ProcessResult;
+	fn handle_events(
+		&mut self,
+		_event_handler: &EventHandler,
+		_view_sender: &ViewSender,
+		_rebase_todo: &mut TodoFile,
+	) -> ProcessResult;
 }

--- a/src/process/testutil.rs
+++ b/src/process/testutil.rs
@@ -26,7 +26,7 @@ pub struct TestContext<'t> {
 }
 
 impl<'t> TestContext<'t> {
-	fn get_build_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc mut ViewData {
+	fn get_build_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc ViewData {
 		module.build_view_data(&self.render_context, &self.rebase_todo_file)
 	}
 
@@ -39,25 +39,26 @@ impl<'t> TestContext<'t> {
 		module.deactivate();
 	}
 
-	pub fn update_view_data_size(&self, module: &'_ mut dyn ProcessModule) {
-		let view_data = self.get_build_data(module);
-		view_data.set_view_size(self.render_context.width(), self.render_context.height());
-	}
-
-	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc mut ViewData {
-		let view_data = self.get_build_data(module);
-		view_data.set_view_size(self.render_context.width(), self.render_context.height());
-		view_data
+	pub fn build_view_data<'tc>(&self, module: &'tc mut dyn ProcessModule) -> &'tc ViewData {
+		self.get_build_data(module)
 	}
 
 	pub fn handle_event(&mut self, module: &'_ mut dyn ProcessModule) -> ProcessResult {
-		module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file)
+		module.handle_events(
+			&self.event_handler_context.event_handler,
+			&self.event_handler_context.view_sender,
+			&mut self.rebase_todo_file,
+		)
 	}
 
 	pub fn handle_n_events(&mut self, module: &'_ mut dyn ProcessModule, n: usize) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..n {
-			results.push(module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file));
+			results.push(module.handle_events(
+				&self.event_handler_context.event_handler,
+				&self.event_handler_context.view_sender,
+				&mut self.rebase_todo_file,
+			));
 		}
 		results
 	}
@@ -65,7 +66,11 @@ impl<'t> TestContext<'t> {
 	pub fn handle_all_events(&mut self, module: &'_ mut dyn ProcessModule) -> Vec<ProcessResult> {
 		let mut results = vec![];
 		for _ in 0..self.event_handler_context.number_events {
-			results.push(module.handle_events(&self.event_handler_context.event_handler, &mut self.rebase_todo_file));
+			results.push(module.handle_events(
+				&self.event_handler_context.event_handler,
+				&self.event_handler_context.view_sender,
+				&mut self.rebase_todo_file,
+			));
 		}
 		results
 	}

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -4,7 +4,7 @@ use crate::{
 	input::{Event, EventHandler, InputOptions},
 	process::{process_module::ProcessModule, process_result::ProcessResult, state::State},
 	todo_file::TodoFile,
-	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine},
+	view::{render_context::RenderContext, view_data::ViewData, view_line::ViewLine, ViewSender},
 };
 
 const HEIGHT_ERROR_MESSAGE: &str = "Window too small, increase height to continue";
@@ -26,7 +26,7 @@ impl ProcessModule for WindowSizeError {
 		ProcessResult::new()
 	}
 
-	fn build_view_data(&mut self, context: &RenderContext, _: &TodoFile) -> &mut ViewData {
+	fn build_view_data(&mut self, context: &RenderContext, _: &TodoFile) -> &ViewData {
 		let view_width = context.width();
 		let message = if !context.is_minimum_view_width() {
 			if view_width >= SHORT_ERROR_MESSAGE.len() {
@@ -52,7 +52,7 @@ impl ProcessModule for WindowSizeError {
 		&mut self.view_data
 	}
 
-	fn handle_events(&mut self, event_handler: &EventHandler, _: &mut TodoFile) -> ProcessResult {
+	fn handle_events(&mut self, event_handler: &EventHandler, _: &ViewSender, _: &mut TodoFile) -> ProcessResult {
 		let event = event_handler.read_event(&INPUT_OPTIONS, |event, _| event);
 		let mut result = ProcessResult::from(event);
 

--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -104,7 +104,7 @@ fn render_overview_minimal_commit() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -132,7 +132,7 @@ fn render_overview_minimal_commit_compact() {
 				"{Normal}01234567",
 				"{BODY}",
 				format!("{{IndicatorColor}}D: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} / {DiffAddColor}0{Normal} / {DiffRemoveColor}0"
 			);
 		},
@@ -159,7 +159,7 @@ fn render_overview_with_author() {
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
 				"{IndicatorColor}Author: {Normal}John Doe <john.doe@example.com>",
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -188,8 +188,8 @@ fn render_overview_with_author_compact() {
 				"{Normal}01234567",
 				"{BODY}",
 				format!("{{IndicatorColor}}D: {{Normal}}{}", commit_date).as_str(),
-				"{IndicatorColor}A: {Normal}John Doe <john.doe@example.com",
-				"",
+				"{IndicatorColor}A: {Normal}John Doe <john.doe@example.com>",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} / {DiffAddColor}0{Normal} / {DiffRemoveColor}0"
 			);
 		},
@@ -216,7 +216,7 @@ fn render_overview_with_committer() {
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
 				"{IndicatorColor}Committer: {Normal}John Doe <john.doe@example.com>",
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -245,8 +245,8 @@ fn render_overview_with_committer_compact() {
 				"{Normal}01234567",
 				"{BODY}",
 				format!("{{IndicatorColor}}D: {{Normal}}{}", commit_date).as_str(),
-				"{IndicatorColor}C: {Normal}John Doe <john.doe@example.com",
-				"",
+				"{IndicatorColor}C: {Normal}John Doe <john.doe@example.com>",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} / {DiffAddColor}0{Normal} / {DiffRemoveColor}0"
 			);
 		},
@@ -273,9 +273,9 @@ fn render_overview_with_commit_body() {
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
 				"{Normal}Commit title",
-				"",
+				"{Normal}",
 				"{Normal}Commit body",
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -310,7 +310,7 @@ fn render_overview_with_file_stats() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions",
 				"{DiffChangeColor} renamed: {DiffRemoveColor}file.1b{Normal} → {DiffAddColor}file.1a",
@@ -354,7 +354,7 @@ fn render_overview_with_file_stats_compact() {
 				"{Normal}01234567",
 				"{BODY}",
 				format!("{{IndicatorColor}}D: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} / {DiffAddColor}0{Normal} / {DiffRemoveColor}0",
 				"{DiffChangeColor}R {DiffRemoveColor}file.1b{Normal}→{DiffAddColor}file.1a",
 				"{DiffAddColor}A {DiffAddColor}file.2a",
@@ -387,7 +387,7 @@ fn render_overview_single_file_changed() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}1{Normal} file{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -414,7 +414,7 @@ fn render_overview_more_than_one_file_changed() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}2{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -441,7 +441,7 @@ fn render_overview_single_insertion() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}1{Normal} insertion{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -468,7 +468,7 @@ fn render_overview_more_than_one_insertion() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}2{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}0{Normal} deletions"
 			);
@@ -495,7 +495,7 @@ fn render_overview_single_deletion() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}1{Normal} deletion"
 			);
@@ -522,7 +522,7 @@ fn render_overview_more_than_one_deletion() {
 				"{IndicatorColor}Commit: {Normal}0123456789abcdef0123456789abcdef",
 				"{BODY}",
 				format!("{{IndicatorColor}}Date: {{Normal}}{}", commit_date).as_str(),
-				"",
+				"{Normal}",
 				"{IndicatorColor}0{Normal} files{Normal} with {DiffAddColor}0{Normal} insertions{Normal} and \
 				 {DiffRemoveColor}2{Normal} deletions"
 			);

--- a/src/view/action.rs
+++ b/src/view/action.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub enum ViewAction {
+	Stop,
+	Refresh,
+	Render,
+	Start,
+	End,
+}

--- a/src/view/render_slice/mod.rs
+++ b/src/view/render_slice/mod.rs
@@ -1,0 +1,457 @@
+mod render_action;
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+	collections::{HashMap, VecDeque},
+	mem,
+};
+
+pub(super) use render_action::RenderAction;
+
+use super::{line_segment::LineSegment, scroll_position::ScrollPosition, view_data::ViewData, view_line::ViewLine};
+
+pub struct RenderSlice {
+	actions: VecDeque<RenderAction>,
+	height: usize,
+	lines: Vec<ViewLine>,
+	lines_count: usize,
+	lines_leading_count: usize,
+	lines_trailing_count: usize,
+	padding_height: usize,
+	scroll_position: ScrollPosition,
+	scroll_position_cache: HashMap<String, ScrollPosition>,
+	should_show_scrollbar: bool,
+	show_help: bool,
+	show_title: bool,
+	version: u32,
+	view_data_name: String,
+	view_data_version: u32,
+	width: usize,
+}
+
+impl RenderSlice {
+	pub(crate) fn new() -> Self {
+		Self {
+			actions: VecDeque::new(),
+			height: 0,
+			lines: vec![],
+			lines_count: 0,
+			lines_leading_count: 0,
+			lines_trailing_count: 0,
+			padding_height: 0,
+			scroll_position: ScrollPosition::new(),
+			scroll_position_cache: HashMap::new(),
+			should_show_scrollbar: false,
+			show_help: false,
+			show_title: false,
+			version: 0,
+			view_data_name: String::from(""),
+			view_data_version: 0,
+			width: 0,
+		}
+	}
+
+	pub(crate) fn record_scroll_up(&mut self) {
+		self.actions.push_back(RenderAction::ScrollUp);
+	}
+
+	pub(crate) fn record_scroll_down(&mut self) {
+		self.actions.push_back(RenderAction::ScrollDown);
+	}
+
+	pub(crate) fn record_page_up(&mut self) {
+		self.actions.push_back(RenderAction::PageUp);
+	}
+
+	pub(crate) fn record_page_down(&mut self) {
+		self.actions.push_back(RenderAction::PageDown);
+	}
+
+	pub(crate) fn record_scroll_left(&mut self) {
+		self.actions.push_back(RenderAction::ScrollLeft);
+	}
+
+	pub(crate) fn record_scroll_right(&mut self) {
+		self.actions.push_back(RenderAction::ScrollRight);
+	}
+
+	pub(crate) fn record_resize(&mut self, width: usize, height: usize) {
+		self.actions.push_back(RenderAction::Resize(width, height));
+	}
+
+	pub(crate) fn sync_view_data(&mut self, view_data: &ViewData) {
+		let cache_expired = self.cache_expired(view_data);
+		// scroll position depends on padding, so if the view has changed it needs to be updated early
+		if cache_expired {
+			self.set_padding_height(view_data);
+		}
+		self.set_active_scroll_position(view_data);
+		let has_actions = !self.actions.is_empty();
+		while let Some(action) = self.actions.pop_front() {
+			match action {
+				RenderAction::ScrollDown => self.scroll_position.scroll_down(),
+				RenderAction::ScrollUp => self.scroll_position.scroll_up(),
+				RenderAction::ScrollRight => self.scroll_position.scroll_right(),
+				RenderAction::ScrollLeft => self.scroll_position.scroll_left(),
+				RenderAction::PageUp => self.scroll_position.page_up(),
+				RenderAction::PageDown => self.scroll_position.page_down(),
+				RenderAction::Resize(width, height) => self.set_size(width, height),
+			}
+		}
+		if has_actions || cache_expired {
+			self.rebuild(view_data);
+		}
+	}
+
+	pub(super) const fn should_show_scroll_bar(&self) -> bool {
+		self.should_show_scrollbar
+	}
+
+	#[allow(
+		clippy::cast_precision_loss,
+		clippy::cast_possible_truncation,
+		clippy::cast_sign_loss
+	)]
+	pub(super) fn get_scroll_index(&self) -> usize {
+		if self.lines_count == 0 || self.scroll_position.get_top_position() == 0 {
+			return 0;
+		}
+
+		let view_height = if self.padding_height < self.height {
+			self.height - self.padding_height
+		}
+		else {
+			0
+		};
+
+		if view_height <= 1 || view_height > self.lines_count {
+			return 0;
+		}
+
+		// view_height >= 2
+		// lines.len() > 2
+
+		// if at bottom of list
+		if self.scroll_position.get_top_position() >= self.lines_count - view_height {
+			return view_height - 1;
+		}
+
+		if view_height <= 2 {
+			return 0;
+		}
+
+		// 0 input range, if first and last item are pinned, so scroll center
+		if self.lines_count - view_height <= 2 {
+			return (0.5 * view_height as f64).round() as usize;
+		}
+
+		// linear range map from scroll range to view range. This only maps the range between the
+		// first and last items, since those items are always returned as 0 or view_height
+		let value = self.scroll_position.get_top_position() as f64;
+		let input_start = 1.0;
+		let input_end = (self.lines_count - view_height) as f64 - 1.0;
+		let output_start = 1.0;
+		let output_end = view_height as f64 - 2.0;
+		let input_range = input_end - input_start;
+		let output_range = output_end - output_start;
+		let slope = output_range / input_range;
+		slope.mul_add(value - input_start, output_start).round() as usize
+	}
+
+	pub(super) const fn show_title(&self) -> bool {
+		self.show_title
+	}
+
+	pub(super) const fn show_help(&self) -> bool {
+		self.show_help
+	}
+
+	pub(super) const fn get_leading_lines_count(&self) -> usize {
+		self.lines_leading_count
+	}
+
+	pub(super) const fn get_trailing_lines_count(&self) -> usize {
+		self.lines_trailing_count
+	}
+
+	pub(super) const fn get_lines(&self) -> &Vec<ViewLine> {
+		&self.lines
+	}
+
+	pub(super) const fn get_version(&self) -> u32 {
+		self.version
+	}
+
+	#[cfg(test)]
+	pub(super) const fn get_actions(&self) -> &VecDeque<RenderAction> {
+		&self.actions
+	}
+
+	fn cache_expired(&self, view_data: &ViewData) -> bool {
+		self.view_data_name != view_data.get_name() || self.view_data_version != view_data.get_version()
+	}
+
+	fn set_size(&mut self, view_width: usize, view_height: usize) {
+		if self.height != view_height || self.width != view_width {
+			self.height = view_height;
+			self.width = view_width;
+			self.update_scroll_position_size();
+		}
+	}
+
+	fn set_padding_height(&mut self, view_data: &ViewData) {
+		let padding_height = if view_data.show_title() { 1 } else { 0 }
+			+ view_data.get_leading_lines().len()
+			+ view_data.get_trailing_lines().len();
+
+		if self.padding_height != padding_height {
+			self.padding_height = padding_height;
+		}
+	}
+
+	fn set_active_scroll_position(&mut self, view_data: &ViewData) {
+		let name = view_data.get_name();
+		if name != self.view_data_name {
+			let previous_scroll_position = mem::replace(
+				&mut self.scroll_position,
+				self.scroll_position_cache
+					.remove(&String::from(name))
+					.unwrap_or_else(ScrollPosition::new),
+			);
+			self.scroll_position_cache
+				.insert(String::from(self.view_data_name.as_str()), previous_scroll_position);
+			let version = view_data.get_scroll_version();
+			if self.scroll_position.get_version() != version || !view_data.retain_scroll_position() {
+				self.scroll_position.reset();
+				self.scroll_position.set_version(version);
+			}
+			self.update_scroll_position_size();
+		}
+	}
+
+	fn update_scroll_position_size(&mut self) {
+		self.scroll_position.resize(
+			if self.height == 0 || self.padding_height > self.height {
+				0
+			}
+			else {
+				self.height - self.padding_height
+			},
+			if self.width == 0 {
+				0
+			}
+			else {
+				self.width - if self.should_show_scroll_bar() { 1 } else { 0 }
+			},
+		);
+	}
+
+	#[allow(clippy::cognitive_complexity)]
+	fn rebuild(&mut self, view_data: &ViewData) {
+		let leading_lines_length = view_data.get_leading_lines().len();
+		let trailing_lines_length = view_data.get_trailing_lines().len();
+		let lines_length = view_data.get_lines().len();
+
+		self.version += 1;
+		self.view_data_name = String::from(view_data.get_name());
+		self.view_data_version = view_data.get_version();
+		self.show_title = view_data.show_title();
+		self.show_help = view_data.show_help();
+		self.should_show_scrollbar =
+			self.padding_height < self.height && lines_length > (self.height - self.padding_height);
+
+		self.scroll_position.set_lines_length(lines_length);
+		if let Some(row) = view_data.get_visible_row().as_ref() {
+			self.scroll_position.ensure_line_visible(*row);
+		}
+
+		let (leading_lines_end, max_leading_line_length) = if leading_lines_length == 0 {
+			(0, 0)
+		}
+		else {
+			// trailing lines have precedence over leading lines, title always has precedence
+			let padding_height = if self.show_title { 1 } else { 0 } + trailing_lines_length;
+			let available_height = if padding_height < self.height {
+				self.height - padding_height
+			}
+			else {
+				0
+			};
+			let leading_lines_end = if leading_lines_length < available_height {
+				leading_lines_length
+			}
+			else {
+				available_height
+			};
+
+			(
+				leading_lines_end,
+				Self::calculate_max_line_length(view_data.get_leading_lines(), 0, leading_lines_end),
+			)
+		};
+
+		let (trailing_lines_end, max_trailing_line_length) = if trailing_lines_length == 0 {
+			(0, 0)
+		}
+		else {
+			// title always has precedence
+			let padding_height = if self.show_title { 1 } else { 0 };
+			let available_height = if padding_height < self.height {
+				self.height - padding_height
+			}
+			else {
+				0
+			};
+
+			let trailing_lines_end = if trailing_lines_length < available_height {
+				trailing_lines_length
+			}
+			else {
+				available_height
+			};
+
+			(
+				trailing_lines_end,
+				Self::calculate_max_line_length(view_data.get_trailing_lines(), 0, trailing_lines_end),
+			)
+		};
+
+		let (lines_start, lines_end, max_line_length) = if lines_length == 0 {
+			(0, 0, 0)
+		}
+		else {
+			// all other lines take precedence over regular lines
+			let available_height = if self.padding_height < self.height {
+				self.height - self.padding_height
+			}
+			else {
+				0
+			};
+
+			let lines_start = self.scroll_position.get_top_position();
+
+			let lines_end = if lines_length < available_height {
+				lines_length
+			}
+			else {
+				available_height
+			};
+
+			let max_line_length = Self::calculate_max_line_length(view_data.get_lines(), lines_start, lines_end);
+			(
+				lines_start,
+				lines_end,
+				max_line_length + if self.should_show_scrollbar { 1 } else { 0 },
+			)
+		};
+
+		self.lines_leading_count = leading_lines_end;
+		self.lines_trailing_count = trailing_lines_end;
+		self.lines_count = lines_length;
+		self.scroll_position.set_max_line_length(
+			max_line_length
+				.max(max_leading_line_length)
+				.max(max_trailing_line_length),
+		);
+		if let Some(column) = view_data.get_visible_column().as_ref() {
+			self.scroll_position.ensure_column_visible(*column);
+		}
+
+		self.lines.clear();
+		self.push_lines(view_data.get_leading_lines(), 0, leading_lines_end, false);
+		self.push_lines(
+			view_data.get_lines(),
+			lines_start,
+			lines_end,
+			self.should_show_scrollbar,
+		);
+		self.push_lines(view_data.get_trailing_lines(), 0, trailing_lines_end, false);
+	}
+
+	fn calculate_max_line_length(view_lines: &[ViewLine], start: usize, length: usize) -> usize {
+		view_lines
+			.iter()
+			.skip(start)
+			.take(length)
+			.fold(0, |longest, line| -> usize {
+				if line.get_segments().len() <= line.get_number_of_pinned_segment() {
+					longest
+				}
+				else {
+					let sum = line.get_segments().iter().fold(0, |s, l| s + l.get_length());
+
+					if sum > longest {
+						sum
+					}
+					else {
+						longest
+					}
+				}
+			})
+	}
+
+	fn push_lines(&mut self, view_lines: &[ViewLine], start: usize, end: usize, scroll_bar: bool) {
+		let window_width = if scroll_bar && self.width > 0 {
+			self.width - 1
+		}
+		else {
+			self.width
+		};
+		let left = self.scroll_position.get_left_position();
+
+		view_lines.iter().skip(start).take(end).for_each(|line| {
+			let mut start = 0;
+			let mut left_start = 0;
+			let mut segments = vec![];
+			// window width can be zero when there is a scrollbar and a view width of 1
+			if window_width > 0 {
+				for (i, segment) in line.get_segments().iter().enumerate() {
+					// set left on first non-pinned segment
+					if i == line.get_number_of_pinned_segment() {
+						left_start = left;
+					}
+
+					let partial = segment.get_partial_segment(left_start, window_width - start);
+
+					if partial.get_length() > 0 {
+						segments.push(LineSegment::new_with_color_and_style(
+							partial.get_content(),
+							segment.get_color(),
+							segment.is_dimmed(),
+							segment.is_underlined(),
+							segment.is_reversed(),
+						));
+
+						start += partial.get_length();
+						if start >= window_width {
+							break;
+						}
+						left_start = 0;
+					}
+					else {
+						left_start -= segment.get_length();
+					}
+				}
+
+				if start < window_width {
+					if let Some(padding) = line.get_padding().as_ref() {
+						segments.push(LineSegment::new_with_color_and_style(
+							padding.get_content().repeat(window_width - start).as_str(),
+							padding.get_color(),
+							padding.is_dimmed(),
+							padding.is_underlined(),
+							padding.is_reversed(),
+						));
+					}
+				}
+			}
+
+			self.lines.push(
+				ViewLine::new_with_pinned_segments(segments, line.get_number_of_pinned_segment())
+					.set_selected(line.get_selected()),
+			);
+		});
+	}
+}

--- a/src/view/render_slice/render_action.rs
+++ b/src/view/render_slice/render_action.rs
@@ -1,0 +1,10 @@
+#[derive(Debug)]
+pub enum RenderAction {
+	ScrollDown,
+	ScrollUp,
+	ScrollRight,
+	ScrollLeft,
+	PageUp,
+	PageDown,
+	Resize(usize, usize),
+}

--- a/src/view/render_slice/tests.rs
+++ b/src/view/render_slice/tests.rs
@@ -1,0 +1,1220 @@
+use super::*;
+use crate::{
+	display::display_color::DisplayColor,
+	view::testutil::{_assert_rendered_output, render_view_line},
+};
+
+fn assert_rendered(render_slice: &RenderSlice, expected: &[&str]) {
+	let mut output = vec![];
+
+	if render_slice.show_title() {
+		if render_slice.show_help() {
+			output.push(String::from("{TITLE}{HELP}"));
+		}
+		else {
+			output.push(String::from("{TITLE}"));
+		}
+	}
+
+	let lines = render_slice.get_lines();
+	if lines.is_empty() {
+		output.push(String::from("{EMPTY}"));
+	}
+	else {
+		let leading_line_count = render_slice.get_leading_lines_count();
+		let trailing_line_count = render_slice.get_trailing_lines_count();
+		let lines_count = lines.len() - leading_line_count - trailing_line_count;
+		let leading_lines = lines.iter().take(leading_line_count);
+		let body_lines = lines.iter().skip(leading_line_count).take(lines_count);
+		let trailing_lines = lines.iter().skip(leading_line_count + lines_count);
+
+		if leading_line_count > 0 {
+			output.push(String::from("{LEADING}"));
+			for line in leading_lines {
+				output.push(render_view_line(line));
+			}
+		}
+
+		if lines_count > 0 {
+			output.push(String::from("{BODY}"));
+			for line in body_lines {
+				output.push(render_view_line(line));
+			}
+		}
+
+		if trailing_line_count > 0 {
+			output.push(String::from("{TRAILING}"));
+			for line in trailing_lines {
+				output.push(render_view_line(line));
+			}
+		}
+	}
+	_assert_rendered_output(
+		&output,
+		&expected.iter().map(|s| String::from(*s)).collect::<Vec<String>>(),
+	);
+}
+
+fn create_view_data(leading_lines: u16, body_lines: u16, trailing_lines: u16) -> ViewData {
+	ViewData::new(|updater| {
+		for index in 1..=leading_lines {
+			updater.push_leading_line(ViewLine::from(format!("L({})", index)));
+		}
+
+		for index in 1..=body_lines {
+			updater.push_line(ViewLine::from(format!("B({})", index)));
+		}
+
+		for index in 1..=trailing_lines {
+			updater.push_trailing_line(ViewLine::from(format!("T({})", index)));
+		}
+	})
+}
+
+fn create_render_slice(width: usize, height: usize, view_data: &ViewData) -> RenderSlice {
+	let mut render_slice = RenderSlice::new();
+	render_slice.set_size(width, height);
+	render_slice.sync_view_data(view_data);
+	render_slice
+}
+
+fn set_scroll_position(render_slice: &mut RenderSlice, scroll_position: usize) {
+	for _ in 0..scroll_position {
+		render_slice.scroll_position.scroll_down();
+	}
+}
+
+#[test]
+fn scroll_up_action() {
+	let view_data = create_view_data(2, 10, 2);
+	let mut render_slice = create_render_slice(100, 8, &view_data);
+	for _ in 0..6 {
+		render_slice.scroll_position.scroll_down();
+	}
+	render_slice.record_scroll_up();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(6)",
+		"{Normal}B(7)",
+		"{Normal}B(8)",
+		"{Normal}B(9)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn scroll_down_action() {
+	let view_data = create_view_data(2, 10, 2);
+	let mut render_slice = create_render_slice(100, 8, &view_data);
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn page_up_action() {
+	let view_data = create_view_data(2, 10, 2);
+	let mut render_slice = create_render_slice(100, 8, &view_data);
+	for _ in 0..6 {
+		render_slice.scroll_position.scroll_down();
+	}
+	render_slice.record_page_up();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(5)",
+		"{Normal}B(6)",
+		"{Normal}B(7)",
+		"{Normal}B(8)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn page_down_action() {
+	let view_data = create_view_data(2, 10, 2);
+	let mut render_slice = create_render_slice(100, 8, &view_data);
+	render_slice.record_page_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{Normal}B(6)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn scroll_left_action() {
+	let view_data = ViewData::new(|updater| updater.push_line(ViewLine::from("1234567890")));
+	let mut render_slice = create_render_slice(5, 1, &view_data);
+	for _ in 0..4 {
+		render_slice.scroll_position.scroll_right();
+	}
+	render_slice.record_scroll_left();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}45678"]);
+}
+
+#[test]
+fn scroll_right_action() {
+	let view_data = ViewData::new(|updater| updater.push_line(ViewLine::from("1234567890")));
+	let mut render_slice = create_render_slice(5, 1, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}23456"]);
+}
+
+#[test]
+fn resize_action() {
+	let view_data = create_view_data(0, 3, 0);
+	let mut render_slice = create_render_slice(1, 1, &view_data);
+	render_slice.record_resize(100, 100);
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+	]);
+}
+
+#[test]
+fn resize_action_zero_width() {
+	let view_data = create_view_data(0, 3, 0);
+	let mut render_slice = create_render_slice(1, 1, &view_data);
+	render_slice.record_resize(0, 100);
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "", "", ""]);
+}
+
+#[test]
+fn resize_action_zero_height() {
+	let view_data = create_view_data(0, 3, 0);
+	let mut render_slice = create_render_slice(1, 1, &view_data);
+	render_slice.record_resize(100, 0);
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{EMPTY}"]);
+}
+
+#[test]
+fn rebuild_with_cache() {
+	let view_data = create_view_data(0, 1, 0);
+	let mut render_slice = create_render_slice(100, 300, &view_data);
+	let version = render_slice.get_version();
+	render_slice.lines.push(ViewLine::new_empty_line());
+	render_slice.sync_view_data(&view_data);
+	assert_eq!(version, render_slice.version);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}B(1)", ""]);
+}
+
+#[test]
+fn rebuild_with_cache_miss_new_view() {
+	let view_data_1 = create_view_data(0, 1, 0);
+	let mut view_data_2 = create_view_data(0, 1, 0);
+	view_data_2.update_view_data(|updater| updater.push_line(ViewLine::from("View Data 2")));
+	let mut render_slice = create_render_slice(100, 300, &view_data_1);
+	let version = render_slice.get_version();
+	render_slice.sync_view_data(&view_data_2);
+	assert_ne!(version, render_slice.version);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}B(1)", "{Normal}View Data 2"]);
+}
+
+#[test]
+fn rebuild_with_cache_miss_new_version() {
+	let mut view_data = create_view_data(0, 1, 0);
+	let mut render_slice = create_render_slice(100, 300, &view_data);
+	let version = render_slice.get_version();
+	view_data.update_view_data(|updater| updater.push_line(ViewLine::from("View Data 2")));
+	render_slice.sync_view_data(&view_data);
+	assert_ne!(version, render_slice.version);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}B(1)", "{Normal}View Data 2"]);
+}
+
+#[test]
+fn swap_active_scroll_position() {
+	let mut view_data_1 = create_view_data(0, 10, 0);
+	view_data_1.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 1")));
+	let mut view_data_2 = create_view_data(0, 10, 0);
+	view_data_2.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 2")));
+	let mut render_slice = create_render_slice(300, 6, &view_data_1);
+	// first view data scroll one way
+	render_slice.record_page_down();
+	render_slice.sync_view_data(&view_data_1);
+
+	// second view data scroll differently
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data_2);
+	// assert scroll position of second view data
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}View Data 2",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+	]);
+	// assert previous scroll position is retained
+	render_slice.sync_view_data(&view_data_1);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}View Data 1",
+		"{BODY}",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{Normal}B(6)",
+		"{Normal}B(7)",
+	]);
+}
+
+#[test]
+fn swap_active_scroll_position_false_retain_scroll_position() {
+	let mut view_data_1 = create_view_data(0, 10, 0);
+	view_data_1.update_view_data(|updater| {
+		updater.push_leading_line(ViewLine::from("View Data 1"));
+		updater.set_retain_scroll_position(false);
+	});
+	let mut view_data_2 = create_view_data(0, 10, 0);
+	view_data_2.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 2")));
+	let mut render_slice = create_render_slice(300, 6, &view_data_1);
+	// first view data scroll one way
+	render_slice.record_page_down();
+	render_slice.sync_view_data(&view_data_1);
+
+	// second view data scroll differently
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data_2);
+
+	// assert scroll position of first view has been reset
+	render_slice.sync_view_data(&view_data_1);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}View Data 1",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+	]);
+}
+
+#[test]
+fn swap_active_scroll_position_after_resize_larger() {
+	let mut view_data_1 = create_view_data(0, 10, 0);
+	view_data_1.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 1")));
+	let mut view_data_2 = create_view_data(0, 10, 0);
+	view_data_2.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 2")));
+	let mut render_slice = create_render_slice(300, 6, &view_data_1);
+	// first view data scroll one way
+	render_slice.record_page_down();
+	render_slice.sync_view_data(&view_data_1);
+
+	// second view data scroll differently
+	render_slice.record_scroll_down();
+	render_slice.record_resize(250, 7);
+	render_slice.sync_view_data(&view_data_2);
+
+	// assert scroll position of second view data
+	render_slice.sync_view_data(&view_data_1);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}View Data 1",
+		"{BODY}",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{Normal}B(6)",
+		"{Normal}B(7)",
+		"{Normal}B(8)",
+	]);
+}
+
+#[test]
+fn swap_active_scroll_position_after_resize_smaller() {
+	let mut view_data_1 = create_view_data(0, 10, 0);
+	view_data_1.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 1")));
+	let mut view_data_2 = create_view_data(0, 10, 0);
+	view_data_2.update_view_data(|updater| updater.push_leading_line(ViewLine::from("View Data 2")));
+	let mut render_slice = create_render_slice(300, 6, &view_data_1);
+	// first view data scroll one way
+	render_slice.record_page_down();
+	render_slice.sync_view_data(&view_data_1);
+
+	// second view data scroll differently
+	render_slice.record_scroll_down();
+	render_slice.record_resize(250, 5);
+	render_slice.sync_view_data(&view_data_2);
+
+	// assert scroll position of second view data
+	render_slice.sync_view_data(&view_data_1);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}View Data 1",
+		"{BODY}",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{Normal}B(6)",
+	]);
+}
+
+#[test]
+fn empty_view_data() {
+	let render_slice = create_render_slice(100, 300, &ViewData::new(|_| {}));
+	assert_rendered(&render_slice, &["{EMPTY}"]);
+}
+
+#[test]
+fn empty_view_data_with_title_with_help() {
+	let render_slice = create_render_slice(
+		100,
+		300,
+		&ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.set_show_help(true);
+		}),
+	);
+	assert_rendered(&render_slice, &["{TITLE}{HELP}", "{EMPTY}"]);
+}
+
+#[test]
+fn empty_view_data_with_title_without_help() {
+	let render_slice = create_render_slice(
+		100,
+		300,
+		&ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.set_show_help(false);
+		}),
+	);
+	assert_rendered(&render_slice, &["{TITLE}", "{EMPTY}"]);
+}
+
+#[test]
+fn only_leading_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(1, 0, 0));
+	assert_rendered(&render_slice, &["{LEADING}", "{Normal}L(1)"]);
+}
+
+#[test]
+fn only_body_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(0, 1, 0));
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}B(1)"]);
+}
+
+#[test]
+fn only_trailing_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(0, 0, 1));
+	assert_rendered(&render_slice, &["{TRAILING}", "{Normal}T(1)"]);
+}
+
+#[test]
+fn no_leading_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(0, 1, 1));
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}B(1)", "{TRAILING}", "{Normal}T(1)"]);
+}
+
+#[test]
+fn no_body_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(1, 0, 1));
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+	]);
+}
+
+#[test]
+fn no_trailing_lines() {
+	let render_slice = create_render_slice(100, 10, &create_view_data(1, 1, 0));
+	assert_rendered(&render_slice, &["{LEADING}", "{Normal}L(1)", "{BODY}", "{Normal}B(1)"]);
+}
+
+#[test]
+fn ensure_row_visible() {
+	let mut view_data = create_view_data(2, 10, 2);
+	view_data.update_view_data(|updater| updater.ensure_line_visible(4));
+	let render_slice = create_render_slice(100, 8, &view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn ensure_column_visible() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("0123456789"));
+		updater.ensure_column_visible(5);
+	});
+	let render_slice = create_render_slice(5, 1, &view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}12345"]);
+}
+
+#[test]
+fn false_should_show_scroll_bar_zero_view_height_with_zero_padding() {
+	let view_data = create_view_data(0, 10, 0);
+	let render_slice = create_render_slice(100, 0, &view_data);
+	assert!(!render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn false_should_show_scroll_bar_zero_view_height_with_padding() {
+	let view_data = create_view_data(2, 10, 2);
+	let render_slice = create_render_slice(100, 4, &view_data);
+	assert!(!render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn false_should_show_scroll_bar_lots_of_view_height_with_zero_padding() {
+	let view_data = create_view_data(0, 10, 0);
+	let render_slice = create_render_slice(100, 10, &view_data);
+	assert!(!render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn false_should_show_scroll_bar_lots_of_view_height_with_padding() {
+	let view_data = create_view_data(2, 10, 2);
+	let render_slice = create_render_slice(100, 14, &view_data);
+	assert!(!render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn true_should_show_scroll_bar_with_zero_padding() {
+	let view_data = create_view_data(0, 10, 0);
+	let render_slice = create_render_slice(100, 9, &view_data);
+	assert!(render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn true_should_show_scroll_bar_lots_of_view_height_with_padding() {
+	let view_data = create_view_data(2, 10, 2);
+	let render_slice = create_render_slice(100, 13, &view_data);
+	assert!(render_slice.should_show_scroll_bar());
+}
+
+#[test]
+fn with_more_than_enough_view_height_for_all_lines() {
+	let view_data = create_view_data(2, 3, 2);
+	let render_slice = create_render_slice(100, 8, &view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_more_than_enough_view_height_for_all_lines_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 9, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_just_enough_height_for_all_lines() {
+	let view_data = create_view_data(2, 3, 2);
+	let render_slice = create_render_slice(100, 7, &view_data);
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_just_enough_height_for_all_lines_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 8, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_all_but_one_body_line() {
+	let render_slice = create_render_slice(100, 6, &create_view_data(2, 3, 2));
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_all_but_one_body_line_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 7, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{Normal}B(2)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_one_body_line() {
+	let render_slice = create_render_slice(100, 5, &create_view_data(2, 3, 2));
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_one_body_line_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 6, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{BODY}",
+		"{Normal}B(1)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_no_height_for_body() {
+	let render_slice = create_render_slice(100, 4, &create_view_data(2, 3, 2));
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_no_height_for_body_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 5, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{Normal}L(2)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_one_less_leading_line() {
+	let render_slice = create_render_slice(100, 3, &create_view_data(2, 3, 2));
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_height_for_one_less_leading_line_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 4, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{LEADING}",
+		"{Normal}L(1)",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_less_height_than_body_lines_and_scrolled_down_one() {
+	let view_data = create_view_data(0, 10, 0);
+	let mut render_slice = create_render_slice(100, 4, &view_data);
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{BODY}",
+		"{Normal}B(2)",
+		"{Normal}B(3)",
+		"{Normal}B(4)",
+		"{Normal}B(5)",
+	]);
+}
+
+#[test]
+fn with_height_only_for_leading_lines() {
+	let render_slice = create_render_slice(100, 2, &create_view_data(2, 3, 2));
+	assert_rendered(&render_slice, &["{TRAILING}", "{Normal}T(1)", "{Normal}T(2)"]);
+}
+
+#[test]
+fn with_height_only_for_leading_lines_with_title() {
+	let mut view_data = create_view_data(2, 3, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 3, &view_data);
+	assert_rendered(&render_slice, &[
+		"{TITLE}",
+		"{TRAILING}",
+		"{Normal}T(1)",
+		"{Normal}T(2)",
+	]);
+}
+
+#[test]
+fn with_zero_height() {
+	let render_slice = create_render_slice(100, 0, &create_view_data(2, 2, 2));
+	assert_rendered(&render_slice, &["{EMPTY}"]);
+}
+
+#[test]
+fn with_height_for_title() {
+	let mut view_data = create_view_data(2, 2, 2);
+	view_data.update_view_data(|updater| updater.set_show_title(true));
+	let render_slice = create_render_slice(100, 1, &view_data);
+	assert_rendered(&render_slice, &["{TITLE}", "{EMPTY}"]);
+}
+
+#[test]
+fn with_padding() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("Foo").set_padding_with_color_and_style(
+			'*',
+			DisplayColor::ActionPick,
+			true,
+			true,
+			true,
+		));
+	});
+	let render_slice = create_render_slice(8, 1, &view_data);
+	assert_rendered(&render_slice, &[
+		"{BODY}",
+		"{Normal}Foo{ActionPick,Dimmed,Underline,Reversed}*****",
+	]);
+}
+
+#[test]
+fn with_padding_no_width() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("Foo").set_padding_with_color_and_style(
+			'*',
+			DisplayColor::ActionPick,
+			true,
+			true,
+			true,
+		));
+	});
+	let render_slice = create_render_slice(3, 1, &view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}Foo"]);
+}
+
+#[test]
+fn with_zero_with_and_scrollbar() {
+	let view_data = create_view_data(0, 10, 0);
+	let render_slice = create_render_slice(0, 4, &view_data);
+	assert_rendered(&render_slice, &["{BODY}", "", "", "", ""]);
+}
+
+#[test]
+fn get_scroll_index_top_position() {
+	let view_data = create_view_data(0, 100, 0);
+	let render_slice = create_render_slice(100, 100, &view_data);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_empty_lines() {
+	let view_data = ViewData::new(|_| {});
+	let render_slice = create_render_slice(100, 100, &view_data);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_end_position() {
+	let view_data = create_view_data(0, 100, 0);
+	let mut render_slice = create_render_slice(100, 10, &view_data);
+	set_scroll_position(&mut render_slice, 90);
+	assert_eq!(render_slice.get_scroll_index(), 9);
+}
+
+#[test]
+fn get_scroll_index_position_one_down() {
+	let view_data = create_view_data(0, 100, 0);
+	let mut render_slice = create_render_slice(100, 10, &view_data);
+	set_scroll_position(&mut render_slice, 1);
+	assert_eq!(render_slice.get_scroll_index(), 1);
+}
+
+#[test]
+fn get_scroll_index_position_low_input_range_1() {
+	let view_data = create_view_data(0, 10, 0);
+	let mut render_slice = create_render_slice(100, 8, &view_data);
+	set_scroll_position(&mut render_slice, 1);
+	assert_eq!(render_slice.get_scroll_index(), 4);
+}
+
+#[test]
+fn get_scroll_index_item_count_smaller_than_height() {
+	let view_data = create_view_data(0, 10, 0);
+	let mut render_slice = create_render_slice(100, 11, &view_data);
+	set_scroll_position(&mut render_slice, 1);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_view_height_too_small() {
+	let view_data = create_view_data(0, 10, 0);
+	let mut render_slice = create_render_slice(100, 2, &view_data);
+	set_scroll_position(&mut render_slice, 5);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_position_zero_line_zero_height() {
+	let view_data = ViewData::new(|_| {});
+	let render_slice = create_render_slice(100, 0, &view_data);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_two_lines_one_height_scrolled_down() {
+	let view_data = create_view_data(0, 2, 0);
+	let mut render_slice = create_render_slice(100, 1, &view_data);
+	set_scroll_position(&mut render_slice, 1);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn get_scroll_index_two_lines_zero_height_scrolled_down() {
+	let view_data = create_view_data(0, 2, 0);
+	let mut render_slice = create_render_slice(100, 0, &view_data);
+	set_scroll_position(&mut render_slice, 1);
+	assert_eq!(render_slice.get_scroll_index(), 0);
+}
+
+#[test]
+fn scroll_right_one_from_start_long_leading() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_leading_line(ViewLine::from("L(123456789)"));
+		updater.push_line(ViewLine::from("B(123)"));
+		updater.push_trailing_line(ViewLine::from("T(123)"));
+	});
+	let mut render_slice = create_render_slice(6, 10, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}(12345",
+		"{BODY}",
+		"{Normal}(123)",
+		"{TRAILING}",
+		"{Normal}(123)",
+	]);
+}
+
+#[test]
+fn scroll_right_one_from_start_long_body() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_leading_line(ViewLine::from("L(123)"));
+		updater.push_line(ViewLine::from("B(123456789)"));
+		updater.push_trailing_line(ViewLine::from("T(123)"));
+	});
+	let mut render_slice = create_render_slice(6, 10, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}(123)",
+		"{BODY}",
+		"{Normal}(12345",
+		"{TRAILING}",
+		"{Normal}(123)",
+	]);
+}
+
+#[test]
+fn scroll_right_one_from_start_long_trailing() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_leading_line(ViewLine::from("L(123)"));
+		updater.push_line(ViewLine::from("B(123)"));
+		updater.push_trailing_line(ViewLine::from("T(123456789)"));
+	});
+	let mut render_slice = create_render_slice(6, 10, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}(123)",
+		"{BODY}",
+		"{Normal}(123)",
+		"{TRAILING}",
+		"{Normal}(12345",
+	]);
+}
+
+#[test]
+fn scroll_right_one_from_start_all_same_length() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_leading_line(ViewLine::from("L(123456789)"));
+		updater.push_line(ViewLine::from("B(123456789)"));
+		updater.push_trailing_line(ViewLine::from("T(123456789)"));
+	});
+	let mut render_slice = create_render_slice(6, 10, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}(12345",
+		"{BODY}",
+		"{Normal}(12345",
+		"{TRAILING}",
+		"{Normal}(12345",
+	]);
+}
+
+#[test]
+fn scroll_one_right_with_scrollbar() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("B(123456789)"));
+		updater.push_line(ViewLine::from("B(123456789)"));
+	});
+	let mut render_slice = create_render_slice(3, 1, &view_data);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}(1"]);
+}
+
+#[test]
+fn scroll_right_to_end_with_scrollbar() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("B(123456789)"));
+		updater.push_line(ViewLine::from("B(123456789)"));
+	});
+	let mut render_slice = create_render_slice(3, 1, &view_data);
+	for _ in 0..10 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}9)"]);
+}
+
+#[test]
+fn scroll_right_to_end_all_same_length() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_leading_line(ViewLine::from("L(123456789)"));
+		updater.push_line(ViewLine::from("B(123456789)"));
+		updater.push_trailing_line(ViewLine::from("T(123456789)"));
+	});
+	let mut render_slice = create_render_slice(6, 10, &view_data);
+	for _ in 0..10 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.sync_view_data(&view_data);
+
+	assert_rendered(&render_slice, &[
+		"{LEADING}",
+		"{Normal}56789)",
+		"{BODY}",
+		"{Normal}56789)",
+		"{TRAILING}",
+		"{Normal}56789)",
+	]);
+}
+
+#[test]
+fn scroll_down_trigger_shorter_line_width_smaller_than_view_width() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("123456789"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+	});
+	let mut render_slice = create_render_slice(5, 3, &view_data);
+	for _ in 0..8 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{BODY}",
+		"{Normal}1234",
+		"{Normal}1234",
+		"{Normal}1234",
+	]);
+}
+
+#[test]
+fn scroll_down_trigger_shorter_line_width_larger_than_view_width() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("123456789"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+	});
+	let mut render_slice = create_render_slice(5, 3, &view_data);
+	for _ in 0..8 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &[
+		"{BODY}",
+		"{Normal}3456",
+		"{Normal}3456",
+		"{Normal}3456",
+	]);
+}
+
+#[test]
+fn scroll_down_trigger_shorter_longest_line_now_visible() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("123456789"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("123456"));
+	});
+	let mut render_slice = create_render_slice(5, 3, &view_data);
+	for _ in 0..8 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}34", "{Normal}34", "{Normal}3456"]);
+}
+
+#[test]
+fn scroll_down_trigger_shorter_longest_line_previous_second() {
+	let view_data = ViewData::new(|updater| {
+		updater.push_line(ViewLine::from("123456789"));
+		updater.push_line(ViewLine::from("123456"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+		updater.push_line(ViewLine::from("1234"));
+	});
+	let mut render_slice = create_render_slice(5, 3, &view_data);
+	for _ in 0..8 {
+		render_slice.record_scroll_right();
+	}
+	render_slice.record_scroll_down();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}3456", "{Normal}34", "{Normal}34"]);
+}
+
+#[test]
+fn scroll_horizontal_with_segments() {
+	let view_data = ViewData::new(|updater| {
+		let segments = vec![
+			LineSegment::new("1"),
+			LineSegment::new("23"),
+			LineSegment::new("456"),
+			LineSegment::new("7890"),
+			LineSegment::new("abcde"),
+		];
+		updater.push_line(ViewLine::from(segments));
+	});
+	let mut render_slice = create_render_slice(3, 10, &view_data);
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}1{Normal}23"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}23{Normal}4"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}3{Normal}45"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}456"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}56{Normal}7"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}6{Normal}78"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}789"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}890"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}90{Normal}a"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}0{Normal}ab"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}abc"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}bcd"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}cde"]);
+	render_slice.record_scroll_right();
+	render_slice.sync_view_data(&view_data);
+	assert_rendered(&render_slice, &["{BODY}", "{Normal}cde"]);
+}
+
+#[test]
+fn calculate_max_line_length_max_first() {
+	let view_lines = [
+		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+		ViewLine::from("012345"),
+	];
+	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 1), 16);
+}
+
+#[test]
+fn calculate_max_line_length_max_last() {
+	let view_lines = [
+		ViewLine::from("012345"),
+		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+	];
+	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 2), 16);
+}
+
+#[test]
+fn calculate_max_line_length_with_slice() {
+	let view_lines = [
+		ViewLine::from("012345"),
+		ViewLine::from("012345"),
+		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
+	];
+	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 1, 2), 16);
+}
+
+#[test]
+fn calculate_max_line_length_ignore_pinned() {
+	let view_lines = [
+		ViewLine::from("012345"),
+		ViewLine::from("012345"),
+		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
+		ViewLine::new_pinned(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
+	];
+	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 4), 16);
+}

--- a/src/view/sender.rs
+++ b/src/view/sender.rs
@@ -1,0 +1,278 @@
+use std::{
+	borrow::BorrowMut,
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		mpsc,
+		Arc,
+		Mutex,
+	},
+};
+
+use anyhow::{anyhow, Error, Result};
+
+use super::{action::ViewAction, render_slice::RenderSlice, view_data::ViewData};
+
+pub struct Sender {
+	poisoned: Arc<AtomicBool>,
+	sender: mpsc::Sender<ViewAction>,
+	render_slice: Arc<Mutex<RenderSlice>>,
+}
+
+fn map_send_err(_: mpsc::SendError<ViewAction>) -> Error {
+	anyhow!("Unable to send data")
+}
+
+impl Sender {
+	pub(crate) fn new(sender: mpsc::Sender<ViewAction>) -> Self {
+		Self {
+			poisoned: Arc::new(AtomicBool::new(false)),
+			sender,
+			render_slice: Arc::new(Mutex::new(RenderSlice::new())),
+		}
+	}
+
+	pub(crate) fn clone_poisoned(&self) -> Arc<AtomicBool> {
+		Arc::clone(&self.poisoned)
+	}
+
+	pub(crate) fn is_poisoned(&self) -> bool {
+		self.poisoned.load(Ordering::Relaxed)
+	}
+
+	pub(crate) fn clone_render_slice(&self) -> Arc<Mutex<RenderSlice>> {
+		Arc::clone(&self.render_slice)
+	}
+
+	pub(crate) fn start(&self) -> Result<()> {
+		self.sender.send(ViewAction::Start).map_err(map_send_err)
+	}
+
+	pub(crate) fn stop(&self) -> Result<()> {
+		self.sender.send(ViewAction::Stop).map_err(map_send_err)
+	}
+
+	pub(crate) fn end(&self) -> Result<()> {
+		self.sender.send(ViewAction::End).map_err(map_send_err)
+	}
+
+	pub(crate) fn scroll_up(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_scroll_up();
+	}
+
+	pub(crate) fn scroll_down(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_scroll_down();
+	}
+
+	pub(crate) fn scroll_left(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_scroll_left();
+	}
+
+	pub(crate) fn scroll_right(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_scroll_right();
+	}
+
+	pub(crate) fn scroll_page_up(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_page_up();
+	}
+
+	pub(crate) fn scroll_page_down(&self) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_page_down();
+	}
+
+	pub(crate) fn resize(&self, width: u16, height: u16) {
+		self.render_slice
+			.lock()
+			.expect("Unable to lock render slice")
+			.borrow_mut()
+			.record_resize(width as usize, height as usize);
+	}
+
+	pub(crate) fn render(&self, view_data: &ViewData) -> Result<()> {
+		self.render_slice
+			.lock()
+			.map_err(|_err| anyhow!("Unable to lock render slice"))?
+			.borrow_mut()
+			.sync_view_data(view_data);
+		self.sender.send(ViewAction::Render).map_err(map_send_err)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::atomic::Ordering;
+
+	use crate::view::{
+		testutil::{render_view_line, with_view_sender},
+		view_line::ViewLine,
+		ViewData,
+	};
+
+	#[test]
+	fn poisoned() {
+		with_view_sender(|context| {
+			context.view_sender.clone_poisoned().store(true, Ordering::SeqCst);
+			assert!(context.view_sender.is_poisoned());
+		});
+	}
+
+	#[test]
+	fn start_success() {
+		with_view_sender(|context| {
+			context.view_sender.start().unwrap();
+			context.assert_sent_messages(vec!["Start"]);
+		});
+	}
+
+	#[test]
+	fn start_error() {
+		with_view_sender(|mut context| {
+			context.drop_receiver();
+			assert_eq!(
+				context.view_sender.start().unwrap_err().to_string(),
+				"Unable to send data"
+			);
+		});
+	}
+
+	#[test]
+	fn stop_success() {
+		with_view_sender(|context| {
+			context.view_sender.stop().unwrap();
+			context.assert_sent_messages(vec!["Stop"]);
+		});
+	}
+
+	#[test]
+	fn stop_error() {
+		with_view_sender(|mut context| {
+			context.drop_receiver();
+			assert_eq!(
+				context.view_sender.stop().unwrap_err().to_string(),
+				"Unable to send data"
+			);
+		});
+	}
+
+	#[test]
+	fn end_success() {
+		with_view_sender(|context| {
+			context.view_sender.end().unwrap();
+			context.assert_sent_messages(vec!["End"]);
+		});
+	}
+
+	#[test]
+	fn end_error() {
+		with_view_sender(|mut context| {
+			context.drop_receiver();
+			assert_eq!(
+				context.view_sender.end().unwrap_err().to_string(),
+				"Unable to send data"
+			);
+		});
+	}
+
+	#[test]
+	fn scroll_up() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_up();
+			context.assert_render_action(&["ScrollUp"]);
+		});
+	}
+
+	#[test]
+	fn scroll_down() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_down();
+			context.assert_render_action(&["ScrollDown"]);
+		});
+	}
+
+	#[test]
+	fn scroll_left() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_left();
+			context.assert_render_action(&["ScrollLeft"]);
+		});
+	}
+
+	#[test]
+	fn scroll_right() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_right();
+			context.assert_render_action(&["ScrollRight"]);
+		});
+	}
+
+	#[test]
+	fn scroll_page_up() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_page_up();
+			context.assert_render_action(&["PageUp"]);
+		});
+	}
+
+	#[test]
+	fn scroll_page_down() {
+		with_view_sender(|context| {
+			context.view_sender.scroll_page_down();
+			context.assert_render_action(&["PageDown"]);
+		});
+	}
+
+	#[test]
+	fn resize() {
+		with_view_sender(|context| {
+			context.view_sender.resize(10, 20);
+			context.assert_render_action(&["Resize(10, 20)"]);
+		});
+	}
+
+	#[test]
+	fn render() {
+		with_view_sender(|context| {
+			context.view_sender.resize(300, 100);
+			context
+				.view_sender
+				.render(&ViewData::new(|updater| updater.push_line(ViewLine::from("Foo"))))
+				.unwrap();
+			assert_eq!(
+				render_view_line(
+					context
+						.view_sender
+						.clone_render_slice()
+						.lock()
+						.unwrap()
+						.get_lines()
+						.first()
+						.unwrap()
+				),
+				"{Normal}Foo"
+			);
+		});
+	}
+}

--- a/src/view/tests.rs
+++ b/src/view/tests.rs
@@ -1,0 +1,195 @@
+use super::*;
+use crate::{config::testutil::create_config, display::CrossTerm};
+
+fn assert_render(width: usize, height: usize, view_data: &ViewData, expected: &[&str]) {
+	let config = create_config();
+	let mut crossterm = CrossTerm::new();
+	crossterm.set_size(Size::new(width, height));
+	let display = Display::new(crossterm, &config.theme);
+	let mut view = View::new(display, "~", "?");
+
+	let mut render_slice = RenderSlice::new();
+	render_slice.record_resize(width, height);
+	render_slice.sync_view_data(view_data);
+	view.render(&render_slice).unwrap();
+
+	assert_eq!(CrossTerm::get_output().join(""), format!("{}\n", expected.join("\n")));
+}
+
+#[test]
+#[serial_test::serial]
+fn render_empty() {
+	assert_render(20, 10, &ViewData::new(|_| {}), &["~"; 10]);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_title_full_width() {
+	let mut expected = vec!["Git Interactive Rebase Tool        "];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		35,
+		10,
+		&ViewData::new(|updater| updater.set_show_title(true)),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_title_short_title() {
+	let mut expected = vec!["Git Rebase                "];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		26,
+		10,
+		&ViewData::new(|updater| updater.set_show_title(true)),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_title_full_width_with_help() {
+	let mut expected = vec!["Git Interactive Rebase Tool Help: ?"];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		35,
+		10,
+		&ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.set_show_help(true);
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_title_full_width_with_help_enabled_but_not_enough_length() {
+	let mut expected = vec!["Git Interactive Rebase Tool       "];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		34,
+		10,
+		&ViewData::new(|updater| {
+			updater.set_show_title(true);
+			updater.set_show_help(true);
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_leading_lines() {
+	let mut expected = vec!["This is a leading line"];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		30,
+		10,
+		&ViewData::new(|updater| {
+			updater.push_leading_line(ViewLine::from("This is a leading line"));
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_normal_lines() {
+	let mut expected = vec!["This is a line"];
+	expected.extend(vec!["~"; 9]);
+	assert_render(
+		30,
+		10,
+		&ViewData::new(|updater| {
+			updater.push_line(ViewLine::from("This is a line"));
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_tailing_lines() {
+	let mut expected = vec!["~"; 9];
+	expected.push("This is a trailing line");
+	assert_render(
+		30,
+		10,
+		&ViewData::new(|updater| {
+			updater.push_trailing_line(ViewLine::from("This is a trailing line"));
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_all_lines() {
+	let mut expected = vec!["This is a leading line", "This is a line"];
+	expected.extend(vec!["~"; 7]);
+	expected.push("This is a trailing line");
+	assert_render(
+		30,
+		10,
+		&ViewData::new(|updater| {
+			updater.push_leading_line(ViewLine::from("This is a leading line"));
+			updater.push_line(ViewLine::from("This is a line"));
+			updater.push_trailing_line(ViewLine::from("This is a trailing line"));
+		}),
+		&expected,
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_with_full_screen_data() {
+	assert_render(
+		30,
+		6,
+		&ViewData::new(|updater| {
+			updater.push_leading_line(ViewLine::from("This is a leading line"));
+			updater.push_line(ViewLine::from("This is line 1"));
+			updater.push_line(ViewLine::from("This is line 2"));
+			updater.push_line(ViewLine::from("This is line 3"));
+			updater.push_line(ViewLine::from("This is line 4"));
+			updater.push_trailing_line(ViewLine::from("This is a trailing line"));
+		}),
+		&[
+			"This is a leading line",
+			"This is line 1",
+			"This is line 2",
+			"This is line 3",
+			"This is line 4",
+			"This is a trailing line",
+		],
+	);
+}
+
+#[test]
+#[serial_test::serial]
+fn render_with_scroll_bar() {
+	assert_render(
+		30,
+		6,
+		&ViewData::new(|updater| {
+			updater.push_leading_line(ViewLine::from("This is a leading line"));
+			updater.push_line(ViewLine::from("This is line 1"));
+			updater.push_line(ViewLine::from("This is line 2"));
+			updater.push_line(ViewLine::from("This is line 3"));
+			updater.push_line(ViewLine::from("This is line 4"));
+			updater.push_line(ViewLine::from("This is line 5"));
+			updater.push_trailing_line(ViewLine::from("This is a trailing line"));
+		}),
+		&[
+			"This is a leading line",
+			"This is line 1█",
+			"This is line 2 ",
+			"This is line 3 ",
+			"This is line 4 ",
+			"This is a trailing line",
+		],
+	);
+}

--- a/src/view/thread.rs
+++ b/src/view/thread.rs
@@ -1,0 +1,65 @@
+use std::{
+	borrow::Borrow,
+	sync::mpsc,
+	thread::{sleep, spawn, JoinHandle},
+	time::{Duration, Instant},
+};
+
+const MINIMUM_TICK_RATE: Duration = Duration::from_millis(20); // ~50 Hz update
+
+use std::sync::atomic::Ordering;
+
+use crate::view::{action::ViewAction, sender::Sender, View};
+
+pub fn spawn_view_thread(view: View) -> (Sender, JoinHandle<()>) {
+	let (sender, receiver) = mpsc::channel();
+	let view_sender = Sender::new(sender.clone());
+	let view_render_slice = view_sender.clone_render_slice();
+	let crashed = view_sender.clone_poisoned();
+
+	let thread = spawn(move || {
+		let mut view = view;
+		let mut last_render_time = Instant::now() + MINIMUM_TICK_RATE;
+		let mut should_render = true;
+		for msg in receiver {
+			let mut err = false;
+			match msg {
+				ViewAction::Render => should_render = true,
+				ViewAction::Start => {
+					if view.start().is_err() {
+						err = true;
+					}
+				},
+				ViewAction::Stop => {
+					if view.end().is_err() {
+						err = true;
+					}
+				},
+				ViewAction::Refresh => {},
+				ViewAction::End => break,
+			}
+			if should_render && Instant::now() >= last_render_time {
+				last_render_time += MINIMUM_TICK_RATE;
+				should_render = false;
+				let render_slice = view_render_slice.lock().unwrap();
+				if view.render(render_slice.borrow()).is_err() {
+					err = true;
+				}
+			}
+			if err {
+				crashed.store(true, Ordering::Relaxed);
+			}
+		}
+	});
+
+	spawn(move || {
+		let sleep_time = MINIMUM_TICK_RATE / 2;
+		let mut time = Instant::now();
+		while sender.send(ViewAction::Refresh).is_ok() {
+			sleep(time.saturating_duration_since(Instant::now()));
+			time += sleep_time;
+		}
+	});
+
+	(view_sender, thread)
+}

--- a/src/view/util.rs
+++ b/src/view/util.rs
@@ -1,18 +1,18 @@
 use crate::{
 	input::{Event, MetaEvent},
-	view::view_data::ViewData,
+	view::ViewSender,
 };
 
-pub fn handle_view_data_scroll(event: Event, view_data: &mut ViewData) -> Option<Event> {
+pub fn handle_view_data_scroll(event: Event, view_sender: &ViewSender) -> Option<Event> {
 	match event {
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollLeft => view_data.scroll_left(),
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollRight => view_data.scroll_right(),
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollDown => view_data.scroll_down(),
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollUp => view_data.scroll_up(),
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollJumpDown => view_data.page_down(),
-		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollJumpUp => view_data.page_up(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollLeft => view_sender.scroll_left(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollRight => view_sender.scroll_right(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollDown => view_sender.scroll_down(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollUp => view_sender.scroll_up(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollJumpDown => view_sender.scroll_page_down(),
+		Event::Meta(meta_event) if meta_event == MetaEvent::ScrollJumpUp => view_sender.scroll_page_up(),
 		_ => return None,
-	}
+	};
 	Some(event)
 }
 
@@ -21,70 +21,32 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
-	use crate::{assert_rendered_output, view::view_line::ViewLine};
+	use crate::view::testutil::with_view_sender;
 
 	#[rstest(
 		meta_event,
-		result,
-		case::scroll_left(MetaEvent::ScrollLeft, "12345"),
-		case::scroll_right(MetaEvent::ScrollRight, "34567")
+		action,
+		case::scroll_left(MetaEvent::ScrollLeft, "ScrollLeft"),
+		case::scroll_right(MetaEvent::ScrollRight, "ScrollRight"),
+		case::scroll_down(MetaEvent::ScrollDown, "ScrollDown"),
+		case::scroll_up(MetaEvent::ScrollUp, "ScrollUp"),
+		case::jump_down(MetaEvent::ScrollJumpDown, "PageDown"),
+		case::jump_up(MetaEvent::ScrollJumpUp, "PageUp")
 	)]
-	fn handle_view_data_scroll_horizontal(meta_event: MetaEvent, result: &str) {
-		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("012345678"));
-		view_data.set_view_size(5, 10);
-		view_data.scroll_right();
-		view_data.scroll_right();
-		assert_eq!(
-			handle_view_data_scroll(Event::from(meta_event), &mut view_data),
-			Some(Event::from(meta_event))
-		);
-		assert_rendered_output!(&mut view_data, "{BODY}", format!("{{Normal}}{}", result));
-	}
-
-	#[rstest(
-	meta_event,
-		result,
-		case::scroll_down(MetaEvent::ScrollDown, ["3", "4", "5", "6"]),
-		case::scroll_up(MetaEvent::ScrollUp, ["1", "2", "3", "4"]),
-		case::jump_down(MetaEvent::ScrollJumpDown, ["4", "5", "6", "7"]),
-		case::jump_up(MetaEvent::ScrollJumpUp, ["0", "1", "2", "3"]),
-	)]
-	fn handle_view_data_scroll_vertical(meta_event: MetaEvent, result: [&str; 4]) {
-		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("0"));
-		view_data.push_line(ViewLine::from("1"));
-		view_data.push_line(ViewLine::from("2"));
-		view_data.push_line(ViewLine::from("3"));
-		view_data.push_line(ViewLine::from("4"));
-		view_data.push_line(ViewLine::from("5"));
-		view_data.push_line(ViewLine::from("6"));
-		view_data.push_line(ViewLine::from("7"));
-		view_data.push_line(ViewLine::from("8"));
-		view_data.push_line(ViewLine::from("9"));
-		view_data.set_view_size(10, 4);
-		view_data.scroll_down();
-		view_data.scroll_down();
-		assert_eq!(
-			handle_view_data_scroll(Event::from(meta_event), &mut view_data),
-			Some(Event::from(meta_event))
-		);
-		assert_rendered_output!(
-			&mut view_data,
-			"{BODY}",
-			format!("{{Normal}}{}", result[0]),
-			format!("{{Normal}}{}", result[1]),
-			format!("{{Normal}}{}", result[2]),
-			format!("{{Normal}}{}", result[3])
-		);
+	fn handle_view_data_scroll_event(meta_event: MetaEvent, action: &str) {
+		with_view_sender(|context| {
+			let event = Event::from(meta_event);
+			assert_eq!(handle_view_data_scroll(event, &context.view_sender), Some(event));
+			context.assert_render_action(&[action]);
+		});
 	}
 
 	#[test]
-	fn handle_view_data_scroll_other_input() {
-		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("012345678"));
-		view_data.set_view_size(5, 10);
-		assert_eq!(handle_view_data_scroll(Event::from('a'), &mut view_data), None);
-		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}01234");
+	fn handle_view_data_scroll_event_other() {
+		with_view_sender(|context| {
+			let event = Event::from('a');
+			assert!(handle_view_data_scroll(event, &context.view_sender).is_none());
+			context.assert_render_action(&[]);
+		});
 	}
 }

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -1,175 +1,74 @@
-use crate::view::{line_segment::LineSegment, scroll_position::ScrollPosition, view_line::ViewLine, ViewDataUpdater};
+use uuid::Uuid;
+
+use super::{view_line::ViewLine, ViewDataUpdater};
 
 pub struct ViewData {
-	empty_lines: Vec<ViewLine>,
-	height: usize,
-	leading_lines: Vec<ViewLine>,
-	leading_lines_cache: Option<Vec<ViewLine>>,
 	lines: Vec<ViewLine>,
-	lines_cache: Option<Vec<ViewLine>>,
-	max_leading_line_length: usize,
-	max_line_length: usize,
-	max_trailing_line_length: usize,
-	scroll_position: ScrollPosition,
+	lines_leading: Vec<ViewLine>,
+	lines_trailing: Vec<ViewLine>,
+	name: String,
+	retain_scroll_position: bool,
+	scroll_version: u32,
 	show_help: bool,
 	show_title: bool,
-	trailing_lines: Vec<ViewLine>,
-	trailing_lines_cache: Option<Vec<ViewLine>>,
 	version: u32,
-	width: usize,
+	visible_column: Option<usize>,
+	visible_row: Option<usize>,
 }
 
 impl ViewData {
 	pub(crate) fn new<C>(callback: C) -> Self
 	where C: FnOnce(&mut ViewDataUpdater<'_>) {
 		let mut view_data = Self {
-			empty_lines: vec![],
-			height: 0,
-			leading_lines: vec![],
-			leading_lines_cache: None,
 			lines: vec![],
-			lines_cache: None,
-			max_leading_line_length: 0,
-			max_line_length: 0,
-			max_trailing_line_length: 0,
-			scroll_position: ScrollPosition::new(),
+			lines_leading: vec![],
+			lines_trailing: vec![],
+			name: Uuid::new_v4().to_hyphenated().to_string(),
+			retain_scroll_position: true,
+			scroll_version: 0,
 			show_help: false,
 			show_title: false,
-			trailing_lines: vec![],
-			trailing_lines_cache: None,
 			version: 0,
-			width: 0,
+			visible_column: None,
+			visible_row: None,
 		};
 		let mut view_data_updater = ViewDataUpdater::new(&mut view_data);
 		callback(&mut view_data_updater);
 		view_data
 	}
 
+	pub(crate) fn is_empty(&self) -> bool {
+		self.lines.is_empty() && self.lines_leading.is_empty() && self.lines_trailing.is_empty()
+	}
+
 	pub(crate) fn update_view_data<C>(&mut self, callback: C)
 	where C: FnOnce(&mut ViewDataUpdater<'_>) {
-		let mut view_data_updater = ViewDataUpdater::new(self);
-		callback(&mut view_data_updater);
-		if view_data_updater.is_modified() {
-			self.version += 1;
+		let modified = {
+			let mut view_data_updater = ViewDataUpdater::new(self);
+			callback(&mut view_data_updater);
+			view_data_updater.is_modified()
+		};
+		if modified {
+			self.version = self.version.wrapping_add(1);
 		}
 	}
 
-	pub(super) fn reset(&mut self) {
-		self.clear();
-		self.scroll_position.reset();
-	}
-
 	pub(super) fn clear(&mut self) {
-		self.leading_lines.clear();
-		self.leading_lines_cache = None;
+		self.lines_leading.clear();
 		self.lines.clear();
-		self.lines_cache = None;
-		self.trailing_lines.clear();
-		self.trailing_lines_cache = None;
+		self.lines_trailing.clear();
 	}
 
 	pub(super) fn clear_body(&mut self) {
 		self.lines.clear();
-		self.lines_cache = None;
 	}
 
-	pub(super) fn scroll_up(&mut self) {
-		self.lines_cache = None;
-		self.scroll_position.scroll_up();
-		self.rebuild();
+	pub(super) fn ensure_line_visible(&mut self, row_index: usize) {
+		self.visible_row = Some(row_index);
 	}
 
-	pub(super) fn scroll_down(&mut self) {
-		self.lines_cache = None;
-		self.scroll_position.scroll_down();
-		self.rebuild();
-	}
-
-	pub(super) fn page_up(&mut self) {
-		self.lines_cache = None;
-		self.scroll_position.page_up();
-		self.rebuild();
-	}
-
-	pub(super) fn page_down(&mut self) {
-		self.lines_cache = None;
-		self.scroll_position.page_down();
-		self.rebuild();
-	}
-
-	pub(super) fn scroll_left(&mut self) {
-		self.leading_lines_cache = None;
-		self.lines_cache = None;
-		self.trailing_lines_cache = None;
-		self.scroll_position.scroll_left();
-		self.rebuild();
-	}
-
-	pub(super) fn scroll_right(&mut self) {
-		self.leading_lines_cache = None;
-		self.lines_cache = None;
-		self.trailing_lines_cache = None;
-		self.scroll_position.scroll_right();
-		self.rebuild();
-	}
-
-	pub(super) fn ensure_line_visible(&mut self, new_cursor_position: usize) {
-		let previous_top = self.scroll_position.get_top_position();
-		self.scroll_position.ensure_line_visible(new_cursor_position);
-
-		if previous_top != self.scroll_position.get_top_position() {
-			self.leading_lines_cache = None;
-			self.lines_cache = None;
-			self.trailing_lines_cache = None;
-			self.rebuild();
-		}
-	}
-
-	pub(super) fn ensure_column_visible(&mut self, new_cursor_position: usize) {
-		let previous_left = self.scroll_position.get_left_position();
-		self.scroll_position.ensure_column_visible(new_cursor_position);
-
-		if previous_left != self.scroll_position.get_left_position() {
-			self.leading_lines_cache = None;
-			self.lines_cache = None;
-			self.trailing_lines_cache = None;
-			self.rebuild();
-		}
-	}
-
-	pub fn set_view_size(&mut self, view_width: usize, view_height: usize) {
-		if self.height != view_height
-			|| self.width != view_width
-			|| self.leading_lines_cache.is_none()
-			|| self.lines_cache.is_none()
-			|| self.trailing_lines_cache.is_none()
-		{
-			self.height = view_height;
-			self.width = view_width;
-			self.leading_lines_cache = None;
-			self.lines_cache = None;
-			self.trailing_lines_cache = None;
-
-			let title_height = if self.show_title { 1 } else { 0 };
-
-			self.scroll_position.view_resize(
-				if self.height == 0 || self.leading_lines.len() + self.trailing_lines.len() + title_height > self.height
-				{
-					0
-				}
-				else {
-					self.height - self.leading_lines.len() - self.trailing_lines.len() - title_height
-				},
-				if self.width == 0 {
-					0
-				}
-				else {
-					self.width - if self.should_show_scroll_bar() { 1 } else { 0 }
-				},
-			);
-
-			self.rebuild();
-		}
+	pub(super) fn ensure_column_visible(&mut self, column_index: usize) {
+		self.visible_column = Some(column_index);
 	}
 
 	pub(super) fn set_show_title(&mut self, show: bool) {
@@ -181,88 +80,23 @@ impl ViewData {
 	}
 
 	pub(super) fn push_leading_line(&mut self, view_line: ViewLine) {
-		self.leading_lines_cache = None;
-		self.lines_cache = None;
-		self.trailing_lines_cache = None;
-		self.leading_lines.push(view_line);
+		self.lines_leading.push(view_line);
 	}
 
 	pub(super) fn push_line(&mut self, view_line: ViewLine) {
-		self.lines_cache = None;
 		self.lines.push(view_line);
 	}
 
 	pub(super) fn push_trailing_line(&mut self, view_line: ViewLine) {
-		self.lines_cache = None;
-		self.trailing_lines_cache = None;
-		self.trailing_lines.push(view_line);
+		self.lines_trailing.push(view_line);
 	}
 
-	pub(super) fn should_show_scroll_bar(&self) -> bool {
-		if self.lines.is_empty() {
-			return false;
-		}
-
-		// all other lines take precedence over regular lines
-		let padding_height = if self.show_title { 1 } else { 0 } + self.leading_lines.len() + self.trailing_lines.len();
-		if padding_height < self.height {
-			self.lines.len() > (self.height - padding_height)
-		}
-		else {
-			false
-		}
+	pub(super) fn set_retain_scroll_position(&mut self, value: bool) {
+		self.retain_scroll_position = value;
 	}
 
-	#[allow(
-		clippy::cast_precision_loss,
-		clippy::cast_possible_truncation,
-		clippy::cast_sign_loss
-	)]
-	pub(crate) fn get_scroll_index(&self) -> usize {
-		if self.lines.is_empty() || self.scroll_position.get_top_position() == 0 {
-			return 0;
-		}
-
-		let padding_height = if self.show_title { 1 } else { 0 } + self.leading_lines.len() + self.trailing_lines.len();
-		let view_height = if padding_height < self.height {
-			self.height - padding_height
-		}
-		else {
-			0
-		};
-
-		if view_height <= 1 || view_height > self.lines.len() {
-			return 0;
-		}
-
-		// view_height >= 2
-		// lines.len() > 2
-
-		// if at bottom of list
-		if self.scroll_position.get_top_position() >= self.lines.len() - view_height {
-			return view_height - 1;
-		}
-
-		if view_height <= 2 {
-			return 0;
-		}
-
-		// 0 input range, if first and last item are pinned, so scroll center
-		if self.lines.len() - view_height <= 2 {
-			return (0.5 * view_height as f64).round() as usize;
-		}
-
-		// linear range map from scroll range to view range. This only maps the range between the
-		// first and last items, since those items are always returned as 0 or view_height
-		let value = self.scroll_position.get_top_position() as f64;
-		let input_start = 1.0;
-		let input_end = (self.lines.len() - view_height) as f64 - 1.0;
-		let output_start = 1.0;
-		let output_end = view_height as f64 - 2.0;
-		let input_range = input_end - input_start;
-		let output_range = output_end - output_start;
-		let slope = output_range / input_range;
-		slope.mul_add(value - input_start, output_start).round() as usize
+	pub(super) fn reset_scroll_position(&mut self) {
+		self.scroll_version = self.scroll_version.wrapping_add(1);
 	}
 
 	pub(super) const fn show_title(&self) -> bool {
@@ -273,1443 +107,168 @@ impl ViewData {
 		self.show_help
 	}
 
-	pub(crate) fn is_empty(&self) -> bool {
-		self.lines.is_empty() && self.leading_lines.is_empty() && self.trailing_lines.is_empty()
+	pub(super) const fn get_leading_lines(&self) -> &Vec<ViewLine> {
+		&self.lines_leading
 	}
 
-	pub(super) fn get_leading_lines(&self) -> &Vec<ViewLine> {
-		self.leading_lines_cache.as_ref().unwrap_or(&self.empty_lines)
+	pub(super) const fn get_lines(&self) -> &Vec<ViewLine> {
+		&self.lines
 	}
 
-	pub(super) fn get_lines(&self) -> &Vec<ViewLine> {
-		self.lines_cache.as_ref().unwrap_or(&self.empty_lines)
+	pub(super) const fn get_trailing_lines(&self) -> &Vec<ViewLine> {
+		&self.lines_trailing
 	}
 
-	pub(super) fn get_trailing_lines(&self) -> &Vec<ViewLine> {
-		self.trailing_lines_cache.as_ref().unwrap_or(&self.empty_lines)
+	pub(super) const fn get_visible_column(&self) -> &Option<usize> {
+		&self.visible_column
 	}
 
-	#[allow(clippy::cognitive_complexity)]
-	fn rebuild(&mut self) {
-		if self.leading_lines_cache.is_none() {
-			self.leading_lines_cache = Some(
-				if self.leading_lines.is_empty() {
-					self.max_leading_line_length =
-						Self::calculate_max_line_length(&self.leading_lines, 0, self.leading_lines.len());
-					self.build_lines(&self.leading_lines, 0, self.leading_lines.len(), false)
-				}
-				else {
-					// trailing lines have precedence over leading lines, title always has precedence
-					let padding_height = if self.show_title { 1 } else { 0 } + self.trailing_lines.len();
-					let available_height = if padding_height < self.height {
-						self.height - padding_height
-					}
-					else {
-						0
-					};
-					let end = if self.leading_lines.len() < available_height {
-						self.leading_lines.len()
-					}
-					else {
-						available_height
-					};
-
-					self.max_leading_line_length = Self::calculate_max_line_length(&self.leading_lines, 0, end);
-					self.build_lines(&self.leading_lines, 0, end, false)
-				},
-			);
-		}
-
-		if self.trailing_lines_cache.is_none() {
-			self.trailing_lines_cache = Some(
-				if self.trailing_lines.is_empty() {
-					self.max_trailing_line_length =
-						Self::calculate_max_line_length(&self.trailing_lines, 0, self.trailing_lines.len());
-					self.build_lines(&self.trailing_lines, 0, self.trailing_lines.len(), false)
-				}
-				else {
-					// title always has precedence
-					let padding_height = if self.show_title { 1 } else { 0 };
-					let available_height = if padding_height < self.height {
-						self.height - padding_height
-					}
-					else {
-						0
-					};
-
-					let end = if self.trailing_lines.len() < available_height {
-						self.trailing_lines.len()
-					}
-					else {
-						available_height
-					};
-
-					self.max_trailing_line_length = Self::calculate_max_line_length(&self.trailing_lines, 0, end);
-					self.build_lines(&self.trailing_lines, 0, end, false)
-				},
-			);
-		}
-
-		if self.lines_cache.is_none() {
-			self.lines_cache = Some(
-				if self.lines.is_empty() {
-					self.max_line_length = 0;
-					vec![]
-				}
-				else {
-					// all other lines take precedence over regular lines
-					let padding_height =
-						if self.show_title { 1 } else { 0 } + self.leading_lines.len() + self.trailing_lines.len();
-					let available_height = if padding_height < self.height {
-						self.height - padding_height
-					}
-					else {
-						0
-					};
-
-					let start = if self.lines.len() <= available_height {
-						0
-					}
-					else if self.scroll_position.get_top_position() + available_height > self.lines.len() {
-						self.lines.len() - available_height
-					}
-					else {
-						self.scroll_position.get_top_position()
-					};
-
-					let end = if self.lines.len() < available_height {
-						self.lines.len()
-					}
-					else {
-						available_height
-					};
-
-					self.max_line_length = Self::calculate_max_line_length(&self.lines, start, end);
-
-					self.scroll_position
-						.set_line_maximums(self.get_max_line_length(), self.lines.len());
-
-					self.build_lines(&self.lines, start, end, self.should_show_scroll_bar())
-				},
-			);
-		}
-		else {
-			self.scroll_position
-				.set_line_maximums(self.get_max_line_length(), self.lines.len());
-		}
+	pub(super) const fn get_visible_row(&self) -> &Option<usize> {
+		&self.visible_row
 	}
 
-	fn calculate_max_line_length(view_lines: &[ViewLine], start: usize, length: usize) -> usize {
-		view_lines
-			.iter()
-			.skip(start)
-			.take(length)
-			.fold(0, |longest, line| -> usize {
-				if line.get_segments().len() <= line.get_number_of_pinned_segment() {
-					longest
-				}
-				else {
-					let sum = line.get_segments().iter().fold(0, |s, l| s + l.get_length());
-
-					if sum > longest {
-						sum
-					}
-					else {
-						longest
-					}
-				}
-			})
+	pub(super) fn get_name(&self) -> &str {
+		self.name.as_str()
 	}
 
-	fn get_max_line_length(&self) -> usize {
-		self.max_line_length
-			.max(self.max_leading_line_length)
-			.max(self.max_trailing_line_length)
+	pub(super) const fn get_version(&self) -> u32 {
+		self.version
 	}
 
-	fn build_lines(&self, view_lines: &[ViewLine], start: usize, end: usize, scroll_bar: bool) -> Vec<ViewLine> {
-		let window_width = if scroll_bar { self.width - 1 } else { self.width };
-		let left = self.scroll_position.get_left_position();
-
-		view_lines
-			.iter()
-			.skip(start)
-			.take(end)
-			.map(|line| -> ViewLine {
-				let mut start = 0;
-				let mut left_start = 0;
-				let mut segments = vec![];
-				for (i, segment) in line.get_segments().iter().enumerate() {
-					// set left on first non-pinned segment
-					if i == line.get_number_of_pinned_segment() {
-						left_start = left;
-					}
-
-					let partial = segment.get_partial_segment(left_start, window_width - start);
-
-					if partial.get_length() > 0 {
-						segments.push(LineSegment::new_with_color_and_style(
-							partial.get_content(),
-							segment.get_color(),
-							segment.is_dimmed(),
-							segment.is_underlined(),
-							segment.is_reversed(),
-						));
-
-						start += partial.get_length();
-						if start >= window_width {
-							break;
-						}
-						left_start = 0;
-					}
-					else {
-						left_start -= segment.get_length();
-					}
-				}
-
-				if start < window_width {
-					if let Some(padding) = line.get_padding().as_ref() {
-						segments.push(LineSegment::new_with_color_and_style(
-							padding.get_content().repeat(window_width - start).as_str(),
-							padding.get_color(),
-							padding.is_dimmed(),
-							padding.is_underlined(),
-							padding.is_reversed(),
-						));
-					}
-				}
-
-				let mut view_line = ViewLine::new_with_pinned_segments(segments, line.get_number_of_pinned_segment())
-					.set_selected(line.get_selected());
-
-				if let Some(padding) = line.get_padding().as_ref() {
-					view_line = view_line.set_padding_with_color_and_style(
-						padding.get_content().chars().next().unwrap_or(' '),
-						padding.get_color(),
-						padding.is_dimmed(),
-						padding.is_underlined(),
-						padding.is_reversed(),
-					);
-				}
-				else {
-					view_line = view_line.set_padding(' ');
-				}
-				view_line
-			})
-			.collect::<Vec<ViewLine>>()
+	pub(super) const fn retain_scroll_position(&self) -> bool {
+		self.retain_scroll_position
 	}
 
-	#[cfg(test)]
-	pub const fn get_size(&self) -> (usize, usize) {
-		(self.width, self.height)
+	pub(super) const fn get_scroll_version(&self) -> u32 {
+		self.scroll_version
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::assert_rendered_output;
 
-	fn create_mock_view_line() -> ViewLine {
-		ViewLine::from("Mocked Line")
+	#[test]
+	fn new_updater_function() {
+		let view_data = ViewData::new(|updater| updater.set_show_title(true));
+		assert!(view_data.show_title());
 	}
 
-	fn create_mocked_view_data() -> ViewData {
-		let mut view_data = ViewData::new(|updater| {
-			updater.push_leading_line(create_mock_view_line());
-			updater.push_leading_line(create_mock_view_line());
-			updater.push_leading_line(create_mock_view_line());
-
-			updater.push_line(create_mock_view_line());
-			updater.push_line(create_mock_view_line());
-			updater.push_line(create_mock_view_line());
-			updater.push_line(create_mock_view_line());
-
-			updater.push_trailing_line(create_mock_view_line());
-			updater.push_trailing_line(create_mock_view_line());
-		});
-		view_data.rebuild();
-		view_data
+	#[test]
+	fn is_empty() {
+		let view_data = ViewData::new(|_| {});
+		assert!(view_data.is_empty());
 	}
 
-	fn create_mocked_scroll_vertical_view_data() -> ViewData {
-		let mut view_data = ViewData::new(|updater| {
-			updater.push_leading_line(create_mock_view_line());
-			updater.push_leading_line(create_mock_view_line());
-			updater.push_leading_line(create_mock_view_line());
-
-			updater.push_line(ViewLine::from("a"));
-			updater.push_line(ViewLine::from("b"));
-			updater.push_line(ViewLine::from("c"));
-			updater.push_line(ViewLine::from("d"));
-			updater.push_line(ViewLine::from("1"));
-			updater.push_line(ViewLine::from("2"));
-			updater.push_line(ViewLine::from("3"));
-			updater.push_line(ViewLine::from("4"));
-			updater.push_line(ViewLine::from("5"));
-
-			updater.push_trailing_line(create_mock_view_line());
-			updater.push_trailing_line(create_mock_view_line());
-		});
-		view_data.set_view_size(100, 10);
-		view_data
-	}
-
-	fn create_mocked_scroll_horizontal_view_data() -> ViewData {
-		let mut view_data = ViewData::new(|updater| {
-			updater.push_leading_line(ViewLine::from("llllllllllllll"));
-			updater.push_line(ViewLine::from("aaaaaaaaaa"));
-			updater.push_line(ViewLine::from("aaaaaaaaaaaaaaa"));
-			updater.push_line(ViewLine::from("aaaaaaaaaa"));
-			updater.push_line(ViewLine::from("aaaaa"));
-			updater.push_line(ViewLine::from("aaaa"));
-			updater.push_line(ViewLine::from("aaa"));
-			updater.push_line(ViewLine::from("aa"));
-			updater.push_line(ViewLine::from("a"));
-			updater.push_trailing_line(ViewLine::from("ttttttttttttttt"));
-		});
-		view_data.set_view_size(7, 20);
-		view_data
-	}
-
-	fn create_mocked_scroll_index_data(number_of_items: usize, height: usize, scroll_position: usize) -> ViewData {
+	#[test]
+	fn update_view_data_without_modifications() {
 		let mut view_data = ViewData::new(|_| {});
-
-		for _ in 0..number_of_items {
-			view_data.push_line(create_mock_view_line());
-		}
-
-		view_data.set_view_size(10, height);
-
-		for _ in 0..scroll_position {
-			view_data.scroll_down();
-		}
-
-		view_data
+		let current_version = view_data.get_version();
+		view_data.update_view_data(|_| {});
+		assert_eq!(view_data.get_version(), current_version);
 	}
 
 	#[test]
-	fn render_empty() {
+	fn update_view_data_with_modifications() {
 		let mut view_data = ViewData::new(|_| {});
-		assert_rendered_output!(&mut view_data, "{EMPTY}");
-	}
-
-	#[test]
-	fn with_title_with_help() {
-		let mut view_data = ViewData::new(|updater| {
-			updater.set_show_title(true);
-			updater.set_show_help(true);
-		});
-		assert_rendered_output!(&mut view_data, "{TITLE}{HELP}", "{EMPTY}");
-	}
-
-	#[test]
-	fn with_title_without_help() {
-		let mut view_data = ViewData::new(|updater| {
-			updater.set_show_title(true);
-			updater.set_show_help(false);
-		});
-		assert_rendered_output!(&mut view_data, "{TITLE}", "{EMPTY}");
+		let current_version = view_data.get_version();
+		view_data.update_view_data(|updater| updater.set_show_title(true));
+		assert_ne!(view_data.get_version(), current_version);
 	}
 
 	#[test]
 	fn clear() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 3);
-		view_data.scroll_position.scroll_down();
+		let mut view_data = ViewData::new(|_| {});
+		view_data.push_line(ViewLine::new_empty_line());
+		view_data.push_leading_line(ViewLine::new_empty_line());
+		view_data.push_trailing_line(ViewLine::new_empty_line());
 		view_data.clear();
-
-		assert_rendered_output!(&mut view_data, "{EMPTY}");
-		assert_eq!(view_data.scroll_position.get_top_position(), 1);
+		assert!(view_data.get_leading_lines().is_empty());
+		assert!(view_data.get_lines().is_empty());
+		assert!(view_data.get_trailing_lines().is_empty());
 	}
 
 	#[test]
 	fn clear_body() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 100);
+		let mut view_data = ViewData::new(|_| {});
+		view_data.push_line(ViewLine::new_empty_line());
+		view_data.push_leading_line(ViewLine::new_empty_line());
+		view_data.push_trailing_line(ViewLine::new_empty_line());
 		view_data.clear_body();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
+		assert!(!view_data.get_leading_lines().is_empty());
+		assert!(view_data.get_lines().is_empty());
+		assert!(!view_data.get_trailing_lines().is_empty());
 	}
 
 	#[test]
-	fn reset() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 3);
-		view_data.scroll_position.scroll_down();
-		view_data.reset();
-
-		assert_rendered_output!(&mut view_data, "{EMPTY}");
-		assert_eq!(view_data.scroll_position.get_top_position(), 0);
-	}
-
-	#[test]
-	fn rebuild_no_leading_lines() {
+	fn ensure_line_visible() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.set_view_size(100, 10);
-		view_data.push_line(create_mock_view_line());
-		view_data.push_trailing_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line"
-		);
+		view_data.ensure_line_visible(10);
+		assert_eq!(view_data.get_visible_row().unwrap(), 10);
 	}
 
 	#[test]
-	fn rebuild_no_body_lines() {
+	fn ensure_column_visible() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.set_view_size(100, 10);
-		view_data.push_leading_line(create_mock_view_line());
-		view_data.push_trailing_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line"
-		);
+		view_data.ensure_column_visible(10);
+		assert_eq!(view_data.get_visible_column().unwrap(), 10);
 	}
 
 	#[test]
-	fn rebuild_no_trailing_lines() {
+	fn set_show_title() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.set_view_size(100, 10);
-		view_data.push_leading_line(create_mock_view_line());
-		view_data.push_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_more_than_enough_view_height_for_all_lines_with_title() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 12);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_more_than_enough_view_height_for_all_lines_without_title() {
-		let mut view_data = create_mocked_view_data();
 		view_data.set_show_title(false);
-		view_data.set_view_size(100, 12);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
+		assert!(!view_data.show_title());
 	}
 
 	#[test]
-	fn rebuild_with_just_enough_height_for_all_lines_with_title() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 10);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_just_enough_height_for_all_lines_without_title() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(false);
-		view_data.set_view_size(100, 9);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_removal_of_single_general_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 8);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_removal_of_all_but_one_general_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 6);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_removal_of_all_general_lines() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 5);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_no_general_lines_and_remove_one_leading_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 4);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_no_general_lines_and_all_but_one_leading_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 3);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_after_adding_leading_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 12);
-		view_data.push_leading_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_after_adding_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 12);
-		view_data.push_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_after_adding_trailing_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 12);
-		view_data.push_trailing_line(create_mock_view_line());
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_no_general_lines_and_no_leading_lines() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 2);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn rebuild_with_no_general_lines_and_no_leading_lines_and_one_trailing_line() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 1);
-
-		assert_rendered_output!(&mut view_data, "{TRAILING}", "{Normal}Mocked Line");
-	}
-
-	#[test]
-	fn rebuild_with_no_change() {
-		// this test isn't great, because it has to modify internals
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 100);
-		view_data.rebuild();
-		// set the cache to something it should not be
-		view_data.leading_lines_cache = Some(vec![]);
-		view_data.lines_cache = Some(vec![]);
-		view_data.trailing_lines_cache = Some(vec![]);
-		view_data.rebuild();
-
-		// cache should still be empty after rebuild
-		assert_rendered_output!(&mut view_data);
-	}
-
-	#[test]
-	fn rebuild_with_no_height() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_view_size(100, 0);
-
-		assert_rendered_output!(&mut view_data);
-	}
-
-	#[test]
-	fn rebuild_with_one_height_and_title() {
-		let mut view_data = create_mocked_view_data();
-		view_data.set_show_title(true);
-		view_data.set_view_size(100, 1);
-
-		assert_rendered_output!(&mut view_data, "{TITLE}");
-	}
-
-	#[test]
-	fn rebuild_retains_selected() {
+	fn set_show_help() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.set_view_size(100, 10);
-		view_data.push_line(ViewLine::new_empty_line().set_padding('*'));
-		view_data.rebuild();
-
-		// padding characters are stripped by the test render, so test it directly
-		assert_eq!(
-			view_data.lines_cache.unwrap()[0]
-				.get_padding()
-				.as_ref()
-				.unwrap()
-				.get_content(),
-			"*"
-		);
+		view_data.set_show_help(false);
+		assert!(!view_data.show_help());
 	}
 
 	#[test]
-	fn rebuild_retains_padding_character() {
+	fn push_leading_line() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.set_view_size(100, 10);
-		view_data.push_line(ViewLine::from("a").set_selected(true));
-		view_data.rebuild();
-
-		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal(selected)}a");
+		view_data.push_leading_line(ViewLine::new_empty_line());
+		assert_eq!(view_data.get_leading_lines().len(), 1);
 	}
 
 	#[test]
-	fn scroll_down_one_line() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		view_data.scroll_down();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_down_two_lines() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		view_data.scroll_down();
-		view_data.scroll_down();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_down_bottom() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		for _ in 0..4 {
-			view_data.scroll_down();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{Normal}5",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_down_one_past_bottom() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{Normal}5",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_up_one_line() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		view_data.scroll_up();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_up_two_lines() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		view_data.scroll_up();
-		view_data.scroll_up();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_up_top() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		for _ in 0..4 {
-			view_data.scroll_up();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}a",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_up_one_past_top() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		for _ in 0..5 {
-			view_data.scroll_up();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}a",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn page_down_once() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		view_data.page_down();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn page_down_past_bottom() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		view_data.page_down();
-		view_data.page_down();
-		view_data.page_down();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{Normal}5",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn page_up_once() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		view_data.page_up();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn page_up_past_top() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-
-		view_data.page_up();
-		view_data.page_up();
-		view_data.page_up();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}a",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn scroll_left() {
-		let mut view_data = create_mocked_scroll_horizontal_view_data();
-		// move right first
-		view_data.scroll_right();
-		view_data.scroll_right();
-		view_data.scroll_left();
-		view_data.scroll_left();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}lllllll",
-			"{BODY}",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaaa",
-			"{Normal}aaaa",
-			"{Normal}aaa",
-			"{Normal}aa",
-			"{Normal}a",
-			"{TRAILING}",
-			"{Normal}ttttttt"
-		);
-	}
-
-	#[test]
-	fn scroll_right_one_from_start() {
-		let mut view_data = create_mocked_scroll_horizontal_view_data();
-		view_data.scroll_right();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}lllllll",
-			"{BODY}",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaaaaa",
-			"{Normal}aaaa",
-			"{Normal}aaa",
-			"{Normal}aa",
-			"{Normal}a",
-			"",
-			"{TRAILING}",
-			"{Normal}ttttttt"
-		);
-	}
-
-	#[test]
-	fn scroll_right_to_end() {
-		let mut view_data = create_mocked_scroll_horizontal_view_data();
-		for _ in 0..8 {
-			view_data.scroll_right();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}llllll",
-			"{BODY}",
-			"{Normal}aa",
-			"{Normal}aaaaaaa",
-			"{Normal}aa",
-			"",
-			"",
-			"",
-			"",
-			"",
-			"{TRAILING}",
-			"{Normal}ttttttt"
-		);
-	}
-
-	#[test]
-	fn scroll_right_past_end() {
-		let mut view_data = create_mocked_scroll_horizontal_view_data();
-		for _ in 0..20 {
-			view_data.scroll_right();
-		}
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}llllll",
-			"{BODY}",
-			"{Normal}aa",
-			"{Normal}aaaaaaa",
-			"{Normal}aa",
-			"",
-			"",
-			"",
-			"",
-			"",
-			"{TRAILING}",
-			"{Normal}ttttttt"
-		);
-	}
-
-	#[test]
-	fn scroll_down_trigger_shorter_width() {
+	fn push_line() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("aaaaaaaaaa"));
-		view_data.push_line(ViewLine::from("aaaaaaaaaaaaaaa"));
-		view_data.push_line(ViewLine::from("aaaaaaaaaa"));
-		view_data.push_line(ViewLine::from("aaaaa"));
-		view_data.push_line(ViewLine::from("aaaa"));
-		view_data.push_line(ViewLine::from("aaa"));
-		view_data.push_line(ViewLine::from("aa"));
-		view_data.push_line(ViewLine::from("a"));
-		view_data.set_view_size(7, 3);
-		for _ in 0..10 {
-			view_data.scroll_right();
-		}
-		for _ in 0..3 {
-			view_data.scroll_down();
-		}
-
-		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}aaaaa", "{Normal}aaaa", "{Normal}aaa");
+		view_data.push_line(ViewLine::new_empty_line());
+		assert_eq!(view_data.get_lines().len(), 1);
 	}
 
 	#[test]
-	fn calculate_max_line_length_max_first() {
-		let view_lines = [
-			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-			ViewLine::from("012345"),
-		];
-		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 1), 16);
-	}
-
-	#[test]
-	fn calculate_max_line_length_max_last() {
-		let view_lines = [
-			ViewLine::from("012345"),
-			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-		];
-		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 2), 16);
-	}
-
-	#[test]
-	fn calculate_max_line_length_with_slice() {
-		let view_lines = [
-			ViewLine::from("012345"),
-			ViewLine::from("012345"),
-			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
-		];
-		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 1, 2), 16);
-	}
-
-	#[test]
-	fn calculate_max_line_length_ignore_pinned() {
-		let view_lines = [
-			ViewLine::from("012345"),
-			ViewLine::from("012345"),
-			ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-			ViewLine::new_pinned(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
-		];
-		assert_eq!(ViewData::calculate_max_line_length(&view_lines, 0, 4), 16);
-	}
-
-	#[test]
-	fn set_view_resize_zero() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		view_data.set_view_size(0, 0);
-		assert_eq!(view_data.height, 0);
-		assert_eq!(view_data.width, 0);
-	}
-
-	#[test]
-	fn set_view_resize_and_top_greater_than_length() {
-		// I don't think this path is triggerable, since a view resize will reset the top position - Tim
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		view_data.set_show_title(false);
-		view_data.scroll_down();
-		view_data.scroll_down();
-		view_data.scroll_down();
-		view_data.scroll_down();
-		view_data.lines_cache = None;
-		view_data.height = 13;
-		view_data.rebuild();
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{Normal}5",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn ensure_line_visible_with_scroll_change() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-		view_data.ensure_line_visible(1);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}b",
-			"{Normal}c",
-			"{Normal}d",
-			"{Normal}1",
-			"{Normal}2",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn ensure_line_visible_without_scroll_change() {
-		let mut view_data = create_mocked_scroll_vertical_view_data();
-		// set scroll position to bottom
-		for _ in 0..5 {
-			view_data.scroll_down();
-		}
-		view_data.ensure_line_visible(4);
-
-		assert_rendered_output!(
-			&mut view_data,
-			"{LEADING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line",
-			"{BODY}",
-			"{Normal}1",
-			"{Normal}2",
-			"{Normal}3",
-			"{Normal}4",
-			"{Normal}5",
-			"{TRAILING}",
-			"{Normal}Mocked Line",
-			"{Normal}Mocked Line"
-		);
-	}
-
-	#[test]
-	fn ensure_column_visible_with_scroll_change() {
+	fn push_trailing_line() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("0123456789"));
-		view_data.set_view_size(5, 1);
-		// set scroll position to right
-		for _ in 0..10 {
-			view_data.scroll_right();
-		}
-
-		view_data.ensure_column_visible(2);
-		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}23456");
+		view_data.push_trailing_line(ViewLine::new_empty_line());
+		assert_eq!(view_data.get_trailing_lines().len(), 1);
 	}
 
 	#[test]
-	fn ensure_column_visible_without_scroll_change() {
+	fn set_retain_scroll_position() {
 		let mut view_data = ViewData::new(|_| {});
-		view_data.push_line(ViewLine::from("0123456789"));
-		view_data.set_view_size(5, 1);
-		// set scroll position to right
-		for _ in 0..10 {
-			view_data.scroll_right();
-		}
-
-		view_data.ensure_column_visible(6);
-		assert_rendered_output!(&mut view_data, "{BODY}", "{Normal}56789");
+		view_data.set_retain_scroll_position(false);
+		assert!(!view_data.retain_scroll_position());
 	}
 
 	#[test]
-	fn get_scroll_index_top_position() {
-		let view_data = create_mocked_scroll_index_data(100, 100, 0);
-		assert_eq!(view_data.get_scroll_index(), 0);
+	fn reset_scroll_position() {
+		let mut view_data = ViewData::new(|_| {});
+		let current_version = view_data.get_scroll_version();
+		view_data.reset_scroll_position();
+		assert_ne!(view_data.get_scroll_version(), current_version);
 	}
 
 	#[test]
-	fn get_scroll_index_empty_lines() {
-		let view_data = ViewData::new(|_| {});
-		assert_eq!(view_data.get_scroll_index(), 0);
-	}
-
-	#[test]
-	fn get_scroll_index_end_position() {
-		let view_data = create_mocked_scroll_index_data(100, 10, 90);
-		assert_eq!(view_data.get_scroll_index(), 9);
-	}
-
-	#[test]
-	fn get_scroll_index_position_one_down() {
-		let view_data = create_mocked_scroll_index_data(100, 10, 1);
-		assert_eq!(view_data.get_scroll_index(), 1);
-	}
-
-	#[test]
-	fn get_scroll_index_position_low_input_range_1() {
-		let view_data = create_mocked_scroll_index_data(10, 8, 1);
-		assert_eq!(view_data.get_scroll_index(), 4);
-	}
-
-	#[test]
-	fn get_scroll_index_item_count_smaller_than_height() {
-		let view_data = create_mocked_scroll_index_data(10, 11, 1);
-		assert_eq!(view_data.get_scroll_index(), 0);
-	}
-
-	#[test]
-	fn get_scroll_index_view_height_too_small() {
-		let view_data = create_mocked_scroll_index_data(10, 2, 5);
-		assert_eq!(view_data.get_scroll_index(), 0);
-	}
-
-	#[test]
-	fn get_scroll_index_position_extreme_lows() {
-		assert_eq!(create_mocked_scroll_index_data(0, 0, 0).get_scroll_index(), 0);
-		assert_eq!(create_mocked_scroll_index_data(2, 1, 1).get_scroll_index(), 0);
-		assert_eq!(create_mocked_scroll_index_data(2, 0, 1).get_scroll_index(), 0);
+	fn get_name() {
+		let view_data_1 = ViewData::new(|_| {});
+		let view_data_2 = ViewData::new(|_| {});
+		assert!(!view_data_1.get_name().is_empty());
+		assert_ne!(view_data_1.get_name(), view_data_2.get_name());
 	}
 }

--- a/src/view/view_data_updater.rs
+++ b/src/view/view_data_updater.rs
@@ -18,11 +18,6 @@ impl<'v> ViewDataUpdater<'v> {
 		self.view_data.clear();
 	}
 
-	pub(crate) fn reset(&mut self) {
-		self.modified = true;
-		self.view_data.reset();
-	}
-
 	pub(crate) fn clear_body(&mut self) {
 		self.modified = true;
 		self.view_data.clear_body();
@@ -63,15 +58,126 @@ impl<'v> ViewDataUpdater<'v> {
 		self.view_data.push_trailing_line(view_line);
 	}
 
-	pub(crate) fn scroll_right(&mut self) {
-		self.view_data.scroll_right();
+	pub(crate) fn set_retain_scroll_position(&mut self, value: bool) {
+		self.modified = true;
+		self.view_data.set_retain_scroll_position(value);
 	}
 
-	pub(crate) fn scroll_left(&mut self) {
-		self.view_data.scroll_left();
+	pub(crate) fn reset_scroll_position(&mut self) {
+		self.modified = true;
+		self.view_data.reset_scroll_position();
 	}
 
 	pub(super) const fn is_modified(&self) -> bool {
 		self.modified
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn clear() {
+		let mut view_data = ViewData::new(|_| {});
+		view_data.push_line(ViewLine::new_empty_line());
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.clear();
+		assert!(updater.is_modified());
+		assert!(view_data.is_empty());
+	}
+
+	#[test]
+	fn clear_body() {
+		let mut view_data = ViewData::new(|_| {});
+		view_data.push_line(ViewLine::new_empty_line());
+		view_data.push_leading_line(ViewLine::new_empty_line());
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.clear_body();
+		assert!(updater.is_modified());
+		assert!(view_data.get_lines().is_empty());
+		assert_eq!(view_data.get_leading_lines().len(), 1);
+	}
+
+	#[test]
+	fn ensure_line_visible() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.ensure_line_visible(10);
+		assert!(updater.is_modified());
+		assert_eq!(view_data.get_visible_row().unwrap(), 10);
+	}
+
+	#[test]
+	fn ensure_column_visible() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.ensure_column_visible(10);
+		assert!(updater.is_modified());
+		assert_eq!(view_data.get_visible_column().unwrap(), 10);
+	}
+
+	#[test]
+	fn set_show_title() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.set_show_title(true);
+		assert!(updater.is_modified());
+		assert!(view_data.show_title());
+	}
+
+	#[test]
+	fn set_show_help() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.set_show_help(true);
+		assert!(updater.is_modified());
+		assert!(view_data.show_help());
+	}
+
+	#[test]
+	fn push_leading_line() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.push_leading_line(ViewLine::new_empty_line());
+		assert!(updater.is_modified());
+		assert_eq!(view_data.get_leading_lines().len(), 1);
+	}
+
+	#[test]
+	fn push_line() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.push_line(ViewLine::new_empty_line());
+		assert!(updater.is_modified());
+		assert_eq!(view_data.get_lines().len(), 1);
+	}
+
+	#[test]
+	fn push_trailing_line() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.push_trailing_line(ViewLine::new_empty_line());
+		assert!(updater.is_modified());
+		assert_eq!(view_data.get_trailing_lines().len(), 1);
+	}
+
+	#[test]
+	fn set_retain_scroll_position() {
+		let mut view_data = ViewData::new(|_| {});
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.set_retain_scroll_position(false);
+		assert!(updater.is_modified());
+		assert!(!view_data.retain_scroll_position());
+	}
+
+	#[test]
+	fn reset_scroll_position() {
+		let mut view_data = ViewData::new(|_| {});
+		let previous_scroll_version = view_data.get_scroll_version();
+		let mut updater = ViewDataUpdater::new(&mut view_data);
+		updater.reset_scroll_position();
+		assert!(updater.is_modified());
+		assert_ne!(view_data.get_scroll_version(), previous_scroll_version);
 	}
 }


### PR DESCRIPTION
# Description

Add to the process tests a function to create an instance of CrossTerm, this way changes to how CrossTerm is initialized require fewer modifications in the future.