### PR TITLE
Remove config references and remove config from the process_module_test function

### DIFF
--- a/src/confirm_abort/mod.rs
+++ b/src/confirm_abort/mod.rs
@@ -54,13 +54,14 @@ mod tests {
 	use super::*;
 	use crate::{assert_process_result, process::testutil::process_module_test};
 
+	fn create_confirm_abort() -> ConfirmAbort {
+		ConfirmAbort::new(&[String::from("y")], &[String::from("n")])
+	}
+
 	#[test]
 	fn build_view_data() {
 		process_module_test(&["pick aaa comment"], &[], |test_context| {
-			let mut module = ConfirmAbort::new(
-				&test_context.config.key_bindings.confirm_yes,
-				&test_context.config.key_bindings.confirm_no,
-			);
+			let mut module = create_confirm_abort();
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -77,10 +78,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::Yes)],
 			|mut test_context| {
-				let mut module = ConfirmAbort::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_abort();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(MetaEvent::Yes),
@@ -97,10 +95,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::No)],
 			|mut test_context| {
-				let mut module = ConfirmAbort::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_abort();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(MetaEvent::No),
@@ -116,10 +111,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(KeyCode::Null)],
 			|mut test_context| {
-				let mut module = ConfirmAbort::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_abort();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(KeyCode::Null)

--- a/src/confirm_rebase/mod.rs
+++ b/src/confirm_rebase/mod.rs
@@ -42,20 +42,20 @@ impl ConfirmRebase {
 
 #[cfg(test)]
 mod tests {
-
 	use input::{Event, KeyCode, MetaEvent};
 	use view::assert_rendered_output;
 
 	use super::*;
 	use crate::{assert_process_result, process::testutil::process_module_test};
 
+	fn create_confirm_rebase() -> ConfirmRebase {
+		ConfirmRebase::new(&[String::from("y")], &[String::from("n")])
+	}
+
 	#[test]
 	fn build_view_data() {
 		process_module_test(&["pick aaa comment"], &[], |test_context| {
-			let mut module = ConfirmRebase::new(
-				&test_context.config.key_bindings.confirm_yes,
-				&test_context.config.key_bindings.confirm_no,
-			);
+			let mut module = create_confirm_rebase();
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -72,10 +72,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::Yes)],
 			|mut test_context| {
-				let mut module = ConfirmRebase::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_rebase();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(MetaEvent::Yes),
@@ -92,10 +89,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::No)],
 			|mut test_context| {
-				let mut module = ConfirmRebase::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_rebase();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(MetaEvent::No),
@@ -111,10 +105,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(KeyCode::Null)],
 			|mut test_context| {
-				let mut module = ConfirmRebase::new(
-					&test_context.config.key_bindings.confirm_yes,
-					&test_context.config.key_bindings.confirm_no,
-				);
+				let mut module = create_confirm_rebase();
 				assert_process_result!(
 					test_context.handle_event(&mut module),
 					event = Event::from(KeyCode::Null)

--- a/src/list/tests.rs
+++ b/src/list/tests.rs
@@ -1,4 +1,5 @@
 use ::input::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind};
+use config::testutil::create_config;
 use view::assert_rendered_output;
 
 use super::*;
@@ -7,7 +8,7 @@ use crate::{assert_process_result, process::testutil::process_module_test};
 #[test]
 fn render_empty_list() {
 	process_module_test(&[], &[], |test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
 			view_data,
@@ -37,7 +38,7 @@ fn render_full() {
 		],
 		&[],
 		|test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -80,7 +81,7 @@ fn render_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -109,7 +110,7 @@ fn move_cursor_down_1() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -130,7 +131,7 @@ fn move_cursor_down_view_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 2],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -151,7 +152,7 @@ fn move_cursor_down_past_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 3],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -176,7 +177,7 @@ fn move_cursor_down_scroll_bottom_move_up_one() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -201,7 +202,7 @@ fn move_cursor_down_scroll_bottom_move_up_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -225,7 +226,7 @@ fn move_cursor_up_attempt_above_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -247,7 +248,7 @@ fn move_cursor_down_attempt_below_bottom() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorDown); 4],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -269,7 +270,7 @@ fn move_cursor_page_up_from_top() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageUp)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -296,7 +297,7 @@ fn move_cursor_page_up_from_one_page_down() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -323,7 +324,7 @@ fn move_cursor_page_up_from_one_page_down_minus_1() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -351,7 +352,7 @@ fn move_cursor_page_up_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -378,7 +379,7 @@ fn move_cursor_home() {
 			Event::from(MetaEvent::MoveCursorHome),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -400,7 +401,7 @@ fn move_cursor_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorEnd)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -422,7 +423,7 @@ fn move_cursor_page_down_past_bottom() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageDown); 3],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -450,7 +451,7 @@ fn move_cursor_page_down_one_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -475,7 +476,7 @@ fn move_cursor_page_down_one_page_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -517,7 +518,7 @@ fn mouse_scroll() {
 			}),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -538,7 +539,7 @@ fn visual_mode_start() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -562,7 +563,7 @@ fn visual_mode_start_cursor_down_one() {
 			Event::from(MetaEvent::MoveCursorDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -592,7 +593,7 @@ fn visual_mode_start_cursor_page_down() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.height = 4;
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -629,7 +630,7 @@ fn visual_mode_start_cursor_from_bottom_move_up() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -668,7 +669,7 @@ fn visual_mode_start_cursor_from_bottom_to_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -691,7 +692,7 @@ fn change_selected_line_to_drop() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -710,7 +711,7 @@ fn change_selected_line_to_edit() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionEdit)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -729,7 +730,7 @@ fn change_selected_line_to_fixup() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionFixup)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -748,7 +749,7 @@ fn change_selected_line_to_pick() {
 		&["drop aaa c1"],
 		&[Event::from(MetaEvent::ActionPick)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -767,7 +768,7 @@ fn change_selected_line_to_reword() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionReword)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -786,7 +787,7 @@ fn change_selected_line_to_squash() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionSquash)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -805,7 +806,7 @@ fn change_selected_line_toggle_break_add() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionBreak)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -828,7 +829,7 @@ fn change_selected_line_toggle_break_remove() {
 			Event::from(MetaEvent::ActionBreak),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -847,7 +848,7 @@ fn change_selected_line_toggle_break_above_existing() {
 		&["pick aaa c1", "break"],
 		&[Event::from(MetaEvent::ActionBreak)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -867,7 +868,7 @@ fn change_selected_line_auto_select_next_with_next_line() {
 		&["pick aaa c1", "pick aaa c2"],
 		&[Event::from(MetaEvent::ActionSquash)],
 		|mut test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.auto_select_next = true;
 			let mut module = List::new(&config);
 			test_context.handle_all_events(&mut module);
@@ -889,7 +890,7 @@ fn change_selected_line_swap_down() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::SwapSelectedDown)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -914,7 +915,7 @@ fn change_selected_line_swap_up() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -935,7 +936,7 @@ fn normal_mode_show_commit_when_hash_available() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ShowCommit)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ShowCommit),
@@ -948,7 +949,7 @@ fn normal_mode_show_commit_when_hash_available() {
 #[test]
 fn normal_mode_show_commit_when_no_selected_line() {
 	process_module_test(&[], &[Event::from(MetaEvent::ShowCommit)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(MetaEvent::ShowCommit)
@@ -962,7 +963,7 @@ fn normal_mode_do_not_show_commit_when_hash_not_available() {
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::ShowCommit)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ShowCommit)
@@ -977,7 +978,7 @@ fn normal_mode_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Abort)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::Abort),
@@ -993,7 +994,7 @@ fn normal_mode_force_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceAbort)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ForceAbort),
@@ -1010,7 +1011,7 @@ fn normal_mode_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Rebase)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::Rebase),
@@ -1026,7 +1027,7 @@ fn normal_mode_force_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceRebase)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ForceRebase),
@@ -1043,7 +1044,7 @@ fn normal_mode_edit_with_edit_content() {
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::Edit)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::Edit)
@@ -1056,7 +1057,7 @@ fn normal_mode_edit_with_edit_content() {
 #[test]
 fn normal_mode_edit_without_edit_content() {
 	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(MetaEvent::Edit)
@@ -1068,7 +1069,7 @@ fn normal_mode_edit_without_edit_content() {
 #[test]
 fn normal_mode_edit_without_selected_line() {
 	process_module_test(&[], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(MetaEvent::Edit)
@@ -1080,7 +1081,7 @@ fn normal_mode_edit_without_selected_line() {
 #[test]
 fn normal_mode_insert_line() {
 	process_module_test(&[], &[Event::from(MetaEvent::InsertLine)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(MetaEvent::InsertLine),
@@ -1095,7 +1096,7 @@ fn normal_mode_open_external_editor() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::OpenInEditor)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::OpenInEditor),
@@ -1111,7 +1112,7 @@ fn normal_mode_undo() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop), Event::from(MetaEvent::Undo)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1140,7 +1141,7 @@ fn normal_mode_undo_visual_mode_change() {
 			Event::from(MetaEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -1164,7 +1165,7 @@ fn normal_mode_redo() {
 			Event::from(MetaEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			test_context.handle_event(&mut module);
 			assert_process_result!(
@@ -1194,7 +1195,7 @@ fn normal_mode_redo_visual_mode_change() {
 			Event::from(MetaEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -1220,7 +1221,7 @@ fn normal_mode_remove_line_first() {
 		],
 		&[Event::from(MetaEvent::Delete)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -1253,7 +1254,7 @@ fn normal_mode_remove_line_end() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -1274,7 +1275,7 @@ fn normal_mode_toggle_visual_mode() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			assert_process_result!(
 				test_context.handle_event(&mut module),
 				event = Event::from(MetaEvent::ToggleVisualMode)
@@ -1288,7 +1289,7 @@ fn normal_mode_toggle_visual_mode() {
 #[test]
 fn normal_mode_other_event() {
 	process_module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(KeyCode::Null)
@@ -1307,7 +1308,7 @@ fn visual_mode_action_change_top_bottom() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1335,7 +1336,7 @@ fn visual_mode_action_change_bottom_top() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1368,7 +1369,7 @@ fn visual_mode_action_change_drop() {
 			Event::from(MetaEvent::ActionDrop),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1403,7 +1404,7 @@ fn visual_mode_action_change_edit() {
 			Event::from(MetaEvent::ActionEdit),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1438,7 +1439,7 @@ fn visual_mode_action_change_fixup() {
 			Event::from(MetaEvent::ActionFixup),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1473,7 +1474,7 @@ fn visual_mode_action_change_pick() {
 			Event::from(MetaEvent::ActionPick),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1508,7 +1509,7 @@ fn visual_mode_action_change_reword() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1543,7 +1544,7 @@ fn visual_mode_action_change_squash() {
 			Event::from(MetaEvent::ActionSquash),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1566,7 +1567,7 @@ fn visual_mode_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Abort)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1586,7 +1587,7 @@ fn visual_mode_force_abort() {
 			Event::from(MetaEvent::ForceAbort),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1604,7 +1605,7 @@ fn visual_mode_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Rebase)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1624,7 +1625,7 @@ fn visual_mode_force_rebase() {
 			Event::from(MetaEvent::ForceRebase),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1654,7 +1655,7 @@ fn visual_mode_swap_down_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1691,7 +1692,7 @@ fn visual_mode_swap_down_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1726,7 +1727,7 @@ fn visual_mode_swap_up_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1763,7 +1764,7 @@ fn visual_mode_swap_up_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1801,7 +1802,7 @@ fn visual_mode_swap_down_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1837,7 +1838,7 @@ fn visual_mode_swap_down_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1873,7 +1874,7 @@ fn visual_mode_swap_up_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1911,7 +1912,7 @@ fn visual_mode_swap_up_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -1937,7 +1938,7 @@ fn visual_mode_toggle_visual_mode() {
 			Event::from(MetaEvent::ToggleVisualMode),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1958,7 +1959,7 @@ fn visual_mode_open_external_editor() {
 			Event::from(MetaEvent::OpenInEditor),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_event(&mut module);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1980,7 +1981,7 @@ fn visual_mode_undo() {
 			Event::from(MetaEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_n_events(&mut module, 3);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -2008,7 +2009,7 @@ fn visual_mode_undo_normal_mode_change() {
 			Event::from(MetaEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_n_events(&mut module, 3);
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -2038,7 +2039,7 @@ fn visual_mode_redo() {
 			Event::from(MetaEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2063,7 +2064,7 @@ fn visual_mode_redo_normal_mode_change() {
 			Event::from(MetaEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2094,7 +2095,7 @@ fn visual_mode_remove_lines_start_index_first() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2130,7 +2131,7 @@ fn visual_mode_remove_lines_end_index_first() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2168,7 +2169,7 @@ fn visual_mode_remove_lines_start_index_last() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2204,7 +2205,7 @@ fn visual_mode_remove_lines_end_index_last() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				test_context.build_view_data(&mut module),
@@ -2224,7 +2225,7 @@ fn visual_mode_remove_lines_end_index_last() {
 #[test]
 fn visual_mode_other_event() {
 	process_module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		assert_process_result!(
 			test_context.handle_event(&mut module),
 			event = Event::from(KeyCode::Null)
@@ -2235,7 +2236,7 @@ fn visual_mode_other_event() {
 #[test]
 fn edit_mode_render() {
 	process_module_test(&["exec foo"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		test_context.handle_all_events(&mut module);
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
@@ -2262,7 +2263,7 @@ fn edit_mode_handle_event() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.build_view_data(&mut module);
 			test_context.handle_all_events(&mut module);
 			assert_eq!(test_context.rebase_todo_file.get_line(0).unwrap().get_content(), "fo");
@@ -2277,7 +2278,7 @@ fn scroll_right() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorRight)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			test_context.view_sender_context.assert_render_action(&["ScrollRight"]);
 		},
@@ -2290,7 +2291,7 @@ fn scroll_left() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorLeft)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			test_context.view_sender_context.assert_render_action(&["ScrollLeft"]);
 		},
@@ -2300,7 +2301,7 @@ fn scroll_left() {
 #[test]
 fn normal_mode_help() {
 	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		module.state = ListState::Normal;
 		test_context.handle_all_events(&mut module);
 		let view_data = test_context.build_view_data(&mut module);
@@ -2352,7 +2353,7 @@ fn normal_mode_help_event() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::SwapSelectedDown)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.state = ListState::Normal;
 			test_context.handle_all_events(&mut module);
 			assert!(!module.normal_mode_help.is_active());
@@ -2363,7 +2364,7 @@ fn normal_mode_help_event() {
 #[test]
 fn visual_mode_help() {
 	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		module.state = ListState::Visual;
 		test_context.handle_all_events(&mut module);
 		let view_data = test_context.build_view_data(&mut module);
@@ -2406,7 +2407,7 @@ fn visual_mode_help_event() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::SwapSelectedDown)],
 		|mut test_context| {
-			let mut module = List::new(test_context.config);
+			let mut module = List::new(&create_config());
 			module.state = ListState::Visual;
 			test_context.handle_all_events(&mut module);
 			assert!(!module.visual_mode_help.is_active());
@@ -2418,7 +2419,7 @@ fn visual_mode_help_event() {
 #[test]
 fn render_noop_list() {
 	process_module_test(&["break"], &[], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		test_context.rebase_todo_file.remove_lines(0, 0);
 		test_context.rebase_todo_file.add_line(0, Line::new("noop").unwrap());
 		let view_data = test_context.build_view_data(&mut module);
@@ -2434,7 +2435,7 @@ fn render_noop_list() {
 #[test]
 fn resize() {
 	process_module_test(&["pick aaa c1"], &[Event::Resize(100, 200)], |mut test_context| {
-		let mut module = List::new(test_context.config);
+		let mut module = List::new(&create_config());
 		test_context.handle_all_events(&mut module);
 		assert_eq!(module.height, 200);
 	});

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -1,6 +1,7 @@
 use std::{path::Path, sync::atomic::Ordering};
 
 use anyhow::anyhow;
+use config::testutil::create_theme;
 use display::{testutil::CrossTerm, Display, Size};
 use input::InputOptions;
 use view::{assert_rendered_output, ViewData};
@@ -57,7 +58,7 @@ fn create_modules() -> Modules {
 fn view_start_error() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -76,7 +77,7 @@ fn window_too_small_on_start() {
 	process_module_test(&["pick aaa comment"], &[Event::from(MetaEvent::Exit)], |test_context| {
 		let mut crossterm = create_crossterm();
 		crossterm.set_size(Size::new(1, 1));
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -93,7 +94,7 @@ fn window_too_small_on_start() {
 fn render_error() {
 	process_module_test(&["pick aaa comment"], &[Event::from(MetaEvent::Exit)], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -113,7 +114,7 @@ fn render_error() {
 fn view_sender_is_poisoned() {
 	process_module_test(&["pick aaa comment"], &[Event::from(MetaEvent::Exit)], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -132,7 +133,7 @@ fn view_sender_is_poisoned() {
 fn stop_error() {
 	process_module_test(&["pick aaa comment"], &[Event::from(MetaEvent::Exit)], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -158,7 +159,7 @@ fn handle_exit_event_that_is_not_kill() {
 		test_context.rebase_todo_file.set_lines(vec![]);
 		let mut shadow_rebase_file = test_context.new_todo_file();
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -186,7 +187,7 @@ fn handle_exit_event_that_is_kill() {
 		test_context.rebase_todo_file.set_lines(vec![]);
 		let mut shadow_rebase_file = test_context.new_todo_file();
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -211,7 +212,7 @@ fn handle_exit_event_that_is_kill() {
 fn handle_process_result_error() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -229,7 +230,7 @@ fn handle_process_result_error() {
 fn handle_process_result_new_state() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -248,7 +249,7 @@ fn handle_process_result_new_state() {
 fn handle_process_result_state_same() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -267,7 +268,7 @@ fn handle_process_result_state_same() {
 fn handle_process_result_exit_event() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -285,7 +286,7 @@ fn handle_process_result_exit_event() {
 fn handle_process_result_kill_event() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -303,7 +304,7 @@ fn handle_process_result_kill_event() {
 fn handle_process_result_resize_event_not_too_small() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -322,7 +323,7 @@ fn handle_process_result_resize_event_not_too_small() {
 fn handle_process_result_resize_event_too_small() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -342,7 +343,7 @@ fn handle_process_result_resize_event_too_small() {
 fn handle_process_result_other_event() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut process = Process::new(
 			test_context.rebase_todo_file,
@@ -361,7 +362,7 @@ fn handle_process_result_other_event() {
 fn handle_process_result_external_command_not_executable() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -401,7 +402,7 @@ fn handle_process_result_external_command_not_executable() {
 fn handle_process_result_external_command_executable_not_found() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -441,7 +442,7 @@ fn handle_process_result_external_command_executable_not_found() {
 fn handle_process_result_external_command_status_success() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(
@@ -463,7 +464,7 @@ fn handle_process_result_external_command_status_success() {
 fn handle_process_result_external_command_status_error() {
 	process_module_test(&["pick aaa comment"], &[], |test_context| {
 		let crossterm = create_crossterm();
-		let display = Display::new(crossterm, &test_context.config.theme);
+		let display = Display::new(crossterm, &create_theme());
 		let view = View::new(display, "~", "?");
 		let mut modules = create_modules();
 		let mut process = Process::new(

--- a/src/process/testutil/process_module_test.rs
+++ b/src/process/testutil/process_module_test.rs
@@ -1,6 +1,5 @@
 use std::{cell::Cell, path::Path};
 
-use config::{testutil::create_config, Config};
 use input::{
 	testutil::{with_event_handler, TestContext as EventHandlerTestContext},
 	Event,
@@ -15,8 +14,7 @@ use view::{
 
 use crate::module::{Module, ProcessResult, State};
 
-pub struct TestContext<'t> {
-	pub config: &'t Config,
+pub struct TestContext {
 	pub event_handler_context: EventHandlerTestContext,
 	pub view_sender_context: ViewSenderContext,
 	pub rebase_todo_file: TodoFile,
@@ -24,7 +22,7 @@ pub struct TestContext<'t> {
 	todo_file: Cell<NamedTempFile>,
 }
 
-impl<'t> TestContext<'t> {
+impl TestContext {
 	fn get_build_data<'tc>(&self, module: &'tc mut dyn Module) -> &'tc ViewData {
 		module.build_view_data(&self.render_context, &self.rebase_todo_file)
 	}
@@ -103,7 +101,7 @@ impl<'t> TestContext<'t> {
 }
 
 pub fn process_module_test<C>(lines: &[&str], events: &[Event], callback: C)
-where C: for<'p> FnOnce(TestContext<'p>) {
+where C: FnOnce(TestContext) {
 	with_event_handler(events, |event_handler_context| {
 		with_view_sender(|view_sender_context| {
 			let git_repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -122,7 +120,6 @@ where C: for<'p> FnOnce(TestContext<'p>) {
 			let mut rebase_todo_file = TodoFile::new(todo_file.path().to_str().unwrap(), 1, "#");
 			rebase_todo_file.set_lines(lines.iter().map(|l| Line::new(l).unwrap()).collect());
 			callback(TestContext {
-				config: &create_config(),
 				event_handler_context,
 				rebase_todo_file,
 				view_sender_context,

--- a/src/show_commit/tests.rs
+++ b/src/show_commit/tests.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use chrono::Local;
+use config::testutil::create_config;
 use rstest::rstest;
 use view::{assert_rendered_output, ViewLine};
 
@@ -30,7 +31,7 @@ fn load_commit_during_activate() {
 		&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			assert_process_result!(test_context.activate(&mut module, State::List));
 			assert!(module.commit.is_some());
 		},
@@ -43,7 +44,7 @@ fn cached_commit_in_activate() {
 		&["pick 18d82dcc4c36cade807d7cf79700b6bbad8080b9 comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			assert_process_result!(test_context.activate(&mut module, State::List));
 			assert_process_result!(test_context.activate(&mut module, State::List));
 		},
@@ -53,7 +54,7 @@ fn cached_commit_in_activate() {
 #[test]
 fn no_selected_line_in_activate() {
 	process_module_test(&[], &[], |test_context| {
-		let mut module = ShowCommit::new(test_context.config);
+		let mut module = ShowCommit::new(&create_config());
 		assert_process_result!(
 			test_context.activate(&mut module, State::List),
 			state = State::List,
@@ -65,7 +66,7 @@ fn no_selected_line_in_activate() {
 #[test]
 fn activate_error() {
 	process_module_test(&["pick aaaaaaaaaa comment1"], &[], |test_context| {
-		let mut module = ShowCommit::new(test_context.config);
+		let mut module = ShowCommit::new(&create_config());
 		assert_process_result!(
 			test_context.activate(&mut module, State::List),
 			state = State::List,
@@ -83,7 +84,7 @@ fn render_overview_minimal_commit() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			module.commit = Some(commit);
@@ -109,7 +110,7 @@ fn render_overview_minimal_commit_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			module.commit = Some(commit);
@@ -133,7 +134,7 @@ fn render_overview_with_author() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.author = User::new(Some("John Doe"), Some("john.doe@example.com"));
@@ -161,7 +162,7 @@ fn render_overview_with_author_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.author = User::new(Some("John Doe"), Some("john.doe@example.com"));
@@ -187,7 +188,7 @@ fn render_overview_with_committer() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.committer = User::new(Some("John Doe"), Some("john.doe@example.com"));
@@ -215,7 +216,7 @@ fn render_overview_with_committer_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.committer = User::new(Some("John Doe"), Some("john.doe@example.com"));
@@ -241,7 +242,7 @@ fn render_overview_with_commit_body() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.body = Some(String::from("Commit title\n\nCommit body"));
@@ -270,7 +271,7 @@ fn render_overview_with_file_stats() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.file_stats = vec![
@@ -312,7 +313,7 @@ fn render_overview_with_file_stats_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.file_stats = vec![
@@ -352,7 +353,7 @@ fn render_overview_single_file_changed() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.number_files_changed = 1;
@@ -378,7 +379,7 @@ fn render_overview_more_than_one_file_changed() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.number_files_changed = 2;
@@ -404,7 +405,7 @@ fn render_overview_single_insertion() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.insertions = 1;
@@ -430,7 +431,7 @@ fn render_overview_more_than_one_insertion() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.insertions = 2;
@@ -456,7 +457,7 @@ fn render_overview_single_deletion() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.deletions = 1;
@@ -482,7 +483,7 @@ fn render_overview_more_than_one_deletion() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let commit_date = commit.get_date().format("%c %z").to_string();
 			commit.deletions = 2;
@@ -508,7 +509,7 @@ fn render_diff_minimal_commit() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			module.commit = Some(create_minimal_commit());
@@ -534,7 +535,7 @@ fn render_diff_minimal_commit_compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			module.commit = Some(create_minimal_commit());
@@ -558,7 +559,7 @@ fn render_diff_basic_file_stats() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -606,7 +607,7 @@ fn render_diff_end_new_line_missing() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			let mut commit = create_minimal_commit();
 			let mut file_stat = FileStat::new("file.txt", "file.txt", Status::Modified);
 			let mut delta = Delta::new("@@ -14,2 +13,3 @@ context", 14, 14, 0, 1);
@@ -642,7 +643,7 @@ fn render_diff_add_line() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -678,7 +679,7 @@ fn render_diff_delete_line() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -714,7 +715,7 @@ fn render_diff_context_add_remove_lines() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -756,7 +757,7 @@ fn render_diff_add_line_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -792,7 +793,7 @@ fn render_diff_delete_line_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -828,7 +829,7 @@ fn render_diff_context_add_remove_lines_with_show_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			let mut module = ShowCommit::new(&config);
 			let mut commit = create_minimal_commit();
@@ -893,7 +894,7 @@ fn render_diff_show_both_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			config.diff_tab_symbol = String::from("#");
 			config.diff_space_symbol = String::from("%");
@@ -939,7 +940,7 @@ fn render_diff_show_leading_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Leading;
 			config.diff_tab_symbol = String::from("#");
 			config.diff_space_symbol = String::from("%");
@@ -985,7 +986,7 @@ fn render_diff_show_no_whitespace() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::None;
 			config.diff_tab_symbol = String::from("#");
 			config.diff_space_symbol = String::from("%");
@@ -1028,7 +1029,7 @@ fn render_diff_show_whitespace_all_spaces() {
 		&["pick 0123456789abcdef0123456789abcdef comment1"],
 		&[],
 		|test_context| {
-			let mut config = test_context.config.clone();
+			let mut config = create_config();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
 			config.diff_tab_symbol = String::from("#");
 			config.diff_space_symbol = String::from("%");
@@ -1067,7 +1068,7 @@ fn handle_event_toggle_diff_to_overview() {
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from(MetaEvent::ShowDiff)],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			module
 				.diff_view_data
 				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
@@ -1088,7 +1089,7 @@ fn handle_event_toggle_overview_to_diff() {
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from(MetaEvent::ShowDiff)],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			module
 				.overview_view_data
 				.update_view_data(|updater| updater.push_line(ViewLine::from("foo")));
@@ -1109,7 +1110,7 @@ fn handle_event_resize() {
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::Resize(100, 100)],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::Resize(100, 100));
 		},
 	);
@@ -1118,7 +1119,7 @@ fn handle_event_resize() {
 #[test]
 fn render_help() {
 	process_module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-		let mut module = ShowCommit::new(test_context.config);
+		let mut module = ShowCommit::new(&create_config());
 		test_context.handle_all_events(&mut module);
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
@@ -1147,7 +1148,7 @@ fn handle_help_event() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Help), Event::from(MetaEvent::ShowDiff)],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			test_context.handle_all_events(&mut module);
 			assert!(!module.help.is_active());
 		},
@@ -1160,7 +1161,7 @@ fn handle_event_other_key_from_diff() {
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from('a')],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			module.state = ShowCommitState::Diff;
 			assert_process_result!(test_context.handle_event(&mut module), event = Event::from('a'));
 			assert_eq!(module.state, ShowCommitState::Overview);
@@ -1174,7 +1175,7 @@ fn handle_event_other_key_from_overview() {
 		&["pick 0123456789abcdef0123456789abcdef c1"],
 		&[Event::from('a')],
 		|mut test_context| {
-			let mut module = ShowCommit::new(test_context.config);
+			let mut module = ShowCommit::new(&create_config());
 			module.state = ShowCommitState::Overview;
 			assert_process_result!(
 				test_context.handle_event(&mut module),
@@ -1196,7 +1197,7 @@ fn handle_event_other_key_from_overview() {
 )]
 fn scroll_events(event: MetaEvent) {
 	process_module_test(&[], &[Event::from(event)], |mut test_context| {
-		let mut module = ShowCommit::new(test_context.config);
+		let mut module = ShowCommit::new(&create_config());
 		assert_process_result!(test_context.handle_event(&mut module), event = Event::from(event));
 	});
 }


### PR DESCRIPTION
# Description

With the addition of the mocked config, the config reference in the `process_module_test` function is no longer needed. This updates the remaining references to create an instance of the `Config` where needed and removes the config reference from the test context.