### PR TITLE
Remove config reference from modules

### DIFF
--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -27,8 +27,8 @@ enum ListState {
 	Edit,
 }
 
-pub struct List<'l> {
-	config: &'l Config,
+pub struct List {
+	auto_select_next: bool,
 	edit: Edit,
 	height: usize,
 	normal_mode_help: Help,
@@ -38,7 +38,7 @@ pub struct List<'l> {
 	visual_mode_help: Help,
 }
 
-impl<'l> ProcessModule for List<'l> {
+impl ProcessModule for List {
 	fn build_view_data(&mut self, context: &RenderContext, todo_file: &TodoFile) -> &ViewData {
 		match self.state {
 			ListState::Normal => self.get_normal_mode_view_data(todo_file, context),
@@ -61,15 +61,15 @@ impl<'l> ProcessModule for List<'l> {
 	}
 }
 
-impl<'l> List<'l> {
-	pub(crate) fn new(config: &'l Config) -> Self {
+impl List {
+	pub(crate) fn new(config: &Config) -> Self {
 		let view_data = ViewData::new(|updater| {
 			updater.set_show_title(true);
 			updater.set_show_help(true);
 		});
 
 		Self {
-			config,
+			auto_select_next: config.auto_select_next,
 			edit: Edit::new(),
 			height: 0,
 			normal_mode_help: Help::new_from_keybindings(&get_list_normal_mode_help_lines(&config.key_bindings)),
@@ -102,7 +102,7 @@ impl<'l> List<'l> {
 		let end_index = self.visual_index_start.unwrap_or(start_index);
 
 		rebase_todo.update_range(start_index, end_index, &EditContext::new().action(action));
-		if self.state == ListState::Normal && self.config.auto_select_next {
+		if self.state == ListState::Normal && self.auto_select_next {
 			Self::move_cursor_down(rebase_todo, 1);
 		}
 	}

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -62,7 +62,7 @@ impl Process {
 		}
 	}
 
-	pub(crate) fn run(&mut self, mut modules: Modules<'_>) -> Result<ExitStatus> {
+	pub(crate) fn run(&mut self, mut modules: Modules) -> Result<ExitStatus> {
 		if self.view_sender.start().is_err() {
 			self.exit_status = Some(ExitStatus::StateError);
 			return Ok(ExitStatus::StateError);
@@ -124,7 +124,7 @@ impl Process {
 		Ok(self.exit_status.unwrap_or(ExitStatus::Good))
 	}
 
-	fn handle_process_result(&mut self, modules: &mut Modules<'_>, result: &ProcessResult) {
+	fn handle_process_result(&mut self, modules: &mut Modules, result: &ProcessResult) {
 		let previous_state = self.state;
 
 		// render context and view_sender need a size update early
@@ -206,7 +206,7 @@ impl Process {
 		result
 	}
 
-	fn activate(&mut self, modules: &mut Modules<'_>, previous_state: State) {
+	fn activate(&mut self, modules: &mut Modules, previous_state: State) {
 		let result = modules.activate(self.state, &self.rebase_todo, previous_state);
 		// always trigger a resize on activate, for modules that track size
 		self.event_handler.push_event(Event::Resize(

--- a/src/process/modules.rs
+++ b/src/process/modules.rs
@@ -12,20 +12,20 @@ use crate::{
 	view::{RenderContext, ViewData, ViewSender},
 };
 
-pub struct Modules<'m> {
+pub struct Modules {
 	pub confirm_abort: ConfirmAbort,
 	pub confirm_rebase: ConfirmRebase,
 	pub error: Error,
 	pub external_editor: ExternalEditor,
 	pub insert: Insert,
-	pub list: List<'m>,
-	pub show_commit: ShowCommit<'m>,
+	pub list: List,
+	pub show_commit: ShowCommit,
 	pub window_size_error: WindowSizeError,
 }
 
-impl<'m> Modules<'m> {
-	pub fn new(config: &'m Config) -> Self {
-		Modules {
+impl Modules {
+	pub fn new(config: &Config) -> Self {
+		Self {
 			confirm_abort: ConfirmAbort::new(&config.key_bindings.confirm_yes, &config.key_bindings.confirm_no),
 			confirm_rebase: ConfirmRebase::new(&config.key_bindings.confirm_yes, &config.key_bindings.confirm_no),
 			error: Error::new(),

--- a/src/show_commit/commit.rs
+++ b/src/show_commit/commit.rs
@@ -38,7 +38,7 @@ pub struct Commit {
 	pub(super) deletions: usize,
 }
 
-fn load_commit_state(hash: &str, config: LoadCommitDiffOptions) -> Result<Commit, Error> {
+fn load_commit_state(hash: &str, config: &LoadCommitDiffOptions) -> Result<Commit, Error> {
 	let repo = Repository::open_from_env()?;
 	let commit = repo.find_commit(repo.revparse_single(hash)?.id())?;
 
@@ -182,7 +182,7 @@ fn load_commit_state(hash: &str, config: LoadCommitDiffOptions) -> Result<Commit
 
 impl Commit {
 	/// Load commit information from a commit hash.
-	pub(super) fn new_from_hash(hash: &str, config: LoadCommitDiffOptions) -> Result<Self> {
+	pub(super) fn new_from_hash(hash: &str, config: &LoadCommitDiffOptions) -> Result<Self> {
 		load_commit_state(hash, config).map_err(|err| anyhow!(err).context(anyhow!("Error loading commit: {}", hash)))
 	}
 
@@ -246,7 +246,7 @@ mod tests {
 	}
 
 	fn load_commit_from_hash(hash: &str) -> Result<Commit> {
-		Commit::new_from_hash(hash, LoadCommitDiffOptions {
+		Commit::new_from_hash(hash, &LoadCommitDiffOptions {
 			context_lines: 3,
 			copies: true,
 			ignore_whitespace: false,


### PR DESCRIPTION
# Description

This removes the config references from the list and show_commit modules. This allows the config reference, and the related lifetime to be removed from the process modules system.