### PR TITLE
Add coverage ignore attributes

### DIFF
--- a/scripts/coverage.bash
+++ b/scripts/coverage.bash
@@ -5,5 +5,5 @@ set -u
 set -o pipefail
 
 rustup update nightly
-cargo +nightly install --version 0.16.0 cargo-tarpaulin
-cargo +nightly tarpaulin --exclude-files=src/display/crossterm.rs --workspace --all-features --ignore-tests --line --verbose --out Html --out Lcov --output-dir coverage "$@"
+cargo +nightly install cargo-tarpaulin
+cargo +nightly tarpaulin --workspace --all-features --ignore-tests --line --verbose --out Html --out Lcov --output-dir coverage "$@"

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -5,4 +5,4 @@ set -u
 set -o pipefail
 
 rustup update stable
-cargo test --workspace
+cargo +stable test --workspace

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -91,6 +91,7 @@ mod diff_ignore_whitespace_setting;
 mod diff_show_whitespace_setting;
 mod git_config;
 mod key_bindings;
+#[cfg(not(tarpaulin_include))]
 pub mod testutil;
 mod theme;
 mod utils;

--- a/src/display/src/lib.rs
+++ b/src/display/src/lib.rs
@@ -105,9 +105,11 @@
 //! performance should only be used in test code.
 
 mod color_mode;
+#[cfg(not(tarpaulin_include))]
 mod crossterm;
 mod display_color;
 mod size;
+#[cfg(not(tarpaulin_include))]
 pub mod testutil;
 mod tui;
 mod utils;

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -86,6 +86,7 @@ mod event_handler;
 mod input_options;
 mod key_bindings;
 mod meta_event;
+#[cfg(not(tarpaulin_include))]
 pub mod testutil;
 
 pub use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ use std::env::args_os;
 
 // TODO use the termination trait once rust-lang/rust#43301 is stable
 #[allow(clippy::exit, clippy::print_stderr)]
+#[cfg(not(tarpaulin_include))]
 fn main() {
 	let exit = core::run(args_os().skip(1).collect());
 	if let Some(message) = exit.get_message().as_ref() {

--- a/src/view/src/lib.rs
+++ b/src/view/src/lib.rs
@@ -97,6 +97,7 @@ mod render_context;
 mod render_slice;
 mod scroll_position;
 mod sender;
+#[cfg(not(tarpaulin_include))]
 pub mod testutil;
 mod thread;
 mod util;


### PR DESCRIPTION
# Description

Ignore some code from coverage reports that cannot or should not be included.