### PR TITLE
Remove unneeded type from process module tests

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -52,12 +52,12 @@ mod tests {
 		assert_process_result,
 		assert_rendered_output,
 		input::{Event, KeyCode, MetaEvent},
-		process::testutil::{process_module_test, TestContext},
+		process::testutil::process_module_test,
 	};
 
 	#[test]
 	fn build_view_data() {
-		process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+		process_module_test(&["pick aaa comment"], &[], |test_context| {
 			let mut module = ConfirmAbort::new(
 				&test_context.config.key_bindings.confirm_yes,
 				&test_context.config.key_bindings.confirm_no,
@@ -77,7 +77,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::Yes)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmAbort::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,
@@ -97,7 +97,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::No)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmAbort::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,
@@ -116,7 +116,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(KeyCode::Null)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmAbort::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -47,12 +47,12 @@ mod tests {
 		assert_process_result,
 		assert_rendered_output,
 		input::{Event, KeyCode, MetaEvent},
-		process::testutil::{process_module_test, TestContext},
+		process::testutil::process_module_test,
 	};
 
 	#[test]
 	fn build_view_data() {
-		process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+		process_module_test(&["pick aaa comment"], &[], |test_context| {
 			let mut module = ConfirmRebase::new(
 				&test_context.config.key_bindings.confirm_yes,
 				&test_context.config.key_bindings.confirm_no,
@@ -72,7 +72,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::Yes)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmRebase::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,
@@ -92,7 +92,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::No)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmRebase::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,
@@ -111,7 +111,7 @@ mod tests {
 		process_module_test(
 			&["pick aaa comment"],
 			&[Event::from(KeyCode::Null)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = ConfirmRebase::new(
 					&test_context.config.key_bindings.confirm_yes,
 					&test_context.config.key_bindings.confirm_no,

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -311,7 +311,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn draw_str() {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.draw_str("Test String").unwrap();
 			let output = CrossTerm::get_output();
@@ -322,7 +322,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn clear() {
-		display_module_test(|mut test_context: TestContext<'_>| {
+		display_module_test(|mut test_context| {
 			test_context.crossterm.print("Test String").unwrap();
 			test_context.crossterm.set_dim(true).unwrap();
 			test_context.crossterm.set_reverse(true).unwrap();
@@ -340,7 +340,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn refresh() {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.refresh().unwrap();
 			assert!(!display.tui.is_dirty());
@@ -486,7 +486,7 @@ mod tests {
 		expected_foreground: CrosstermColor,
 		expected_background: CrosstermColor,
 	) {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.color(display_color, selected).unwrap();
 			assert!(display
@@ -510,7 +510,7 @@ mod tests {
 	)]
 	#[serial_test::serial()]
 	fn style(dim: bool, underline: bool, reverse: bool) {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.set_style(dim, underline, reverse).unwrap();
 			assert_eq!(display.tui.is_dimmed(), dim);
@@ -522,7 +522,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn get_window_size() {
-		display_module_test(|mut test_context: TestContext<'_>| {
+		display_module_test(|mut test_context| {
 			test_context.crossterm.set_size(Size::new(12, 10));
 			let display = Display::new(test_context.crossterm, &test_context.config.theme);
 			assert_eq!(display.get_window_size(), Size::new(12, 10));
@@ -532,7 +532,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn ensure_at_line_start() {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.ensure_at_line_start().unwrap();
 			assert_eq!(display.tui.get_position(), (1, 0));
@@ -542,7 +542,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn move_from_end_of_line() {
-		display_module_test(|mut test_context: TestContext<'_>| {
+		display_module_test(|mut test_context| {
 			test_context.crossterm.set_size(Size::new(20, 10));
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.move_from_end_of_line(5).unwrap();
@@ -554,7 +554,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn start() {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.start().unwrap();
 			assert_eq!(display.tui.get_state(), State::Normal);
@@ -564,7 +564,7 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn end() {
-		display_module_test(|test_context: TestContext<'_>| {
+		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);
 			display.end().unwrap();
 			assert_eq!(display.tui.get_state(), State::Ended);

--- a/src/insert/tests.rs
+++ b/src/insert/tests.rs
@@ -3,12 +3,12 @@ use crate::{
 	assert_process_result,
 	assert_rendered_output,
 	input::{Event, KeyCode},
-	process::testutil::{process_module_test, TestContext},
+	process::testutil::process_module_test,
 };
 
 #[test]
 fn activate() {
-	process_module_test(&[], &[], |test_context: TestContext<'_>| {
+	process_module_test(&[], &[], |test_context| {
 		let mut module = Insert::new();
 		assert_process_result!(test_context.activate(&mut module, State::List));
 	});
@@ -16,7 +16,7 @@ fn activate() {
 
 #[test]
 fn render_prompt() {
-	process_module_test(&[], &[], |test_context: TestContext<'_>| {
+	process_module_test(&[], &[], |test_context| {
 		let mut module = Insert::new();
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
@@ -40,7 +40,7 @@ fn render_prompt() {
 
 #[test]
 fn prompt_cancel() {
-	process_module_test(&[], &[Event::from('q')], |mut test_context: TestContext<'_>| {
+	process_module_test(&[], &[Event::from('q')], |mut test_context| {
 		let mut module = Insert::new();
 		assert_process_result!(
 			test_context.handle_event(&mut module),
@@ -61,7 +61,7 @@ fn edit_render_exec() {
 			Event::from('o'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
@@ -98,7 +98,7 @@ fn edit_render_pick() {
 			Event::from('c'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
@@ -138,7 +138,7 @@ fn edit_render_label() {
 			Event::from('o'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
@@ -177,7 +177,7 @@ fn edit_render_reset() {
 			Event::from('o'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
@@ -216,7 +216,7 @@ fn edit_render_merge() {
 			Event::from('o'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
@@ -255,7 +255,7 @@ fn edit_select_next_index() {
 			Event::from('o'),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_all_events(&mut module);
 			assert_eq!(test_context.rebase_todo_file.get_selected_line_index(), 1);
@@ -268,7 +268,7 @@ fn cancel_edit() {
 	process_module_test(
 		&[],
 		&[Event::from('e'), Event::from(KeyCode::Enter)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = Insert::new();
 			test_context.handle_all_events(&mut module);
 			assert!(test_context.rebase_todo_file.is_empty());

--- a/src/list/tests.rs
+++ b/src/list/tests.rs
@@ -4,12 +4,12 @@ use crate::{
 	assert_render_action,
 	assert_rendered_output,
 	input::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind},
-	process::testutil::{process_module_test, TestContext},
+	process::testutil::process_module_test,
 };
 
 #[test]
 fn render_empty_list() {
-	process_module_test(&[], &[], |test_context: TestContext<'_>| {
+	process_module_test(&[], &[], |test_context| {
 		let mut module = List::new(test_context.config);
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
@@ -39,7 +39,7 @@ fn render_full() {
 			"merge command",
 		],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = List::new(test_context.config);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -81,7 +81,7 @@ fn render_compact() {
 			"merge command",
 		],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut module = List::new(test_context.config);
 			let view_data = test_context.build_view_data(&mut module);
@@ -111,7 +111,7 @@ fn move_cursor_down_1() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -132,7 +132,7 @@ fn move_cursor_down_view_end() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 2],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -153,7 +153,7 @@ fn move_cursor_down_past_end() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 3],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -178,7 +178,7 @@ fn move_cursor_down_scroll_bottom_move_up_one() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -203,7 +203,7 @@ fn move_cursor_down_scroll_bottom_move_up_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::MoveCursorUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -227,7 +227,7 @@ fn move_cursor_up_attempt_above_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::MoveCursorUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -249,7 +249,7 @@ fn move_cursor_down_attempt_below_bottom() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorDown); 4],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -271,7 +271,7 @@ fn move_cursor_page_up_from_top() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageUp)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -298,7 +298,7 @@ fn move_cursor_page_up_from_one_page_down() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -325,7 +325,7 @@ fn move_cursor_page_up_from_one_page_down_minus_1() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -353,7 +353,7 @@ fn move_cursor_page_up_from_bottom() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -380,7 +380,7 @@ fn move_cursor_home() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorHome),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -402,7 +402,7 @@ fn move_cursor_end() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorEnd)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -424,7 +424,7 @@ fn move_cursor_page_down_past_bottom() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageDown); 3],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -452,7 +452,7 @@ fn move_cursor_page_down_one_from_bottom() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -477,7 +477,7 @@ fn move_cursor_page_down_one_page_from_bottom() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -519,7 +519,7 @@ fn mouse_scroll() {
 				modifiers: KeyModifiers::empty(),
 			}),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -540,7 +540,7 @@ fn visual_mode_start() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -564,7 +564,7 @@ fn visual_mode_start_cursor_down_one() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -594,7 +594,7 @@ fn visual_mode_start_cursor_page_down() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
@@ -631,7 +631,7 @@ fn visual_mode_start_cursor_from_bottom_move_up() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::MoveCursorUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -670,7 +670,7 @@ fn visual_mode_start_cursor_from_bottom_to_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::MoveCursorUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -693,7 +693,7 @@ fn change_selected_line_to_drop() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -712,7 +712,7 @@ fn change_selected_line_to_edit() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionEdit)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -731,7 +731,7 @@ fn change_selected_line_to_fixup() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionFixup)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -750,7 +750,7 @@ fn change_selected_line_to_pick() {
 	process_module_test(
 		&["drop aaa c1"],
 		&[Event::from(MetaEvent::ActionPick)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -769,7 +769,7 @@ fn change_selected_line_to_reword() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionReword)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -788,7 +788,7 @@ fn change_selected_line_to_squash() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionSquash)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -807,7 +807,7 @@ fn change_selected_line_toggle_break_add() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionBreak)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -830,7 +830,7 @@ fn change_selected_line_toggle_break_remove() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionBreak),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -849,7 +849,7 @@ fn change_selected_line_toggle_break_above_existing() {
 	process_module_test(
 		&["pick aaa c1", "break"],
 		&[Event::from(MetaEvent::ActionBreak)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -869,7 +869,7 @@ fn change_selected_line_auto_select_next_with_next_line() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2"],
 		&[Event::from(MetaEvent::ActionSquash)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut config = test_context.config.clone();
 			config.auto_select_next = true;
 			let mut module = List::new(&config);
@@ -891,7 +891,7 @@ fn change_selected_line_swap_down() {
 	process_module_test(
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::SwapSelectedDown)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -916,7 +916,7 @@ fn change_selected_line_swap_up() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -937,7 +937,7 @@ fn normal_mode_show_commit_when_hash_available() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ShowCommit)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -950,17 +950,13 @@ fn normal_mode_show_commit_when_hash_available() {
 
 #[test]
 fn normal_mode_show_commit_when_no_selected_line() {
-	process_module_test(
-		&[],
-		&[Event::from(MetaEvent::ShowCommit)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(MetaEvent::ShowCommit)
-			);
-		},
-	);
+	process_module_test(&[], &[Event::from(MetaEvent::ShowCommit)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(MetaEvent::ShowCommit)
+		);
+	});
 }
 
 #[test]
@@ -968,7 +964,7 @@ fn normal_mode_do_not_show_commit_when_hash_not_available() {
 	process_module_test(
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::ShowCommit)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -983,7 +979,7 @@ fn normal_mode_abort() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Abort)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -999,7 +995,7 @@ fn normal_mode_force_abort() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceAbort)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1016,7 +1012,7 @@ fn normal_mode_rebase() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Rebase)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1032,7 +1028,7 @@ fn normal_mode_force_rebase() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceRebase)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1049,7 +1045,7 @@ fn normal_mode_edit_with_edit_content() {
 	process_module_test(
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::Edit)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1062,50 +1058,38 @@ fn normal_mode_edit_with_edit_content() {
 
 #[test]
 fn normal_mode_edit_without_edit_content() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Edit)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(MetaEvent::Edit)
-			);
-			assert_eq!(module.state, ListState::Normal);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(MetaEvent::Edit)
+		);
+		assert_eq!(module.state, ListState::Normal);
+	});
 }
 
 #[test]
 fn normal_mode_edit_without_selected_line() {
-	process_module_test(
-		&[],
-		&[Event::from(MetaEvent::Edit)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(MetaEvent::Edit)
-			);
-			assert_eq!(module.state, ListState::Normal);
-		},
-	);
+	process_module_test(&[], &[Event::from(MetaEvent::Edit)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(MetaEvent::Edit)
+		);
+		assert_eq!(module.state, ListState::Normal);
+	});
 }
 
 #[test]
 fn normal_mode_insert_line() {
-	process_module_test(
-		&[],
-		&[Event::from(MetaEvent::InsertLine)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(MetaEvent::InsertLine),
-				state = State::Insert
-			);
-		},
-	);
+	process_module_test(&[], &[Event::from(MetaEvent::InsertLine)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(MetaEvent::InsertLine),
+			state = State::Insert
+		);
+	});
 }
 
 #[test]
@@ -1113,7 +1097,7 @@ fn normal_mode_open_external_editor() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::OpenInEditor)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1129,7 +1113,7 @@ fn normal_mode_undo() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop), Event::from(MetaEvent::Undo)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1158,7 +1142,7 @@ fn normal_mode_undo_visual_mode_change() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::Undo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -1182,7 +1166,7 @@ fn normal_mode_redo() {
 			Event::from(MetaEvent::Undo),
 			Event::from(MetaEvent::Redo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			test_context.handle_event(&mut module);
@@ -1212,7 +1196,7 @@ fn normal_mode_redo_visual_mode_change() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::Redo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -1238,7 +1222,7 @@ fn normal_mode_remove_line_first() {
 			"pick eee c5",
 		],
 		&[Event::from(MetaEvent::Delete)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -1271,7 +1255,7 @@ fn normal_mode_remove_line_end() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::Delete),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -1292,7 +1276,7 @@ fn normal_mode_toggle_visual_mode() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1306,17 +1290,13 @@ fn normal_mode_toggle_visual_mode() {
 
 #[test]
 fn normal_mode_other_event() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(KeyCode::Null)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(KeyCode::Null)
-			);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(KeyCode::Null)
+		);
+	});
 }
 
 #[test]
@@ -1329,7 +1309,7 @@ fn visual_mode_action_change_top_bottom() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionReword),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1357,7 +1337,7 @@ fn visual_mode_action_change_bottom_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::ActionReword),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1390,7 +1370,7 @@ fn visual_mode_action_change_drop() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionDrop),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1425,7 +1405,7 @@ fn visual_mode_action_change_edit() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionEdit),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1460,7 +1440,7 @@ fn visual_mode_action_change_fixup() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionFixup),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1495,7 +1475,7 @@ fn visual_mode_action_change_pick() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionPick),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1530,7 +1510,7 @@ fn visual_mode_action_change_reword() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionReword),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1565,7 +1545,7 @@ fn visual_mode_action_change_squash() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::ActionSquash),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1588,7 +1568,7 @@ fn visual_mode_abort() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Abort)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1608,7 +1588,7 @@ fn visual_mode_force_abort() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::ForceAbort),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1626,7 +1606,7 @@ fn visual_mode_rebase() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Rebase)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1646,7 +1626,7 @@ fn visual_mode_force_rebase() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::ForceRebase),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1676,7 +1656,7 @@ fn visual_mode_swap_down_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1713,7 +1693,7 @@ fn visual_mode_swap_down_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1748,7 +1728,7 @@ fn visual_mode_swap_up_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1785,7 +1765,7 @@ fn visual_mode_swap_up_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1823,7 +1803,7 @@ fn visual_mode_swap_down_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1859,7 +1839,7 @@ fn visual_mode_swap_down_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1895,7 +1875,7 @@ fn visual_mode_swap_up_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1933,7 +1913,7 @@ fn visual_mode_swap_up_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -1959,7 +1939,7 @@ fn visual_mode_toggle_visual_mode() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::ToggleVisualMode),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1980,7 +1960,7 @@ fn visual_mode_open_external_editor() {
 			Event::from(MetaEvent::ToggleVisualMode),
 			Event::from(MetaEvent::OpenInEditor),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -2002,7 +1982,7 @@ fn visual_mode_undo() {
 			Event::from(MetaEvent::ActionDrop),
 			Event::from(MetaEvent::Undo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_n_events(&mut module, 3);
 			assert_process_result!(
@@ -2030,7 +2010,7 @@ fn visual_mode_undo_normal_mode_change() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::Undo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_n_events(&mut module, 3);
 			assert_process_result!(
@@ -2060,7 +2040,7 @@ fn visual_mode_redo() {
 			Event::from(MetaEvent::Undo),
 			Event::from(MetaEvent::Redo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2085,7 +2065,7 @@ fn visual_mode_redo_normal_mode_change() {
 			Event::from(MetaEvent::Undo),
 			Event::from(MetaEvent::Redo),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2116,7 +2096,7 @@ fn visual_mode_remove_lines_start_index_first() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::Delete),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2152,7 +2132,7 @@ fn visual_mode_remove_lines_end_index_first() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::Delete),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2190,7 +2170,7 @@ fn visual_mode_remove_lines_start_index_last() {
 			Event::from(MetaEvent::MoveCursorUp),
 			Event::from(MetaEvent::Delete),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2226,7 +2206,7 @@ fn visual_mode_remove_lines_end_index_last() {
 			Event::from(MetaEvent::MoveCursorDown),
 			Event::from(MetaEvent::Delete),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
@@ -2246,41 +2226,33 @@ fn visual_mode_remove_lines_end_index_last() {
 
 #[test]
 fn visual_mode_other_event() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(KeyCode::Null)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			assert_process_result!(
-				test_context.handle_event(&mut module),
-				event = Event::from(KeyCode::Null)
-			);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		assert_process_result!(
+			test_context.handle_event(&mut module),
+			event = Event::from(KeyCode::Null)
+		);
+	});
 }
 
 #[test]
 fn edit_mode_render() {
-	process_module_test(
-		&["exec foo"],
-		&[Event::from(MetaEvent::Edit)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			test_context.handle_all_events(&mut module);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{IndicatorColor}Modifying line: exec foo",
-				"",
-				"{BODY}",
-				"{Normal,Dimmed}exec {Normal}foo{Normal,Underline} ",
-				"{TRAILING}",
-				"{IndicatorColor}Enter to finish"
-			);
-		},
-	);
+	process_module_test(&["exec foo"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		test_context.handle_all_events(&mut module);
+		let view_data = test_context.build_view_data(&mut module);
+		assert_rendered_output!(
+			view_data,
+			"{TITLE}",
+			"{LEADING}",
+			"{IndicatorColor}Modifying line: exec foo",
+			"",
+			"{BODY}",
+			"{Normal,Dimmed}exec {Normal}foo{Normal,Underline} ",
+			"{TRAILING}",
+			"{IndicatorColor}Enter to finish"
+		);
+	});
 }
 
 #[test]
@@ -2292,7 +2264,7 @@ fn edit_mode_handle_event() {
 			Event::from(KeyCode::Backspace),
 			Event::from(KeyCode::Enter),
 		],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.build_view_data(&mut module);
 			test_context.handle_all_events(&mut module);
@@ -2307,7 +2279,7 @@ fn scroll_right() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorRight)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_render_action!(&test_context.event_handler_context.view_sender, "ScrollRight");
@@ -2320,7 +2292,7 @@ fn scroll_left() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorLeft)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert_render_action!(&test_context.event_handler_context.view_sender, "ScrollLeft");
@@ -2330,55 +2302,51 @@ fn scroll_left() {
 
 #[test]
 fn normal_mode_help() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Help)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			module.state = ListState::Normal;
-			test_context.handle_all_events(&mut module);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-				"{BODY}",
-				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
-				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
-				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
-				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
-				"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
-				"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
-				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
-				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
-				"{IndicatorColor} q       {Normal,Dimmed}|{Normal}Abort interactive rebase",
-				"{IndicatorColor} Q       {Normal,Dimmed}|{Normal}Immediately abort interactive rebase",
-				"{IndicatorColor} w       {Normal,Dimmed}|{Normal}Write interactive rebase file",
-				"{IndicatorColor} W       {Normal,Dimmed}|{Normal}Immediately write interactive rebase file",
-				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual mode",
-				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-				"{IndicatorColor} c       {Normal,Dimmed}|{Normal}Show commit information",
-				"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commit down",
-				"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commit up",
-				"{IndicatorColor} b       {Normal,Dimmed}|{Normal}Toggle break action",
-				"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commit to be picked",
-				"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commit to be reworded",
-				"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commit to be edited",
-				"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commit to be squashed",
-				"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commit to be fixed-up",
-				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commit to be dropped",
-				"{IndicatorColor} E       {Normal,Dimmed}|{Normal}Edit an exec action's command",
-				"{IndicatorColor} I       {Normal,Dimmed}|{Normal}Insert a new line",
-				"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected line",
-				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
-				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
-				"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
-				"{TRAILING}",
-				"{IndicatorColor}Press any key to close"
-			);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		module.state = ListState::Normal;
+		test_context.handle_all_events(&mut module);
+		let view_data = test_context.build_view_data(&mut module);
+		assert_rendered_output!(
+			view_data,
+			"{TITLE}",
+			"{LEADING}",
+			"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+			"{BODY}",
+			"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
+			"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
+			"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
+			"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
+			"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
+			"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
+			"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
+			"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
+			"{IndicatorColor} q       {Normal,Dimmed}|{Normal}Abort interactive rebase",
+			"{IndicatorColor} Q       {Normal,Dimmed}|{Normal}Immediately abort interactive rebase",
+			"{IndicatorColor} w       {Normal,Dimmed}|{Normal}Write interactive rebase file",
+			"{IndicatorColor} W       {Normal,Dimmed}|{Normal}Immediately write interactive rebase file",
+			"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual mode",
+			"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+			"{IndicatorColor} c       {Normal,Dimmed}|{Normal}Show commit information",
+			"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commit down",
+			"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commit up",
+			"{IndicatorColor} b       {Normal,Dimmed}|{Normal}Toggle break action",
+			"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commit to be picked",
+			"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commit to be reworded",
+			"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commit to be edited",
+			"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commit to be squashed",
+			"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commit to be fixed-up",
+			"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commit to be dropped",
+			"{IndicatorColor} E       {Normal,Dimmed}|{Normal}Edit an exec action's command",
+			"{IndicatorColor} I       {Normal,Dimmed}|{Normal}Insert a new line",
+			"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected line",
+			"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
+			"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
+			"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
+			"{TRAILING}",
+			"{IndicatorColor}Press any key to close"
+		);
+	});
 }
 
 #[test]
@@ -2386,7 +2354,7 @@ fn normal_mode_help_event() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::SwapSelectedDown)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.state = ListState::Normal;
 			test_context.handle_all_events(&mut module);
@@ -2397,46 +2365,42 @@ fn normal_mode_help_event() {
 
 #[test]
 fn visual_mode_help() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Help)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			module.state = ListState::Visual;
-			test_context.handle_all_events(&mut module);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-				"{BODY}",
-				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
-				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
-				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
-				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
-				"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
-				"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
-				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
-				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
-				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-				"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commits down",
-				"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commits up",
-				"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commits to be picked",
-				"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commits to be reworded",
-				"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commits to be edited",
-				"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commits to be squashed",
-				"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commits to be fixed-up",
-				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commits to be dropped",
-				"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected lines",
-				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
-				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
-				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual mode",
-				"{TRAILING}",
-				"{IndicatorColor}Press any key to close"
-			);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		module.state = ListState::Visual;
+		test_context.handle_all_events(&mut module);
+		let view_data = test_context.build_view_data(&mut module);
+		assert_rendered_output!(
+			view_data,
+			"{TITLE}",
+			"{LEADING}",
+			"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+			"{BODY}",
+			"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
+			"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
+			"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
+			"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
+			"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
+			"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
+			"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
+			"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
+			"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+			"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commits down",
+			"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commits up",
+			"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commits to be picked",
+			"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commits to be reworded",
+			"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commits to be edited",
+			"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commits to be squashed",
+			"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commits to be fixed-up",
+			"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commits to be dropped",
+			"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected lines",
+			"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
+			"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
+			"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual mode",
+			"{TRAILING}",
+			"{IndicatorColor}Press any key to close"
+		);
+	});
 }
 
 #[test]
@@ -2444,7 +2408,7 @@ fn visual_mode_help_event() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::SwapSelectedDown)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = List::new(test_context.config);
 			module.state = ListState::Visual;
 			test_context.handle_all_events(&mut module);
@@ -2456,7 +2420,7 @@ fn visual_mode_help_event() {
 // this can technically never happen, but it's worth testing, just in case of an invalid state
 #[test]
 fn render_noop_list() {
-	process_module_test(&["break"], &[], |mut test_context: TestContext<'_>| {
+	process_module_test(&["break"], &[], |mut test_context| {
 		let mut module = List::new(test_context.config);
 		test_context.rebase_todo_file.remove_lines(0, 0);
 		test_context.rebase_todo_file.add_line(0, Line::new("noop").unwrap());
@@ -2472,13 +2436,9 @@ fn render_noop_list() {
 
 #[test]
 fn resize() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::Resize(100, 200)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = List::new(test_context.config);
-			test_context.handle_all_events(&mut module);
-			assert_eq!(module.height, 200);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::Resize(100, 200)], |mut test_context| {
+		let mut module = List::new(test_context.config);
+		test_context.handle_all_events(&mut module);
+		assert_eq!(module.height, 200);
+	});
 }

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -81,12 +81,12 @@ mod tests {
 		assert_process_result,
 		assert_rendered_output,
 		input::{Event, MetaEvent},
-		process::testutil::{process_module_test, TestContext},
+		process::testutil::process_module_test,
 	};
 
 	#[test]
 	fn simple_error() {
-		process_module_test(&[], &[], |test_context: TestContext<'_>| {
+		process_module_test(&[], &[], |test_context| {
 			let mut module = Error::new();
 			module.set_error_message(&anyhow!("Test Error"));
 			let view_data = test_context.build_view_data(&mut module);
@@ -103,7 +103,7 @@ mod tests {
 
 	#[test]
 	fn error_with_contest() {
-		process_module_test(&[], &[], |test_context: TestContext<'_>| {
+		process_module_test(&[], &[], |test_context| {
 			let mut module = Error::new();
 			module.set_error_message(&anyhow!("Test Error").context("Context"));
 			let view_data = test_context.build_view_data(&mut module);
@@ -121,7 +121,7 @@ mod tests {
 
 	#[test]
 	fn error_with_newlines() {
-		process_module_test(&[], &[], |test_context: TestContext<'_>| {
+		process_module_test(&[], &[], |test_context| {
 			let mut module = Error::new();
 			module.set_error_message(&anyhow!("Test\nError").context("With\nContext"));
 			let view_data = test_context.build_view_data(&mut module);
@@ -141,7 +141,7 @@ mod tests {
 
 	#[test]
 	fn return_state() {
-		process_module_test(&[], &[Event::from('a')], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[Event::from('a')], |mut test_context| {
 			let mut module = Error::new();
 			test_context.activate(&mut module, State::ConfirmRebase);
 			module.set_error_message(&anyhow!("Test Error"));
@@ -155,7 +155,7 @@ mod tests {
 
 	#[test]
 	fn resize() {
-		process_module_test(&[], &[Event::Resize(100, 100)], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[Event::Resize(100, 100)], |mut test_context| {
 			let mut module = Error::new();
 			test_context.activate(&mut module, State::ConfirmRebase);
 			module.set_error_message(&anyhow!("Test Error"));
@@ -175,7 +175,7 @@ mod tests {
 				Event::from(MetaEvent::ScrollJumpDown),
 				Event::from(MetaEvent::ScrollJumpUp),
 			],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				let mut module = Error::new();
 				test_context.activate(&mut module, State::ConfirmRebase);
 				module.set_error_message(&anyhow!("Test Error"));

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -91,10 +91,7 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
-	use crate::{
-		input::Event,
-		process::testutil::{process_module_test, TestContext},
-	};
+	use crate::{input::Event, process::testutil::process_module_test};
 
 	#[rstest(
 		state,
@@ -112,7 +109,7 @@ mod tests {
 		process_module_test(
 			&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment"],
 			&[Event::Resize(100, 100)],
-			|mut test_context: TestContext<'_>| {
+			|mut test_context| {
 				test_context.set_git_directory_environment();
 				let config = test_context.config.clone();
 				let mut modules = Modules::new(&config);
@@ -131,7 +128,7 @@ mod tests {
 
 	#[test]
 	fn set_error_message() {
-		process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+		process_module_test(&["pick aaa comment"], &[], |test_context| {
 			let mut modules = Modules::new(test_context.config);
 			modules.set_error_message(&anyhow!("Test Error"));
 		});

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 	assert_rendered_output,
 	display::{testutil::CrossTerm, Display, Size},
 	input::InputOptions,
-	process::testutil::{process_module_test, TestContext},
+	process::testutil::process_module_test,
 	todo_file::Line,
 };
 
@@ -19,22 +19,18 @@ fn create_crossterm() -> CrossTerm {
 
 #[test]
 fn window_too_small() {
-	process_module_test(
-		&["pick aaa comment"],
-		&[Event::from(MetaEvent::Exit)],
-		|test_context: TestContext<'_>| {
-			let crossterm = create_crossterm();
-			let display = Display::new(crossterm, &test_context.config.theme);
-			let view = View::new(display, "~", "?");
-			let mut process = Process::new(
-				test_context.rebase_todo_file,
-				test_context.event_handler_context.event_handler,
-				view,
-			);
-			let modules = Modules::new(test_context.config);
-			assert_eq!(process.run(modules).unwrap(), ExitStatus::Abort);
-		},
-	);
+	process_module_test(&["pick aaa comment"], &[Event::from(MetaEvent::Exit)], |test_context| {
+		let crossterm = create_crossterm();
+		let display = Display::new(crossterm, &test_context.config.theme);
+		let view = View::new(display, "~", "?");
+		let mut process = Process::new(
+			test_context.rebase_todo_file,
+			test_context.event_handler_context.event_handler,
+			view,
+		);
+		let modules = Modules::new(test_context.config);
+		assert_eq!(process.run(modules).unwrap(), ExitStatus::Abort);
+	});
 }
 
 #[test]
@@ -42,7 +38,7 @@ fn force_abort() {
 	process_module_test(
 		&["pick aaa comment"],
 		&[Event::from(MetaEvent::ForceAbort)],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let crossterm = create_crossterm();
 			let display = Display::new(crossterm, &test_context.config.theme);
 			let view = View::new(display, "~", "?");
@@ -65,7 +61,7 @@ fn force_rebase() {
 	process_module_test(
 		&["pick aaa comment"],
 		&[Event::from(MetaEvent::ForceRebase)],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let crossterm = create_crossterm();
 			let display = Display::new(crossterm, &test_context.config.theme);
 			let view = View::new(display, "~", "?");
@@ -91,7 +87,7 @@ fn error_write_todo() {
 	process_module_test(
 		&["pick aaa comment"],
 		&[Event::from(MetaEvent::ForceRebase)],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let crossterm = create_crossterm();
 			let display = Display::new(crossterm, &test_context.config.theme);
 			let view = View::new(display, "~", "?");
@@ -116,7 +112,7 @@ fn resize_window_size_okay() {
 	process_module_test(
 		&["pick aaa comment"],
 		&[Event::Resize(100, 100), Event::from(MetaEvent::Exit)],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let crossterm = create_crossterm();
 			let display = Display::new(crossterm, &test_context.config.theme);
 			let view = View::new(display, "~", "?");
@@ -133,7 +129,7 @@ fn resize_window_size_okay() {
 
 #[test]
 fn resize_window_size_too_small() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -151,7 +147,7 @@ fn resize_window_size_too_small() {
 
 #[test]
 fn error() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -168,7 +164,7 @@ fn error() {
 
 #[test]
 fn handle_exit_event() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -186,7 +182,7 @@ fn handle_exit_event() {
 
 #[test]
 fn handle_kill_event() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -204,7 +200,7 @@ fn handle_kill_event() {
 
 #[test]
 fn other_event() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -221,7 +217,7 @@ fn other_event() {
 
 #[test]
 fn handle_external_command_not_executable() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -261,7 +257,7 @@ fn handle_external_command_not_executable() {
 
 #[test]
 fn handle_external_command_executable_not_found() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -301,7 +297,7 @@ fn handle_external_command_executable_not_found() {
 
 #[test]
 fn handle_external_command_status_success() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");
@@ -323,7 +319,7 @@ fn handle_external_command_status_success() {
 
 #[test]
 fn handle_external_command_status_error() {
-	process_module_test(&["pick aaa comment"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
 		let display = Display::new(crossterm, &test_context.config.theme);
 		let view = View::new(display, "~", "?");

--- a/src/process/window_size_error.rs
+++ b/src/process/window_size_error.rs
@@ -81,11 +81,7 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
-	use crate::{
-		assert_process_result,
-		assert_rendered_output,
-		process::testutil::{process_module_test, TestContext},
-	};
+	use crate::{assert_process_result, assert_rendered_output, process::testutil::process_module_test};
 
 	const MINIMUM_WINDOW_HEIGHT: usize = 5;
 	const MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH: usize = 45;
@@ -103,7 +99,7 @@ mod tests {
 	)]
 	#[allow(clippy::cast_possible_wrap)]
 	fn build_view_data(width: usize, height: usize, expected: &str) {
-		process_module_test(&[], &[], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[], |mut test_context| {
 			test_context.render_context.update(width as u16, height as u16);
 			let mut module = WindowSizeError::new();
 			let view_data = test_context.build_view_data(&mut module);
@@ -113,7 +109,7 @@ mod tests {
 
 	#[test]
 	fn event_resize_window_still_small() {
-		process_module_test(&[], &[Event::Resize(1, 1)], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[Event::Resize(1, 1)], |mut test_context| {
 			let mut module = WindowSizeError::new();
 			test_context.activate(&mut module, State::ConfirmRebase);
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::Resize(1, 1));
@@ -122,7 +118,7 @@ mod tests {
 
 	#[test]
 	fn event_resize_window_no_longer_too_small() {
-		process_module_test(&[], &[Event::Resize(100, 100)], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[Event::Resize(100, 100)], |mut test_context| {
 			let mut module = WindowSizeError::new();
 			test_context.activate(&mut module, State::ConfirmRebase);
 			assert_process_result!(
@@ -135,7 +131,7 @@ mod tests {
 
 	#[test]
 	fn event_other_character() {
-		process_module_test(&[], &[Event::from('a')], |mut test_context: TestContext<'_>| {
+		process_module_test(&[], &[Event::from('a')], |mut test_context| {
 			let mut module = WindowSizeError::new();
 			test_context.activate(&mut module, State::ConfirmRebase);
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('a'));

--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::{
 	assert_process_result,
 	assert_rendered_output,
-	process::testutil::{process_module_test, TestContext},
+	process::testutil::process_module_test,
 	show_commit::{delta::Delta, diff_line::DiffLine, file_stat::FileStat, origin::Origin, status::Status, user::User},
 	view::ViewLine,
 };
@@ -30,7 +30,7 @@ fn load_commit_during_activate() {
 	process_module_test(
 		&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			assert_process_result!(test_context.activate(&mut module, State::List));
 			assert!(module.commit.is_some());
@@ -43,7 +43,7 @@ fn cached_commit_in_activate() {
 	process_module_test(
 		&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			assert_process_result!(test_context.activate(&mut module, State::List));
 			assert_process_result!(test_context.activate(&mut module, State::List));
@@ -53,7 +53,7 @@ fn cached_commit_in_activate() {
 
 #[test]
 fn no_selected_line_in_activate() {
-	process_module_test(&[], &[], |test_context: TestContext<'_>| {
+	process_module_test(&[], &[], |test_context| {
 		let mut module = ShowCommit::new(test_context.config);
 		assert_process_result!(
 			test_context.activate(&mut module, State::List),
@@ -65,7 +65,7 @@ fn no_selected_line_in_activate() {
 
 #[test]
 fn activate_error() {
-	process_module_test(&["pick aaaaaaaaaa comment1"], &[], |test_context: TestContext<'_>| {
+	process_module_test(&["pick aaaaaaaaaa comment1"], &[], |test_context| {
 		let mut module = ShowCommit::new(test_context.config);
 		assert_process_result!(
 			test_context.activate(&mut module, State::List),
@@ -83,7 +83,7 @@ fn render_overview_minimal_commit() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -108,7 +108,7 @@ fn render_overview_minimal_commit_compact() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut module = ShowCommit::new(test_context.config);
 			let commit = create_minimal_commit();
@@ -133,7 +133,7 @@ fn render_overview_with_author() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -160,7 +160,7 @@ fn render_overview_with_author_compact() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
@@ -187,7 +187,7 @@ fn render_overview_with_committer() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -214,7 +214,7 @@ fn render_overview_with_committer_compact() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
@@ -241,7 +241,7 @@ fn render_overview_with_commit_body() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -270,7 +270,7 @@ fn render_overview_with_file_stats() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -311,7 +311,7 @@ fn render_overview_with_file_stats_compact() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
@@ -352,7 +352,7 @@ fn render_overview_single_file_changed() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -378,7 +378,7 @@ fn render_overview_more_than_one_file_changed() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -404,7 +404,7 @@ fn render_overview_single_insertion() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -430,7 +430,7 @@ fn render_overview_more_than_one_insertion() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -456,7 +456,7 @@ fn render_overview_single_deletion() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -482,7 +482,7 @@ fn render_overview_more_than_one_deletion() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
@@ -508,7 +508,7 @@ fn render_diff_minimal_commit() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
@@ -533,7 +533,7 @@ fn render_diff_minimal_commit_compact() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			test_context.render_context.update(30, 300);
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
@@ -558,7 +558,7 @@ fn render_diff_basic_file_stats() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
@@ -606,7 +606,7 @@ fn render_diff_end_new_line_missing() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			let mut commit = create_minimal_commit();
 			let mut file_stat = FileStat::new("file.txt", "file.txt", Status::Modified);
@@ -642,7 +642,7 @@ fn render_diff_add_line() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
@@ -678,7 +678,7 @@ fn render_diff_delete_line() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
@@ -714,7 +714,7 @@ fn render_diff_context_add_remove_lines() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
@@ -756,7 +756,7 @@ fn render_diff_add_line_with_show_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
@@ -792,7 +792,7 @@ fn render_diff_delete_line_with_show_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
@@ -828,7 +828,7 @@ fn render_diff_context_add_remove_lines_with_show_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
@@ -893,7 +893,7 @@ fn render_diff_show_both_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			config.diff_tab_symbol = String::from("#");
@@ -939,7 +939,7 @@ fn render_diff_show_leading_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Leading;
 			config.diff_tab_symbol = String::from("#");
@@ -985,7 +985,7 @@ fn render_diff_show_no_whitespace() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			config.diff_tab_symbol = String::from("#");
@@ -1028,7 +1028,7 @@ fn render_diff_show_whitespace_all_spaces() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
-		|test_context: TestContext<'_>| {
+		|test_context| {
 			let mut config = test_context.config.clone();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			config.diff_tab_symbol = String::from("#");
@@ -1067,7 +1067,7 @@ fn handle_event_toggle_diff_to_overview() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from(MetaEvent::ShowDiff)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			module
 				.diff_view_data
@@ -1088,7 +1088,7 @@ fn handle_event_toggle_overview_to_diff() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from(MetaEvent::ShowDiff)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			module
 				.overview_view_data
@@ -1109,7 +1109,7 @@ fn handle_event_resize() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::Resize(100, 100)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::Resize(100, 100));
 		},
@@ -1118,32 +1118,28 @@ fn handle_event_resize() {
 
 #[test]
 fn render_help() {
-	process_module_test(
-		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Help)],
-		|mut test_context: TestContext<'_>| {
-			let mut module = ShowCommit::new(test_context.config);
-			test_context.handle_all_events(&mut module);
-			let view_data = test_context.build_view_data(&mut module);
-			assert_rendered_output!(
-				view_data,
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-				"{BODY}",
-				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Scroll up",
-				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Scroll down",
-				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Scroll up half a page",
-				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Scroll down half a page",
-				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll right",
-				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll left",
-				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Show full diff",
-				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-				"{TRAILING}",
-				"{IndicatorColor}Press any key to close"
-			);
-		},
-	);
+	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
+		let mut module = ShowCommit::new(test_context.config);
+		test_context.handle_all_events(&mut module);
+		let view_data = test_context.build_view_data(&mut module);
+		assert_rendered_output!(
+			view_data,
+			"{TITLE}",
+			"{LEADING}",
+			"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+			"{BODY}",
+			"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Scroll up",
+			"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Scroll down",
+			"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Scroll up half a page",
+			"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Scroll down half a page",
+			"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll right",
+			"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll left",
+			"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Show full diff",
+			"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+			"{TRAILING}",
+			"{IndicatorColor}Press any key to close"
+		);
+	});
 }
 
 #[test]
@@ -1151,7 +1147,7 @@ fn handle_help_event() {
 	process_module_test(
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::ShowDiff)],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			test_context.handle_all_events(&mut module);
 			assert!(!module.help.is_active());
@@ -1164,7 +1160,7 @@ fn handle_event_other_key_from_diff() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from('a')],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			module.state = ShowCommitState::Diff;
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('a'));
@@ -1178,7 +1174,7 @@ fn handle_event_other_key_from_overview() {
 	process_module_test(
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from('a')],
-		|mut test_context: TestContext<'_>| {
+		|mut test_context| {
 			let mut module = ShowCommit::new(test_context.config);
 			module.state = ShowCommitState::Overview;
 			assert_process_result!(
@@ -1200,7 +1196,7 @@ fn handle_event_other_key_from_overview() {
 	case::scroll_jump_up(MetaEvent::ScrollJumpUp)
 )]
 fn scroll_events(event: MetaEvent) {
-	process_module_test(&[], &[Event::from(event)], |mut test_context: TestContext<'_>| {
+	process_module_test(&[], &[Event::from(event)], |mut test_context| {
 		let mut module = ShowCommit::new(test_context.config);
 		assert_process_result!(test_context.handle_event(&mut module), event = Event::from(event));
 	});


### PR DESCRIPTION
# Description

The process TestContext type was not needed on the closures, so this removes it.