### PR TITLE
Fix external command return

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -186,7 +186,7 @@ impl Process {
 			})
 			.map_err(|err| anyhow!(err));
 
-		self.view_sender.stop()?;
+		self.view_sender.start()?;
 
 		result
 	}


### PR DESCRIPTION
# Description

When returning from an external command, the display was not being restarted. This was caused by a bad call to stop, that should have been a start.