### PR TITLE
Add timeout to GitHub actions

### DIFF
--- a/.github/workflows/master-coverage.yml
+++ b/.github/workflows/master-coverage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   coverage:
     runs-on: [ubuntu-latest]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   linux:
     runs-on: [ubuntu-latest]
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -20,6 +21,7 @@ jobs:
 
   lint:
     runs-on: [ubuntu-latest]
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -31,6 +33,7 @@ jobs:
 
   coverage:
     runs-on: [ubuntu-latest]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -45,6 +48,7 @@ jobs:
   macos:
     name: MacOS
     runs-on: [macos-latest]
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - name: Update Rust
@@ -59,6 +63,7 @@ jobs:
   windows:
     name: Windows Test
     runs-on: [windows-latest]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Update Rust

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -8,6 +8,7 @@ jobs:
   ubuntu:
     name: Ubuntu
     runs-on: [ubuntu-latest]
+    timeout-minutes: 10
     env:
         TARGET_RELEASE_ID: 18843342
         GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -38,6 +39,7 @@ jobs:
   macos:
     name: MacOS
     runs-on: [macos-latest]
+    timeout-minutes: 5
     env:
         TARGET_RELEASE_ID: 18843342
         GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
             matrix:
                 version: ['14.04', '16.04']
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         container:
             image: 'docker://ubuntu:${{ matrix.version }}'
         steps:
@@ -48,6 +49,7 @@ jobs:
             matrix:
                 version: ['18.04', '20.04', '20.10']
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         container:
             image: 'docker://ubuntu:${{ matrix.version }}'
         steps:
@@ -87,6 +89,7 @@ jobs:
             matrix:
                 version: ['8']
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         container:
             image: 'docker://debian:${{ matrix.version }}-slim'
         steps:
@@ -125,6 +128,7 @@ jobs:
             matrix:
                 version: ['9', '10', 'bullseye', 'sid']
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         container:
             image: 'docker://debian:${{ matrix.version }}-slim'
         steps:
@@ -160,6 +164,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build-macos:
         runs-on: [macos-latest]
+        timeout-minutes: 5
         steps:
             - name: "Checkout project"
               uses: actions/checkout@v2
@@ -176,6 +181,7 @@ jobs:
 
     build-windows:
         runs-on: [windows-latest]
+        timeout-minutes: 10
         steps:
             - name: "Checkout project"
               uses: actions/checkout@v2


### PR DESCRIPTION
# Description

GitHub actions have been having network connection issues, particularly on macOS, that result in actions running for hours. This adds timeout limits to the various jobs, to avoid this issue.