### PR TITLE
Remove serial test that are not needed

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -479,7 +479,6 @@ mod tests {
 			CrosstermColor::AnsiValue(237)
 		)
 	)]
-	#[serial_test::serial()]
 	fn color(
 		display_color: DisplayColor,
 		selected: bool,
@@ -508,7 +507,7 @@ mod tests {
 		case::dim_underline(true, true, false),
 		case::all_on(true, true, true)
 	)]
-	#[serial_test::serial()]
+	#[serial_test::serial]
 	fn style(dim: bool, underline: bool, reverse: bool) {
 		display_module_test(|test_context| {
 			let mut display = Display::new(test_context.crossterm, &test_context.config.theme);

--- a/src/insert/tests.rs
+++ b/src/insert/tests.rs
@@ -87,7 +87,6 @@ fn edit_render_exec() {
 }
 
 #[test]
-#[serial_test::serial]
 fn edit_render_pick() {
 	process_module_test(
 		&[],
@@ -127,7 +126,6 @@ fn edit_render_pick() {
 }
 
 #[test]
-#[serial_test::serial]
 fn edit_render_label() {
 	process_module_test(
 		&[],


### PR DESCRIPTION
Some tests no longer need serial test, so remove them.