### PR TITLE
Migrate rstest to new format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,12 +46,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -120,7 +114,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -132,7 +126,7 @@ dependencies = [
  "anyhow",
  "concat-idents",
  "git2",
- "rstest 0.6.4",
+ "rstest",
  "rustc_version 0.4.0",
  "serial_test",
  "tempfile",
@@ -154,7 +148,7 @@ dependencies = [
  "lazy_static",
  "num-format",
  "pico-args",
- "rstest 0.6.4",
+ "rstest",
  "rustc_version 0.4.0",
  "serial_test",
  "tempfile",
@@ -168,7 +162,7 @@ dependencies = [
  "anyhow",
  "crossterm",
  "girt-config",
- "rstest 0.6.4",
+ "rstest",
  "rustc_version 0.4.0",
  "serial_test",
 ]
@@ -180,7 +174,7 @@ dependencies = [
  "anyhow",
  "crossterm",
  "girt-config",
- "rstest 0.6.4",
+ "rstest",
  "rustc_version 0.4.0",
 ]
 
@@ -190,7 +184,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "concat-idents",
- "rstest 0.10.0",
+ "rstest",
  "rustc_version 0.4.0",
  "tempfile",
 ]
@@ -203,7 +197,7 @@ dependencies = [
  "girt-config",
  "girt-display",
  "girt-input",
- "rstest 0.10.0",
+ "rstest",
  "rustc_version 0.4.0",
  "unicode-segmentation",
  "unicode-width",
@@ -249,7 +243,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -318,7 +312,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -410,7 +404,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -529,37 +523,15 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
-dependencies = [
- "cfg-if 0.1.10",
- "proc-macro2",
- "quote",
- "rustc_version 0.2.3",
- "syn",
-]
-
-[[package]]
-name = "rstest"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version 0.3.3",
  "syn",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
 ]
 
 [[package]]
@@ -588,20 +560,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -609,12 +572,6 @@ name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -700,7 +657,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -24,7 +24,7 @@ features = []
 
 [dev-dependencies]
 concat-idents = "1.1.2"
-rstest = "0.6.4"
+rstest = "0.10.0"
 serial_test = "0.5.1"
 tempfile = "3.2.0"
 

--- a/src/config/src/tests.rs
+++ b/src/config/src/tests.rs
@@ -648,39 +648,36 @@ fn config_git_editor_invalid() {
 	);
 }
 
-#[rstest(
-	binding,
-	expected,
-	case::backspace("backspace", "Backspace"),
-	case::backtab("backtab", "BackTab"),
-	case::delete("delete", "Delete"),
-	case::down("down", "Down"),
-	case::end("end", "End"),
-	case::home("home", "Home"),
-	case::insert("insert", "Insert"),
-	case::left("left", "Left"),
-	case::pagedown("pagedown", "PageDown"),
-	case::pageup("pageup", "PageUp"),
-	case::right("right", "Right"),
-	case::tab("tab", "Tab"),
-	case::up("up", "Up"),
-	case::f1("f1", "F1"),
-	case::f255("f255", "F255"),
-	case::modifier_character_lowercase("Control+a", "Controla"),
-	case::modifier_character_uppercase("Control+A", "ControlA"),
-	case::modifier_character_number("Control+1", "Control1"),
-	case::modifier_character_special("Control++", "Control+"),
-	case::modifier_character("Control+a", "Controla"),
-	case::modifier_special("Control+End", "ControlEnd"),
-	case::modifier_function("Control+F32", "ControlF32"),
-	case::modifier_control_alt_shift_out_of_order_1("Alt+Shift+Control+End", "ShiftControlAltEnd"),
-	case::modifier_control_alt_shift_out_of_order_2("Shift+Control+Alt+End", "ShiftControlAltEnd"),
-	case::modifier_only_shift("Shift+End", "ShiftEnd"),
-	case::modifier_only_control("Control+End", "ControlEnd"),
-	case::modifier_only_control("a b c d", "a,b,c,d"),
-	case::modifier_only_control("Control+End Control+A", "ControlEnd,ControlA")
-)]
-fn config_key_bindings(binding: &str, expected: &str) {
+#[rstest]
+#[case::backspace("backspace", "Backspace")]
+#[case::backtab("backtab", "BackTab")]
+#[case::delete("delete", "Delete")]
+#[case::down("down", "Down")]
+#[case::end("end", "End")]
+#[case::home("home", "Home")]
+#[case::insert("insert", "Insert")]
+#[case::left("left", "Left")]
+#[case::pagedown("pagedown", "PageDown")]
+#[case::pageup("pageup", "PageUp")]
+#[case::right("right", "Right")]
+#[case::tab("tab", "Tab")]
+#[case::up("up", "Up")]
+#[case::f1("f1", "F1")]
+#[case::f255("f255", "F255")]
+#[case::modifier_character_lowercase("Control+a", "Controla")]
+#[case::modifier_character_uppercase("Control+A", "ControlA")]
+#[case::modifier_character_number("Control+1", "Control1")]
+#[case::modifier_character_special("Control++", "Control+")]
+#[case::modifier_character("Control+a", "Controla")]
+#[case::modifier_special("Control+End", "ControlEnd")]
+#[case::modifier_function("Control+F32", "ControlF32")]
+#[case::modifier_control_alt_shift_out_of_order_1("Alt+Shift+Control+End", "ShiftControlAltEnd")]
+#[case::modifier_control_alt_shift_out_of_order_2("Shift+Control+Alt+End", "ShiftControlAltEnd")]
+#[case::modifier_only_shift("Shift+End", "ShiftEnd")]
+#[case::modifier_only_control("Control+End", "ControlEnd")]
+#[case::modifier_only_control("a b c d", "a,b,c,d")]
+#[case::modifier_only_control("Control+End Control+A", "ControlEnd,ControlA")]
+fn config_key_bindings(#[case] binding: &str, #[case] expected: &str) {
 	let config = load(|git_config| {
 		git_config
 			.set_str("interactive-rebase-tool.inputAbort", binding)

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -34,7 +34,7 @@ features = []
 
 [dev-dependencies]
 captur = "0.1.0"
-rstest = "0.6.4"
+rstest = "0.10.0"
 serial_test = "0.5.1"
 tempfile = "3.2.0"
 

--- a/src/core/src/components/choice/tests.rs
+++ b/src/core/src/components/choice/tests.rs
@@ -94,17 +94,15 @@ fn invalid_selection_character() {
 	});
 }
 
-#[rstest(
-	event,
-	case::resize(Event::Resize(100, 100)),
-	case::scroll_left(Event::from(MetaEvent::ScrollLeft)),
-	case::scroll_right(Event::from(MetaEvent::ScrollRight)),
-	case::scroll_down(Event::from(MetaEvent::ScrollDown)),
-	case::scroll_up(Event::from(MetaEvent::ScrollUp)),
-	case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown)),
-	case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))
-)]
-fn event_standard(event: Event) {
+#[rstest]
+#[case::resize(Event::Resize(100, 100))]
+#[case::scroll_left(Event::from(MetaEvent::ScrollLeft))]
+#[case::scroll_right(Event::from(MetaEvent::ScrollRight))]
+#[case::scroll_down(Event::from(MetaEvent::ScrollDown))]
+#[case::scroll_up(Event::from(MetaEvent::ScrollUp))]
+#[case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown))]
+#[case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))]
+fn event_standard(#[case] event: Event) {
 	handle_event_test(&[event], |context| {
 		let mut module = Choice::new(create_choices());
 		let _ = module.handle_event(&context.event_handler, &context.view_sender);

--- a/src/core/src/components/confirm/tests.rs
+++ b/src/core/src/components/confirm/tests.rs
@@ -48,17 +48,15 @@ fn handle_event_no() {
 	});
 }
 
-#[rstest(
-	event,
-	case::resize(Event::Resize(100, 100)),
-	case::scroll_left(Event::from(MetaEvent::ScrollLeft)),
-	case::scroll_right(Event::from(MetaEvent::ScrollRight)),
-	case::scroll_down(Event::from(MetaEvent::ScrollDown)),
-	case::scroll_up(Event::from(MetaEvent::ScrollUp)),
-	case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown)),
-	case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))
-)]
-fn input_standard(event: Event) {
+#[rstest]
+#[case::resize(Event::Resize(100, 100))]
+#[case::scroll_left(Event::from(MetaEvent::ScrollLeft))]
+#[case::scroll_right(Event::from(MetaEvent::ScrollRight))]
+#[case::scroll_down(Event::from(MetaEvent::ScrollDown))]
+#[case::scroll_up(Event::from(MetaEvent::ScrollUp))]
+#[case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown))]
+#[case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))]
+fn input_standard(#[case] event: Event) {
 	with_event_handler(&[event], |context| {
 		let module = Confirm::new("Prompt message", &[], &[]);
 		let (confirmed, evt) = module.handle_event(&context.event_handler);

--- a/src/core/src/components/help/tests.rs
+++ b/src/core/src/components/help/tests.rs
@@ -37,17 +37,15 @@ fn from_key_bindings() {
 	);
 }
 
-#[rstest(
-	event,
-	case::resize(Event::Resize(100, 100)),
-	case::scroll_left(Event::from(MetaEvent::ScrollLeft)),
-	case::scroll_right(Event::from(MetaEvent::ScrollRight)),
-	case::scroll_down(Event::from(MetaEvent::ScrollDown)),
-	case::scroll_up(Event::from(MetaEvent::ScrollUp)),
-	case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown)),
-	case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))
-)]
-fn input_continue_active(event: Event) {
+#[rstest]
+#[case::resize(Event::Resize(100, 100))]
+#[case::scroll_left(Event::from(MetaEvent::ScrollLeft))]
+#[case::scroll_right(Event::from(MetaEvent::ScrollRight))]
+#[case::scroll_down(Event::from(MetaEvent::ScrollDown))]
+#[case::scroll_up(Event::from(MetaEvent::ScrollUp))]
+#[case::scroll_jump_down(Event::from(MetaEvent::ScrollJumpDown))]
+#[case::scroll_jump_up(Event::from(MetaEvent::ScrollJumpUp))]
+fn input_continue_active(#[case] event: Event) {
 	handle_event_test(&[event], |context| {
 		let mut module = Help::new_from_keybindings(&[]);
 		module.set_active();

--- a/src/core/src/module/exit_status.rs
+++ b/src/core/src/module/exit_status.rs
@@ -29,18 +29,15 @@ mod tests {
 
 	use super::*;
 
-	#[rstest(
-		input,
-		expected,
-		case::abort(ExitStatus::Abort, 5),
-		case::config_error(ExitStatus::ConfigError, 1),
-		case::file_read_error(ExitStatus::FileReadError, 2),
-		case::file_write_error(ExitStatus::FileWriteError, 3),
-		case::good(ExitStatus::Good, 0),
-		case::state_error(ExitStatus::StateError, 4),
-		case::kill(ExitStatus::Kill, 6)
-	)]
-	fn to_code(input: ExitStatus, expected: i32) {
+	#[rstest]
+	#[case::abort(ExitStatus::Abort, 5)]
+	#[case::config_error(ExitStatus::ConfigError, 1)]
+	#[case::file_read_error(ExitStatus::FileReadError, 2)]
+	#[case::file_write_error(ExitStatus::FileWriteError, 3)]
+	#[case::good(ExitStatus::Good, 0)]
+	#[case::state_error(ExitStatus::StateError, 4)]
+	#[case::kill(ExitStatus::Kill, 6)]
+	fn to_code(#[case] input: ExitStatus, #[case] expected: i32) {
 		assert_eq!(ExitStatus::to_code(input), expected);
 	}
 }

--- a/src/core/src/modules/insert/line_type.rs
+++ b/src/core/src/modules/insert/line_type.rs
@@ -27,17 +27,14 @@ mod tests {
 
 	use super::*;
 
-	#[rstest(
-		line_type,
-		expected,
-		case::cancel(&LineType::Cancel, "<cancel>"),
-		case::pick(&LineType::Pick, "pick"),
-		case::exec(&LineType::Exec, "exec"),
-		case::label(&LineType::Label, "label"),
-		case::merge(&LineType::Merge, "merge"),
-		case::reset(&LineType::Reset, "reset"),
-	)]
-	fn to_string(line_type: &LineType, expected: &str) {
+	#[rstest]
+	#[case::cancel(&LineType::Cancel, "<cancel>")]
+	#[case::pick(&LineType::Pick, "pick")]
+	#[case::exec(&LineType::Exec, "exec")]
+	#[case::label(&LineType::Label, "label")]
+	#[case::merge(&LineType::Merge, "merge")]
+	#[case::reset(&LineType::Reset, "reset")]
+	fn to_string(#[case] line_type: &LineType, #[case] expected: &str) {
 		assert_eq!(line_type.to_string(), String::from(expected));
 	}
 }

--- a/src/core/src/modules/show_commit/origin.rs
+++ b/src/core/src/modules/show_commit/origin.rs
@@ -23,18 +23,15 @@ mod tests {
 
 	use super::*;
 
-	#[rstest(
-		input,
-		expected,
-		case::space(' ', &Origin::Context),
-		case::equals('=', &Origin::Context),
-		case::plus('+', &Origin::Addition),
-		case::greater_than('>', &Origin::Addition),
-		case::minus('-', &Origin::Deletion),
-		case::less_than('-', &Origin::Deletion),
-		case::other('a', &Origin::Context)
-	)]
-	fn from_char(input: char, expected: &Origin) {
+	#[rstest]
+	#[case::space(' ', &Origin::Context)]
+	#[case::equals('=', &Origin::Context)]
+	#[case::plus('+', &Origin::Addition)]
+	#[case::greater_than('>', &Origin::Addition)]
+	#[case::minus('-', &Origin::Deletion)]
+	#[case::less_than('-', &Origin::Deletion)]
+	#[case::other('a', &Origin::Context)]
+	fn from_char(#[case] input: char, #[case] expected: &Origin) {
 		assert_eq!(&Origin::from(input), expected);
 	}
 }

--- a/src/core/src/modules/show_commit/status.rs
+++ b/src/core/src/modules/show_commit/status.rs
@@ -40,22 +40,19 @@ mod tests {
 
 	use super::*;
 
-	#[rstest(
-		input,
-		expected,
-		case::added(Delta::Added, &Status::Added),
-		case::copied(Delta::Copied, &Status::Copied),
-		case::deleted(Delta::Deleted, &Status::Deleted),
-		case::modified(Delta::Modified, &Status::Modified),
-		case::renamed(Delta::Renamed, &Status::Renamed),
-		case::typechange(Delta::Typechange, &Status::Typechange),
-		case::ignored(Delta::Ignored, &Status::Other),
-		case::conflicted(Delta::Conflicted, &Status::Other),
-		case::unmodified(Delta::Unmodified, &Status::Other),
-		case::unreadable(Delta::Unreadable, &Status::Other),
-		case::untracked(Delta::Untracked, &Status::Other)
-	)]
-	fn from_delta(input: Delta, expected: &Status) {
+	#[rstest]
+	#[case::added(Delta::Added, &Status::Added)]
+	#[case::copied(Delta::Copied, &Status::Copied)]
+	#[case::deleted(Delta::Deleted, &Status::Deleted)]
+	#[case::modified(Delta::Modified, &Status::Modified)]
+	#[case::renamed(Delta::Renamed, &Status::Renamed)]
+	#[case::typechange(Delta::Typechange, &Status::Typechange)]
+	#[case::ignored(Delta::Ignored, &Status::Other)]
+	#[case::conflicted(Delta::Conflicted, &Status::Other)]
+	#[case::unmodified(Delta::Unmodified, &Status::Other)]
+	#[case::unreadable(Delta::Unreadable, &Status::Other)]
+	#[case::untracked(Delta::Untracked, &Status::Other)]
+	fn from_delta(#[case] input: Delta, #[case] expected: &Status) {
 		assert_eq!(&Status::from(input), expected);
 	}
 }

--- a/src/core/src/modules/show_commit/tests.rs
+++ b/src/core/src/modules/show_commit/tests.rs
@@ -1182,16 +1182,14 @@ fn handle_event_other_key_from_overview() {
 	);
 }
 
-#[rstest(
-	event,
-	case::scroll_left(MetaEvent::ScrollLeft),
-	case::scroll_right(MetaEvent::ScrollRight),
-	case::scroll_down(MetaEvent::ScrollDown),
-	case::scroll_up(MetaEvent::ScrollUp),
-	case::scroll_jump_down(MetaEvent::ScrollJumpDown),
-	case::scroll_jump_up(MetaEvent::ScrollJumpUp)
-)]
-fn scroll_events(event: MetaEvent) {
+#[rstest]
+#[case::scroll_left(MetaEvent::ScrollLeft)]
+#[case::scroll_right(MetaEvent::ScrollRight)]
+#[case::scroll_down(MetaEvent::ScrollDown)]
+#[case::scroll_up(MetaEvent::ScrollUp)]
+#[case::scroll_jump_down(MetaEvent::ScrollJumpDown)]
+#[case::scroll_jump_up(MetaEvent::ScrollJumpUp)]
+fn scroll_events(#[case] event: MetaEvent) {
 	module_test(&[], &[Event::from(event)], |mut test_context| {
 		let mut module = ShowCommit::new(&create_config());
 		assert_process_result!(test_context.handle_event(&mut module), event = Event::from(event));

--- a/src/core/src/modules/window_size_error/mod.rs
+++ b/src/core/src/modules/window_size_error/mod.rs
@@ -85,19 +85,25 @@ mod tests {
 	const MINIMUM_WINDOW_HEIGHT: usize = 5;
 	const MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH: usize = 45;
 
-	#[rstest(
-		width, height, expected,
-		case::width_too_small_long_message(SHORT_ERROR_MESSAGE.len(), MINIMUM_WINDOW_HEIGHT + 1, "Window too small"),
-		case::width_too_small_short_message(SHORT_ERROR_MESSAGE.len() - 1, MINIMUM_WINDOW_HEIGHT + 1, "Size!"),
-		case::height_too_small_long_message(
-			MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH, MINIMUM_WINDOW_HEIGHT, "Window too small, increase height to continue"
-		),
-		case::height_too_small_short_message(
-			MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH - 1, MINIMUM_WINDOW_HEIGHT, "Window too small"
-		)
+	#[rstest]
+	#[case::width_too_small_long_message(
+		SHORT_ERROR_MESSAGE.len(),
+		MINIMUM_WINDOW_HEIGHT + 1,
+		"Window too small"
+	)]
+	#[case::width_too_small_short_message(SHORT_ERROR_MESSAGE.len() - 1, MINIMUM_WINDOW_HEIGHT + 1, "Size!")]
+	#[case::height_too_small_long_message(
+		MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH,
+		MINIMUM_WINDOW_HEIGHT,
+		"Window too small, increase height to continue"
+	)]
+	#[case::height_too_small_short_message(
+		MINIMUM_WINDOW_HEIGHT_ERROR_WIDTH - 1,
+		MINIMUM_WINDOW_HEIGHT,
+		"Window too small"
 	)]
 	#[allow(clippy::cast_possible_wrap)]
-	fn build_view_data(width: usize, height: usize, expected: &str) {
+	fn build_view_data(#[case] width: usize, #[case] height: usize, #[case] expected: &str) {
 		module_test(&[], &[], |mut test_context| {
 			test_context.render_context.update(width as u16, height as u16);
 			let mut module = WindowSizeError::new();

--- a/src/display/Cargo.toml
+++ b/src/display/Cargo.toml
@@ -20,7 +20,7 @@ crossterm = "0.20.0"
 girt-config = {version = "1.0.0", path = "../config"}
 
 [dev-dependencies]
-rstest = "0.6.4"
+rstest = "0.10.0"
 serial_test = "0.5.1"
 
 [build-dependencies]

--- a/src/display/src/lib.rs
+++ b/src/display/src/lib.rs
@@ -459,143 +459,128 @@ mod tests {
 		assert!(!display.tui.is_dirty());
 	}
 
-	#[rstest(
-		display_color,
-		selected,
-		expected_foreground,
-		expected_background,
-		case::action_break(DisplayColor::ActionBreak, false, CrosstermColor::White, CrosstermColor::Reset),
-		case::action_break_selected(
-			DisplayColor::ActionBreak,
-			true,
-			CrosstermColor::White,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_drop(DisplayColor::ActionDrop, false, CrosstermColor::Red, CrosstermColor::Reset),
-		case::action_drop_selected(
-			DisplayColor::ActionDrop,
-			true,
-			CrosstermColor::Red,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_edit(DisplayColor::ActionEdit, false, CrosstermColor::Blue, CrosstermColor::Reset),
-		case::action_edit_selected(
-			DisplayColor::ActionEdit,
-			true,
-			CrosstermColor::Blue,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_exec(DisplayColor::ActionExec, false, CrosstermColor::White, CrosstermColor::Reset),
-		case::action_exec_selected(
-			DisplayColor::ActionExec,
-			true,
-			CrosstermColor::White,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_fixup(DisplayColor::ActionFixup, false, CrosstermColor::Magenta, CrosstermColor::Reset),
-		case::action_fixup_selected(
-			DisplayColor::ActionFixup,
-			true,
-			CrosstermColor::Magenta,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_pick(DisplayColor::ActionPick, false, CrosstermColor::Green, CrosstermColor::Reset),
-		case::action_pick_selected(
-			DisplayColor::ActionPick,
-			true,
-			CrosstermColor::Green,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_reword(DisplayColor::ActionReword, false, CrosstermColor::Yellow, CrosstermColor::Reset),
-		case::action_reword_selected(
-			DisplayColor::ActionReword,
-			true,
-			CrosstermColor::Yellow,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_squash(DisplayColor::ActionSquash, false, CrosstermColor::Cyan, CrosstermColor::Reset),
-		case::action_squash_selected(
-			DisplayColor::ActionSquash,
-			true,
-			CrosstermColor::Cyan,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_label(DisplayColor::ActionLabel, false, CrosstermColor::DarkYellow, CrosstermColor::Reset),
-		case::action_label_selected(
-			DisplayColor::ActionLabel,
-			true,
-			CrosstermColor::DarkYellow,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_reset(DisplayColor::ActionReset, false, CrosstermColor::DarkYellow, CrosstermColor::Reset),
-		case::action_reset_selected(
-			DisplayColor::ActionReset,
-			true,
-			CrosstermColor::DarkYellow,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::action_merge(DisplayColor::ActionMerge, false, CrosstermColor::DarkYellow, CrosstermColor::Reset),
-		case::action_merge_selected(
-			DisplayColor::ActionMerge,
-			true,
-			CrosstermColor::DarkYellow,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::normal(DisplayColor::Normal, false, CrosstermColor::Reset, CrosstermColor::Reset),
-		case::normal_selected(DisplayColor::Normal, true, CrosstermColor::Reset, CrosstermColor::AnsiValue(237)),
-		case::indicator(DisplayColor::IndicatorColor, false, CrosstermColor::Cyan, CrosstermColor::Reset),
-		case::indicator_selected(
-			DisplayColor::IndicatorColor,
-			true,
-			CrosstermColor::Cyan,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::diff_add(DisplayColor::DiffAddColor, false, CrosstermColor::Green, CrosstermColor::Reset),
-		case::diff_add_selected(
-			DisplayColor::DiffAddColor,
-			true,
-			CrosstermColor::Green,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::diff_remove(DisplayColor::DiffRemoveColor, false, CrosstermColor::Red, CrosstermColor::Reset),
-		case::diff_remove_selected(
-			DisplayColor::DiffRemoveColor,
-			true,
-			CrosstermColor::Red,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::diff_change(DisplayColor::DiffChangeColor, false, CrosstermColor::Yellow, CrosstermColor::Reset),
-		case::diff_change_selected(
-			DisplayColor::DiffChangeColor,
-			true,
-			CrosstermColor::Yellow,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::diff_context(DisplayColor::DiffContextColor, false, CrosstermColor::White, CrosstermColor::Reset),
-		case::diff_context_selected(
-			DisplayColor::DiffContextColor,
-			true,
-			CrosstermColor::White,
-			CrosstermColor::AnsiValue(237)
-		),
-		case::diff_whitespace(
-			DisplayColor::DiffWhitespaceColor,
-			false,
-			CrosstermColor::DarkGrey,
-			CrosstermColor::Reset
-		),
-		case::diff_whitespace_selected(
-			DisplayColor::DiffWhitespaceColor,
-			true,
-			CrosstermColor::DarkGrey,
-			CrosstermColor::AnsiValue(237)
-		)
+	#[rstest]
+	#[case::action_break(DisplayColor::ActionBreak, false, CrosstermColor::White, CrosstermColor::Reset)]
+	#[case::action_break_selected(
+		DisplayColor::ActionBreak,
+		true,
+		CrosstermColor::White,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_drop(DisplayColor::ActionDrop, false, CrosstermColor::Red, CrosstermColor::Reset)]
+	#[case::action_drop_selected(DisplayColor::ActionDrop, true, CrosstermColor::Red, CrosstermColor::AnsiValue(237))]
+	#[case::action_edit(DisplayColor::ActionEdit, false, CrosstermColor::Blue, CrosstermColor::Reset)]
+	#[case::action_edit_selected(DisplayColor::ActionEdit, true, CrosstermColor::Blue, CrosstermColor::AnsiValue(237))]
+	#[case::action_exec(DisplayColor::ActionExec, false, CrosstermColor::White, CrosstermColor::Reset)]
+	#[case::action_exec_selected(
+		DisplayColor::ActionExec,
+		true,
+		CrosstermColor::White,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_fixup(DisplayColor::ActionFixup, false, CrosstermColor::Magenta, CrosstermColor::Reset)]
+	#[case::action_fixup_selected(
+		DisplayColor::ActionFixup,
+		true,
+		CrosstermColor::Magenta,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_pick(DisplayColor::ActionPick, false, CrosstermColor::Green, CrosstermColor::Reset)]
+	#[case::action_pick_selected(
+		DisplayColor::ActionPick,
+		true,
+		CrosstermColor::Green,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_reword(DisplayColor::ActionReword, false, CrosstermColor::Yellow, CrosstermColor::Reset)]
+	#[case::action_reword_selected(
+		DisplayColor::ActionReword,
+		true,
+		CrosstermColor::Yellow,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_squash(DisplayColor::ActionSquash, false, CrosstermColor::Cyan, CrosstermColor::Reset)]
+	#[case::action_squash_selected(
+		DisplayColor::ActionSquash,
+		true,
+		CrosstermColor::Cyan,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_label(DisplayColor::ActionLabel, false, CrosstermColor::DarkYellow, CrosstermColor::Reset)]
+	#[case::action_label_selected(
+		DisplayColor::ActionLabel,
+		true,
+		CrosstermColor::DarkYellow,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_reset(DisplayColor::ActionReset, false, CrosstermColor::DarkYellow, CrosstermColor::Reset)]
+	#[case::action_reset_selected(
+		DisplayColor::ActionReset,
+		true,
+		CrosstermColor::DarkYellow,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::action_merge(DisplayColor::ActionMerge, false, CrosstermColor::DarkYellow, CrosstermColor::Reset)]
+	#[case::action_merge_selected(
+		DisplayColor::ActionMerge,
+		true,
+		CrosstermColor::DarkYellow,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::normal(DisplayColor::Normal, false, CrosstermColor::Reset, CrosstermColor::Reset)]
+	#[case::normal_selected(DisplayColor::Normal, true, CrosstermColor::Reset, CrosstermColor::AnsiValue(237))]
+	#[case::indicator(DisplayColor::IndicatorColor, false, CrosstermColor::Cyan, CrosstermColor::Reset)]
+	#[case::indicator_selected(
+		DisplayColor::IndicatorColor,
+		true,
+		CrosstermColor::Cyan,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::diff_add(DisplayColor::DiffAddColor, false, CrosstermColor::Green, CrosstermColor::Reset)]
+	#[case::diff_add_selected(
+		DisplayColor::DiffAddColor,
+		true,
+		CrosstermColor::Green,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::diff_remove(DisplayColor::DiffRemoveColor, false, CrosstermColor::Red, CrosstermColor::Reset)]
+	#[case::diff_remove_selected(
+		DisplayColor::DiffRemoveColor,
+		true,
+		CrosstermColor::Red,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::diff_change(DisplayColor::DiffChangeColor, false, CrosstermColor::Yellow, CrosstermColor::Reset)]
+	#[case::diff_change_selected(
+		DisplayColor::DiffChangeColor,
+		true,
+		CrosstermColor::Yellow,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::diff_context(DisplayColor::DiffContextColor, false, CrosstermColor::White, CrosstermColor::Reset)]
+	#[case::diff_context_selected(
+		DisplayColor::DiffContextColor,
+		true,
+		CrosstermColor::White,
+		CrosstermColor::AnsiValue(237)
+	)]
+	#[case::diff_whitespace(
+		DisplayColor::DiffWhitespaceColor,
+		false,
+		CrosstermColor::DarkGrey,
+		CrosstermColor::Reset
+	)]
+	#[case::diff_whitespace_selected(
+		DisplayColor::DiffWhitespaceColor,
+		true,
+		CrosstermColor::DarkGrey,
+		CrosstermColor::AnsiValue(237)
 	)]
 	fn color(
-		display_color: DisplayColor,
-		selected: bool,
-		expected_foreground: CrosstermColor,
-		expected_background: CrosstermColor,
+		#[case] display_color: DisplayColor,
+		#[case] selected: bool,
+		#[case] expected_foreground: CrosstermColor,
+		#[case] expected_background: CrosstermColor,
 	) {
 		let mut display = Display::new(CrossTerm::new(), &create_theme());
 		display.color(display_color, selected).unwrap();
@@ -604,20 +589,16 @@ mod tests {
 			.is_colors_enabled(Colors::new(expected_foreground, expected_background)));
 	}
 
-	#[rstest(
-		dim,
-		underline,
-		reverse,
-		case::all_off(false, false, false),
-		case::reverse(false, false, true),
-		case::underline(false, true, false),
-		case::underline_reverse(false, true, true),
-		case::dim(true, false, false),
-		case::dim_reverse(true, false, true),
-		case::dim_underline(true, true, false),
-		case::all_on(true, true, true)
-	)]
-	fn style(dim: bool, underline: bool, reverse: bool) {
+	#[rstest]
+	#[case::all_off(false, false, false)]
+	#[case::reverse(false, false, true)]
+	#[case::underline(false, true, false)]
+	#[case::underline_reverse(false, true, true)]
+	#[case::dim(true, false, false)]
+	#[case::dim_reverse(true, false, true)]
+	#[case::dim_underline(true, true, false)]
+	#[case::all_on(true, true, true)]
+	fn style(#[case] dim: bool, #[case] underline: bool, #[case] reverse: bool) {
 		let mut display = Display::new(CrossTerm::new(), &create_theme());
 		display.set_style(dim, underline, reverse).unwrap();
 		assert_eq!(display.tui.is_dimmed(), dim);

--- a/src/display/src/utils.rs
+++ b/src/display/src/utils.rs
@@ -335,43 +335,38 @@ mod tests {
 		set_var("WT_SESSION", "32a25081-6745-4b65-909d-e8257bdbe852");
 		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
 	}
-	#[rstest(
-		red,
-		green,
-		blue,
-		expected_index,
-		case::black(0, 0, 0, 0),
-		case::black(0, 0, 127, 0),
-		case::black(0, 127, 0, 0),
-		case::black(127, 0, 0, 0),
-		case::black(127, 0, 127, 0),
-		case::black(127, 127, 0, 0),
-		case::black(127, 127, 127, 0),
-		case::red(128, 0, 0, 1),
-		case::red(255, 0, 0, 1),
-		case::green(0, 128, 0, 2),
-		case::green(0, 255, 0, 2),
-		case::blue(0, 0, 128, 4),
-		case::blue(0, 0, 255, 4),
-		case::yellow(128, 128, 0, 3),
-		case::yellow(128, 255, 0, 3),
-		case::yellow(255, 255, 0, 3),
-		case::cyan(0, 128, 128, 6),
-		case::cyan(0, 128, 255, 6),
-		case::cyan(0, 255, 255, 6),
-		case::magenta(128, 0, 128, 5),
-		case::magenta(128, 0, 255, 5),
-		case::magenta(255, 0, 255, 5),
-		case::white(128, 128, 128, 7),
-		case::white(128, 128, 255, 7),
-		case::white(128, 255, 128, 7),
-		case::white(128, 255, 255, 7),
-		case::white(155, 128, 128, 7),
-		case::white(155, 128, 255, 7),
-		case::white(155, 255, 128, 7),
-		case::white(155, 255, 255, 7)
-	)]
-	fn find_color_three_bit_rgb(red: u8, green: u8, blue: u8, expected_index: u8) {
+	#[rstest]
+	#[case::black(0, 0, 0, 0)]
+	#[case::black(0, 0, 127, 0)]
+	#[case::black(0, 127, 0, 0)]
+	#[case::black(127, 0, 0, 0)]
+	#[case::black(127, 0, 127, 0)]
+	#[case::black(127, 127, 0, 0)]
+	#[case::black(127, 127, 127, 0)]
+	#[case::red(128, 0, 0, 1)]
+	#[case::red(255, 0, 0, 1)]
+	#[case::green(0, 128, 0, 2)]
+	#[case::green(0, 255, 0, 2)]
+	#[case::blue(0, 0, 128, 4)]
+	#[case::blue(0, 0, 255, 4)]
+	#[case::yellow(128, 128, 0, 3)]
+	#[case::yellow(128, 255, 0, 3)]
+	#[case::yellow(255, 255, 0, 3)]
+	#[case::cyan(0, 128, 128, 6)]
+	#[case::cyan(0, 128, 255, 6)]
+	#[case::cyan(0, 255, 255, 6)]
+	#[case::magenta(128, 0, 128, 5)]
+	#[case::magenta(128, 0, 255, 5)]
+	#[case::magenta(255, 0, 255, 5)]
+	#[case::white(128, 128, 128, 7)]
+	#[case::white(128, 128, 255, 7)]
+	#[case::white(128, 255, 128, 7)]
+	#[case::white(128, 255, 255, 7)]
+	#[case::white(155, 128, 128, 7)]
+	#[case::white(155, 128, 255, 7)]
+	#[case::white(155, 255, 128, 7)]
+	#[case::white(155, 255, 255, 7)]
+	fn find_color_three_bit_rgb(#[case] red: u8, #[case] green: u8, #[case] blue: u8, #[case] expected_index: u8) {
 		let color = Color::Rgb { red, green, blue };
 		assert_eq!(
 			find_color(ColorMode::ThreeBit, color),
@@ -379,65 +374,57 @@ mod tests {
 		);
 	}
 
-	#[rstest(
-		color,
-		expected,
-		case::dark_black(Color::DarkBlack, CrosstermColor::Black),
-		case::dark_blue(Color::DarkBlue, CrosstermColor::Blue),
-		case::dark_cyan(Color::DarkCyan, CrosstermColor::Cyan),
-		case::dark_green(Color::DarkGreen, CrosstermColor::Green),
-		case::dark_magenta(Color::DarkMagenta, CrosstermColor::Magenta),
-		case::dark_red(Color::DarkRed, CrosstermColor::Red),
-		case::dark_white(Color::DarkWhite, CrosstermColor::White),
-		case::dark_white(Color::DarkGrey, CrosstermColor::Grey),
-		case::dark_yellow(Color::DarkYellow, CrosstermColor::Yellow),
-		case::light_black(Color::LightBlack, CrosstermColor::DarkGrey),
-		case::light_grey(Color::LightGrey, CrosstermColor::White),
-		case::light_blue(Color::LightBlue, CrosstermColor::Blue),
-		case::light_cyan(Color::LightCyan, CrosstermColor::Cyan),
-		case::light_green(Color::LightGreen, CrosstermColor::Green),
-		case::light_magenta(Color::LightMagenta, CrosstermColor::Magenta),
-		case::light_red(Color::LightRed, CrosstermColor::Red),
-		case::light_white(Color::LightWhite, CrosstermColor::White),
-		case::light_yellow(Color::LightYellow, CrosstermColor::Yellow),
-		case::default(Color::Default, CrosstermColor::Reset)
-	)]
-	fn find_color_three_bit_color(color: Color, expected: CrosstermColor) {
+	#[rstest]
+	#[case::dark_black(Color::DarkBlack, CrosstermColor::Black)]
+	#[case::dark_blue(Color::DarkBlue, CrosstermColor::Blue)]
+	#[case::dark_cyan(Color::DarkCyan, CrosstermColor::Cyan)]
+	#[case::dark_green(Color::DarkGreen, CrosstermColor::Green)]
+	#[case::dark_magenta(Color::DarkMagenta, CrosstermColor::Magenta)]
+	#[case::dark_red(Color::DarkRed, CrosstermColor::Red)]
+	#[case::dark_white(Color::DarkWhite, CrosstermColor::White)]
+	#[case::dark_white(Color::DarkGrey, CrosstermColor::Grey)]
+	#[case::dark_yellow(Color::DarkYellow, CrosstermColor::Yellow)]
+	#[case::light_black(Color::LightBlack, CrosstermColor::DarkGrey)]
+	#[case::light_grey(Color::LightGrey, CrosstermColor::White)]
+	#[case::light_blue(Color::LightBlue, CrosstermColor::Blue)]
+	#[case::light_cyan(Color::LightCyan, CrosstermColor::Cyan)]
+	#[case::light_green(Color::LightGreen, CrosstermColor::Green)]
+	#[case::light_magenta(Color::LightMagenta, CrosstermColor::Magenta)]
+	#[case::light_red(Color::LightRed, CrosstermColor::Red)]
+	#[case::light_white(Color::LightWhite, CrosstermColor::White)]
+	#[case::light_yellow(Color::LightYellow, CrosstermColor::Yellow)]
+	#[case::default(Color::Default, CrosstermColor::Reset)]
+	fn find_color_three_bit_color(#[case] color: Color, #[case] expected: CrosstermColor) {
 		assert_eq!(find_color(ColorMode::ThreeBit, color), expected);
 	}
 
-	#[rstest(
-		red,
-		green,
-		blue,
-		expected_index,
-		case::black(0, 0, 0, 16),
-		case::black(1, 1, 1, 16),
-		case::black(4, 4, 4, 16),
-		case::black(7, 7, 7, 16),
-		case::grey(8, 8, 8, 232),
-		case::grey(16, 16, 16, 232),
-		case::grey(32, 32, 32, 234),
-		case::grey(64, 64, 64, 237),
-		case::grey(128, 128, 128, 244),
-		case::grey(246, 246, 246, 255),
-		case::white(247, 247, 247, 231),
-		case::white(248, 248, 248, 231),
-		case::white(253, 253, 253, 231),
-		case::white(255, 255, 255, 231),
-		case::base(255, 0, 0, 196),
-		case::base(0, 255, 0, 46),
-		case::base(0, 0, 255, 21),
-		case::base(0, 255, 255, 51),
-		case::base(255, 0, 255, 201),
-		case::base(255, 255, 0, 226),
-		case::sample(127, 0, 0, 88),
-		case::sample(0, 127, 0, 28),
-		case::sample(0, 0, 127, 18),
-		case::sample(127, 0, 127, 90),
-		case::sample(255, 95, 0, 208)
-	)]
-	fn find_color_four_bit_rgb(red: u8, green: u8, blue: u8, expected_index: u8) {
+	#[rstest]
+	#[case::black(0, 0, 0, 16)]
+	#[case::black(1, 1, 1, 16)]
+	#[case::black(4, 4, 4, 16)]
+	#[case::black(7, 7, 7, 16)]
+	#[case::grey(8, 8, 8, 232)]
+	#[case::grey(16, 16, 16, 232)]
+	#[case::grey(32, 32, 32, 234)]
+	#[case::grey(64, 64, 64, 237)]
+	#[case::grey(128, 128, 128, 244)]
+	#[case::grey(246, 246, 246, 255)]
+	#[case::white(247, 247, 247, 231)]
+	#[case::white(248, 248, 248, 231)]
+	#[case::white(253, 253, 253, 231)]
+	#[case::white(255, 255, 255, 231)]
+	#[case::base(255, 0, 0, 196)]
+	#[case::base(0, 255, 0, 46)]
+	#[case::base(0, 0, 255, 21)]
+	#[case::base(0, 255, 255, 51)]
+	#[case::base(255, 0, 255, 201)]
+	#[case::base(255, 255, 0, 226)]
+	#[case::sample(127, 0, 0, 88)]
+	#[case::sample(0, 127, 0, 28)]
+	#[case::sample(0, 0, 127, 18)]
+	#[case::sample(127, 0, 127, 90)]
+	#[case::sample(255, 95, 0, 208)]
+	fn find_color_four_bit_rgb(#[case] red: u8, #[case] green: u8, #[case] blue: u8, #[case] expected_index: u8) {
 		let color = Color::Rgb { red, green, blue };
 		assert_eq!(
 			find_color(ColorMode::FourBit, color),
@@ -445,53 +432,46 @@ mod tests {
 		);
 	}
 
-	#[rstest(
-		color,
-		expected,
-		case::dark_black(Color::DarkBlack, CrosstermColor::Black),
-		case::dark_blue(Color::DarkBlue, CrosstermColor::DarkBlue),
-		case::dark_cyan(Color::DarkCyan, CrosstermColor::DarkCyan),
-		case::dark_green(Color::DarkGreen, CrosstermColor::DarkGreen),
-		case::dark_magenta(Color::DarkMagenta, CrosstermColor::DarkMagenta),
-		case::dark_red(Color::DarkRed, CrosstermColor::DarkRed),
-		case::dark_white(Color::DarkWhite, CrosstermColor::Grey),
-		case::dark_white(Color::DarkGrey, CrosstermColor::DarkGrey),
-		case::dark_yellow(Color::DarkYellow, CrosstermColor::DarkYellow),
-		case::light_black(Color::LightBlack, CrosstermColor::DarkGrey),
-		case::light_grey(Color::LightGrey, CrosstermColor::White),
-		case::light_blue(Color::LightBlue, CrosstermColor::Blue),
-		case::light_cyan(Color::LightCyan, CrosstermColor::Cyan),
-		case::light_green(Color::LightGreen, CrosstermColor::Green),
-		case::light_magenta(Color::LightMagenta, CrosstermColor::Magenta),
-		case::light_red(Color::LightRed, CrosstermColor::Red),
-		case::light_white(Color::LightWhite, CrosstermColor::White),
-		case::light_yellow(Color::LightYellow, CrosstermColor::Yellow),
-		case::default(Color::Default, CrosstermColor::Reset)
-	)]
-	fn find_color_four_bit_color(color: Color, expected: CrosstermColor) {
+	#[rstest]
+	#[case::dark_black(Color::DarkBlack, CrosstermColor::Black)]
+	#[case::dark_blue(Color::DarkBlue, CrosstermColor::DarkBlue)]
+	#[case::dark_cyan(Color::DarkCyan, CrosstermColor::DarkCyan)]
+	#[case::dark_green(Color::DarkGreen, CrosstermColor::DarkGreen)]
+	#[case::dark_magenta(Color::DarkMagenta, CrosstermColor::DarkMagenta)]
+	#[case::dark_red(Color::DarkRed, CrosstermColor::DarkRed)]
+	#[case::dark_white(Color::DarkWhite, CrosstermColor::Grey)]
+	#[case::dark_white(Color::DarkGrey, CrosstermColor::DarkGrey)]
+	#[case::dark_yellow(Color::DarkYellow, CrosstermColor::DarkYellow)]
+	#[case::light_black(Color::LightBlack, CrosstermColor::DarkGrey)]
+	#[case::light_grey(Color::LightGrey, CrosstermColor::White)]
+	#[case::light_blue(Color::LightBlue, CrosstermColor::Blue)]
+	#[case::light_cyan(Color::LightCyan, CrosstermColor::Cyan)]
+	#[case::light_green(Color::LightGreen, CrosstermColor::Green)]
+	#[case::light_magenta(Color::LightMagenta, CrosstermColor::Magenta)]
+	#[case::light_red(Color::LightRed, CrosstermColor::Red)]
+	#[case::light_white(Color::LightWhite, CrosstermColor::White)]
+	#[case::light_yellow(Color::LightYellow, CrosstermColor::Yellow)]
+	#[case::default(Color::Default, CrosstermColor::Reset)]
+	fn find_color_four_bit_color(#[case] color: Color, #[case] expected: CrosstermColor) {
 		assert_eq!(find_color(ColorMode::FourBit, color), expected);
 	}
 
-	#[rstest(
-		red,
-		green,
-		blue,
-		case::black(0, 0, 0),
-		case::grey(128, 128, 128),
-		case::white(255, 255, 255),
-		case::base(255, 0, 0),
-		case::base(0, 255, 0),
-		case::base(0, 0, 255),
-		case::base(0, 255, 255),
-		case::base(255, 0, 255),
-		case::base(255, 255, 0),
-		case::sample(127, 0, 0),
-		case::sample(0, 127, 0),
-		case::sample(0, 0, 127),
-		case::sample(127, 0, 127),
-		case::sample(255, 95, 0)
-	)]
-	fn find_color_true_rgb(red: u8, green: u8, blue: u8) {
+	#[rstest]
+	#[case::black(0, 0, 0)]
+	#[case::grey(128, 128, 128)]
+	#[case::white(255, 255, 255)]
+	#[case::base(255, 0, 0)]
+	#[case::base(0, 255, 0)]
+	#[case::base(0, 0, 255)]
+	#[case::base(0, 255, 255)]
+	#[case::base(255, 0, 255)]
+	#[case::base(255, 255, 0)]
+	#[case::sample(127, 0, 0)]
+	#[case::sample(0, 127, 0)]
+	#[case::sample(0, 0, 127)]
+	#[case::sample(127, 0, 127)]
+	#[case::sample(255, 95, 0)]
+	fn find_color_true_rgb(#[case] red: u8, #[case] green: u8, #[case] blue: u8) {
 		let color = Color::Rgb { red, green, blue };
 		assert_eq!(find_color(ColorMode::TrueColor, color), CrosstermColor::Rgb {
 			r: red,

--- a/src/input/Cargo.toml
+++ b/src/input/Cargo.toml
@@ -20,7 +20,7 @@ crossterm = "0.20.0"
 girt-config = {version = "1.0.0", path = "../config"}
 
 [dev-dependencies]
-rstest = "0.6.4"
+rstest = "0.10.0"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/src/input/src/event_handler.rs
+++ b/src/input/src/event_handler.rs
@@ -175,23 +175,20 @@ mod tests {
 		assert_eq!(event_handler.poll_event(), Event::None);
 	}
 
-	#[rstest(
-		event,
-		handled,
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('c'),
-			modifiers: KeyModifiers::CONTROL,
-		}), true),
-		case::resize(Event::Resize(100, 100), false),
-		case::movement(Event::from(KeyCode::Up), false),
-		case::help(Event::from('?'), false),
-		case::undo_redo(Event::Key(KeyEvent {
-			code: KeyCode::Char('z'),
-			modifiers: KeyModifiers::CONTROL,
-		}), false),
-		case::other(Event::from('a'), false),
-	)]
-	fn read_event_options_disabled(event: Event, handled: bool) {
+	#[rstest]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('c'),
+		modifiers: KeyModifiers::CONTROL,
+	}), true)]
+	#[case::resize(Event::Resize(100, 100), false)]
+	#[case::movement(Event::from(KeyCode::Up), false)]
+	#[case::help(Event::from('?'), false)]
+	#[case::undo_redo(Event::Key(KeyEvent {
+		code: KeyCode::Char('z'),
+		modifiers: KeyModifiers::CONTROL,
+	}), false)]
+	#[case::other(Event::from('a'), false)]
+	fn read_event_options_disabled(#[case] event: Event, #[case] handled: bool) {
 		with_event_handler(&[event], |context| {
 			let result = context
 				.event_handler
@@ -206,23 +203,20 @@ mod tests {
 		});
 	}
 
-	#[rstest(
-		event,
-		handled,
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('c'),
-			modifiers: KeyModifiers::CONTROL,
-		}), true),
-		case::resize(Event::Resize(100, 100), true),
-		case::movement(Event::from(KeyCode::Up), true),
-		case::help(Event::from('?'), true),
-		case::undo_redo(Event::Key(KeyEvent {
-			code: KeyCode::Char('z'),
-			modifiers: KeyModifiers::CONTROL,
-		}), true),
-		case::other(Event::from('a'), false),
-	)]
-	fn read_event_enabled(event: Event, handled: bool) {
+	#[rstest]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('c'),
+		modifiers: KeyModifiers::CONTROL,
+	}), true)]
+	#[case::resize(Event::Resize(100, 100), true)]
+	#[case::movement(Event::from(KeyCode::Up), true)]
+	#[case::help(Event::from('?'), true)]
+	#[case::undo_redo(Event::Key(KeyEvent {
+		code: KeyCode::Char('z'),
+		modifiers: KeyModifiers::CONTROL,
+	}), true)]
+	#[case::other(Event::from('a'), false)]
+	fn read_event_enabled(#[case] event: Event, #[case] handled: bool) {
 		with_event_handler(&[event], |context| {
 			let result = context.event_handler.read_event(
 				&InputOptions::new().movement(true).help(true).undo_redo(true),
@@ -238,20 +232,17 @@ mod tests {
 		});
 	}
 
-	#[rstest(
-		event,
-		expected,
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('c'),
-			modifiers: KeyModifiers::CONTROL,
-		}), Event::from(MetaEvent::Kill)),
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('d'),
-			modifiers: KeyModifiers::CONTROL,
-		}), Event::from(MetaEvent::Exit)),
-		case::other(Event::from('a'), Event::from(KeyCode::Null)),
-	)]
-	fn standard_inputs(event: Event, expected: Event) {
+	#[rstest]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('c'),
+		modifiers: KeyModifiers::CONTROL,
+	}), Event::from(MetaEvent::Kill))]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('d'),
+		modifiers: KeyModifiers::CONTROL,
+	}), Event::from(MetaEvent::Exit))]
+	#[case::other(Event::from('a'), Event::from(KeyCode::Null))]
+	fn standard_inputs(#[case] event: Event, #[case] expected: Event) {
 		with_event_handler(&[event], |context| {
 			let result = context
 				.event_handler
@@ -261,20 +252,17 @@ mod tests {
 		});
 	}
 
-	#[rstest(
-		event,
-		expected,
-		case::standard(Event::from(KeyCode::Up), Event::from(MetaEvent::ScrollUp)),
-		case::standard(Event::from(KeyCode::Down), Event::from(MetaEvent::ScrollDown)),
-		case::standard(Event::from(KeyCode::Left), Event::from(MetaEvent::ScrollLeft)),
-		case::standard(Event::from(KeyCode::Right), Event::from(MetaEvent::ScrollRight)),
-		case::standard(Event::from(KeyCode::PageUp), Event::from(MetaEvent::ScrollJumpUp)),
-		case::standard(Event::from(KeyCode::PageDown), Event::from(MetaEvent::ScrollJumpDown)),
-		case::standard(Event::from(KeyCode::Home), Event::from(MetaEvent::ScrollTop)),
-		case::standard(Event::from(KeyCode::End), Event::from(MetaEvent::ScrollBottom)),
-		case::other(Event::from('a'), Event::from(KeyCode::Null))
-	)]
-	fn movement_inputs(event: Event, expected: Event) {
+	#[rstest]
+	#[case::standard(Event::from(KeyCode::Up), Event::from(MetaEvent::ScrollUp))]
+	#[case::standard(Event::from(KeyCode::Down), Event::from(MetaEvent::ScrollDown))]
+	#[case::standard(Event::from(KeyCode::Left), Event::from(MetaEvent::ScrollLeft))]
+	#[case::standard(Event::from(KeyCode::Right), Event::from(MetaEvent::ScrollRight))]
+	#[case::standard(Event::from(KeyCode::PageUp), Event::from(MetaEvent::ScrollJumpUp))]
+	#[case::standard(Event::from(KeyCode::PageDown), Event::from(MetaEvent::ScrollJumpDown))]
+	#[case::standard(Event::from(KeyCode::Home), Event::from(MetaEvent::ScrollTop))]
+	#[case::standard(Event::from(KeyCode::End), Event::from(MetaEvent::ScrollBottom))]
+	#[case::other(Event::from('a'), Event::from(KeyCode::Null))]
+	fn movement_inputs(#[case] event: Event, #[case] expected: Event) {
 		with_event_handler(&[event], |context| {
 			let result = context
 				.event_handler
@@ -284,20 +272,17 @@ mod tests {
 		});
 	}
 
-	#[rstest(
-		event,
-		expected,
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('z'),
-			modifiers: KeyModifiers::CONTROL,
-		}), Event::from(MetaEvent::Undo)),
-		case::standard(Event::Key(KeyEvent {
-			code: KeyCode::Char('y'),
-			modifiers: KeyModifiers::CONTROL,
-		}), Event::from(MetaEvent::Redo)),
-		case::other(Event::from('a'), Event::from(KeyCode::Null))
-	)]
-	fn undo_redo_inputs(event: Event, expected: Event) {
+	#[rstest]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('z'),
+		modifiers: KeyModifiers::CONTROL,
+	}), Event::from(MetaEvent::Undo))]
+	#[case::standard(Event::Key(KeyEvent {
+		code: KeyCode::Char('y'),
+		modifiers: KeyModifiers::CONTROL,
+	}), Event::from(MetaEvent::Redo))]
+	#[case::other(Event::from('a'), Event::from(KeyCode::Null))]
+	fn undo_redo_inputs(#[case] event: Event, #[case] expected: Event) {
 		with_event_handler(&[event], |context| {
 			let result = context
 				.event_handler

--- a/src/input/src/key_bindings.rs
+++ b/src/input/src/key_bindings.rs
@@ -183,29 +183,26 @@ mod tests {
 		)]);
 	}
 
-	#[rstest(
-		binding,
-		key_code,
-		case::backspace("Backspace", KeyCode::Backspace),
-		case::back_tab("BackTab", KeyCode::BackTab),
-		case::delete("Delete", KeyCode::Delete),
-		case::down("Down", KeyCode::Down),
-		case::end("End", KeyCode::End),
-		case::enter("Enter", KeyCode::Enter),
-		case::esc("Esc", KeyCode::Esc),
-		case::home("Home", KeyCode::Home),
-		case::insert("Insert", KeyCode::Insert),
-		case::left("Left", KeyCode::Left),
-		case::page_down("PageDown", KeyCode::PageDown),
-		case::page_up("PageUp", KeyCode::PageUp),
-		case::right("Right", KeyCode::Right),
-		case::tab("Tab", KeyCode::Tab),
-		case::up("Up", KeyCode::Up),
-		case::function_in_range("F10", KeyCode::F(10)),
-		case::function_out_of_range("F10000", KeyCode::F(1)),
-		case::char("a", KeyCode::Char('a'))
-	)]
-	fn map_keybindings_key_code(binding: &str, key_code: KeyCode) {
+	#[rstest]
+	#[case::backspace("Backspace", KeyCode::Backspace)]
+	#[case::back_tab("BackTab", KeyCode::BackTab)]
+	#[case::delete("Delete", KeyCode::Delete)]
+	#[case::down("Down", KeyCode::Down)]
+	#[case::end("End", KeyCode::End)]
+	#[case::enter("Enter", KeyCode::Enter)]
+	#[case::esc("Esc", KeyCode::Esc)]
+	#[case::home("Home", KeyCode::Home)]
+	#[case::insert("Insert", KeyCode::Insert)]
+	#[case::left("Left", KeyCode::Left)]
+	#[case::page_down("PageDown", KeyCode::PageDown)]
+	#[case::page_up("PageUp", KeyCode::PageUp)]
+	#[case::right("Right", KeyCode::Right)]
+	#[case::tab("Tab", KeyCode::Tab)]
+	#[case::up("Up", KeyCode::Up)]
+	#[case::function_in_range("F10", KeyCode::F(10))]
+	#[case::function_out_of_range("F10000", KeyCode::F(1))]
+	#[case::char("a", KeyCode::Char('a'))]
+	fn map_keybindings_key_code(#[case] binding: &str, #[case] key_code: KeyCode) {
 		assert_eq!(map_keybindings(&[String::from(binding)]), vec![Event::from(key_code)]);
 	}
 }

--- a/src/todo_file/src/action.rs
+++ b/src/todo_file/src/action.rs
@@ -201,23 +201,20 @@ mod tests {
 	test_action_to_abbreviation!(t, Action::Reset, "t");
 	test_action_to_abbreviation!(m, Action::Merge, "m");
 
-	#[rstest(
-		action,
-		expected,
-		case::break_action(Action::Break, true),
-		case::drop(Action::Drop, false),
-		case::edit(Action::Edit, false),
-		case::exec(Action::Exec, true),
-		case::fixup(Action::Fixup, false),
-		case::noop(Action::Noop, true),
-		case::pick(Action::Pick, false),
-		case::reword(Action::Reword, false),
-		case::squash(Action::Squash, false),
-		case::squash(Action::Label, true),
-		case::squash(Action::Reset, true),
-		case::squash(Action::Merge, true)
-	)]
-	fn module_lifecycle(action: Action, expected: bool) {
+	#[rstest]
+	#[case::break_action(Action::Break, true)]
+	#[case::drop(Action::Drop, false)]
+	#[case::edit(Action::Edit, false)]
+	#[case::exec(Action::Exec, true)]
+	#[case::fixup(Action::Fixup, false)]
+	#[case::noop(Action::Noop, true)]
+	#[case::pick(Action::Pick, false)]
+	#[case::reword(Action::Reword, false)]
+	#[case::squash(Action::Squash, false)]
+	#[case::squash(Action::Label, true)]
+	#[case::squash(Action::Reset, true)]
+	#[case::squash(Action::Merge, true)]
+	fn module_lifecycle(#[case] action: Action, #[case] expected: bool) {
 		assert_eq!(action.is_static(), expected);
 	}
 }

--- a/src/todo_file/src/line.rs
+++ b/src/todo_file/src/line.rs
@@ -214,89 +214,86 @@ mod tests {
 
 	use super::*;
 
-	#[rstest(
-		line,
-		expected,
-		case::pick_action("pick aaa comment", &Line {
-			action: Action::Pick,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::reword_action("reword aaa comment", &Line {
-			action: Action::Reword,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::edit_action("edit aaa comment", &Line {
-			action: Action::Edit,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::squash_action("squash aaa comment", &Line {
-			action: Action::Squash,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::fixup_action("fixup aaa comment", &Line {
-			action: Action::Fixup,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::drop_action("drop aaa comment", &Line {
-			action: Action::Drop,
-			hash: String::from("aaa"),
-			content: String::from("comment"),
-			mutated: false,
-		}),
-		case::action_without_comment("pick aaa", &Line {
-			action: Action::Pick,
-			hash: String::from("aaa"),
-			content: String::from(""),
-			mutated: false,
-		}),
-		case::exec_action("exec command", &Line {
-			action: Action::Exec,
-			hash: String::from(""),
-			content: String::from("command"),
-			mutated: false,
-		}),
-		case::label_action("label ref", &Line {
-			action: Action::Label,
-			hash: String::from(""),
-			content: String::from("ref"),
-			mutated: false,
-		}),
-		case::reset_action("reset ref", &Line {
-			action: Action::Reset,
-			hash: String::from(""),
-			content: String::from("ref"),
-			mutated: false,
-		}),
-		case::reset_action("merge command", &Line {
-			action: Action::Merge,
-			hash: String::from(""),
-			content: String::from("command"),
-			mutated: false,
-		}),
-		case::break_action("break", &Line {
-			action: Action::Break,
-			hash: String::from(""),
-			content: String::from(""),
-			mutated: false,
-		}),
-		case::nnop( "noop", &Line {
-			action: Action::Noop,
-			hash: String::from(""),
-			content: String::from(""),
-			mutated: false,
-		}),
-	)]
-	fn new(line: &str, expected: &Line) {
+	#[rstest]
+	#[case::pick_action("pick aaa comment", &Line {
+		action: Action::Pick,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::reword_action("reword aaa comment", &Line {
+		action: Action::Reword,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::edit_action("edit aaa comment", &Line {
+		action: Action::Edit,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::squash_action("squash aaa comment", &Line {
+		action: Action::Squash,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::fixup_action("fixup aaa comment", &Line {
+		action: Action::Fixup,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::drop_action("drop aaa comment", &Line {
+		action: Action::Drop,
+		hash: String::from("aaa"),
+		content: String::from("comment"),
+		mutated: false,
+	})]
+	#[case::action_without_comment("pick aaa", &Line {
+		action: Action::Pick,
+		hash: String::from("aaa"),
+		content: String::from(""),
+		mutated: false,
+	})]
+	#[case::exec_action("exec command", &Line {
+		action: Action::Exec,
+		hash: String::from(""),
+		content: String::from("command"),
+		mutated: false,
+	})]
+	#[case::label_action("label ref", &Line {
+		action: Action::Label,
+		hash: String::from(""),
+		content: String::from("ref"),
+		mutated: false,
+	})]
+	#[case::reset_action("reset ref", &Line {
+		action: Action::Reset,
+		hash: String::from(""),
+		content: String::from("ref"),
+		mutated: false,
+	})]
+	#[case::reset_action("merge command", &Line {
+		action: Action::Merge,
+		hash: String::from(""),
+		content: String::from("command"),
+		mutated: false,
+	})]
+	#[case::break_action("break", &Line {
+		action: Action::Break,
+		hash: String::from(""),
+		content: String::from(""),
+		mutated: false,
+	})]
+	#[case::nnop( "noop", &Line {
+		action: Action::Noop,
+		hash: String::from(""),
+		content: String::from(""),
+		mutated: false,
+	})]
+	fn new(#[case] line: &str, #[case] expected: &Line) {
 		assert_eq!(&Line::new(line).unwrap(), expected);
 	}
 
@@ -360,54 +357,45 @@ mod tests {
 		});
 	}
 
-	#[rstest(
-		line,
-		expected_err,
-		case::invalid_action("invalid aaa comment", "Invalid action: invalid"),
-		case::invalid_line_only("invalid", "Invalid line: invalid"),
-		case::pick_line_only("pick", "Invalid line: pick"),
-		case::reword_line_only("reword", "Invalid line: reword"),
-		case::edit_line_only("edit", "Invalid line: edit"),
-		case::squash_line_only("squash", "Invalid line: squash"),
-		case::fixup_line_only("fixup", "Invalid line: fixup"),
-		case::exec_line_only("exec", "Invalid line: exec"),
-		case::drop_line_only("drop", "Invalid line: drop"),
-		case::label_line_only("label", "Invalid line: label"),
-		case::reset_line_only("reset", "Invalid line: reset"),
-		case::merge_line_only("merge", "Invalid line: merge")
-	)]
-	fn new_err(line: &str, expected_err: &str) {
+	#[rstest]
+	#[case::invalid_action("invalid aaa comment", "Invalid action: invalid")]
+	#[case::invalid_line_only("invalid", "Invalid line: invalid")]
+	#[case::pick_line_only("pick", "Invalid line: pick")]
+	#[case::reword_line_only("reword", "Invalid line: reword")]
+	#[case::edit_line_only("edit", "Invalid line: edit")]
+	#[case::squash_line_only("squash", "Invalid line: squash")]
+	#[case::fixup_line_only("fixup", "Invalid line: fixup")]
+	#[case::exec_line_only("exec", "Invalid line: exec")]
+	#[case::drop_line_only("drop", "Invalid line: drop")]
+	#[case::label_line_only("label", "Invalid line: label")]
+	#[case::reset_line_only("reset", "Invalid line: reset")]
+	#[case::merge_line_only("merge", "Invalid line: merge")]
+	fn new_err(#[case] line: &str, #[case] expected_err: &str) {
 		assert_eq!(Line::new(line).unwrap_err().to_string(), expected_err);
 	}
 
-	#[rstest(
-		from,
-		to,
-		case::drop(Action::Drop, Action::Fixup),
-		case::edit(Action::Edit, Action::Fixup),
-		case::fixup(Action::Fixup, Action::Pick),
-		case::pick(Action::Pick, Action::Fixup),
-		case::reword(Action::Reword, Action::Fixup),
-		case::squash(Action::Squash, Action::Fixup)
-	)]
-	fn set_action_non_static(from: Action, to: Action) {
+	#[rstest]
+	#[case::drop(Action::Drop, Action::Fixup)]
+	#[case::edit(Action::Edit, Action::Fixup)]
+	#[case::fixup(Action::Fixup, Action::Pick)]
+	#[case::pick(Action::Pick, Action::Fixup)]
+	#[case::reword(Action::Reword, Action::Fixup)]
+	#[case::squash(Action::Squash, Action::Fixup)]
+	fn set_action_non_static(#[case] from: Action, #[case] to: Action) {
 		let mut line = Line::new(format!("{} aaa bbb", from.as_string()).as_str()).unwrap();
 		line.set_action(to);
 		assert_eq!(line.action, to);
 		assert!(line.mutated);
 	}
 
-	#[rstest(
-		from,
-		to,
-		case::break_action(Action::Break, Action::Fixup),
-		case::label_action(Action::Label, Action::Fixup),
-		case::reset_action(Action::Reset, Action::Fixup),
-		case::merge_action(Action::Merge, Action::Fixup),
-		case::exec(Action::Exec, Action::Fixup),
-		case::noop(Action::Noop, Action::Fixup)
-	)]
-	fn set_action_static(from: Action, to: Action) {
+	#[rstest]
+	#[case::break_action(Action::Break, Action::Fixup)]
+	#[case::label_action(Action::Label, Action::Fixup)]
+	#[case::reset_action(Action::Reset, Action::Fixup)]
+	#[case::merge_action(Action::Merge, Action::Fixup)]
+	#[case::exec(Action::Exec, Action::Fixup)]
+	#[case::noop(Action::Noop, Action::Fixup)]
+	fn set_action_static(#[case] from: Action, #[case] to: Action) {
 		let mut line = Line::new(format!("{} comment", from.as_string()).as_str()).unwrap();
 		line.set_action(to);
 		assert_eq!(line.action, from);
@@ -430,127 +418,107 @@ mod tests {
 		assert!(!line.mutated);
 	}
 
-	#[rstest(
-		line,
-		expected,
-		case::break_action("break", ""),
-		case::drop("drop aaa comment", "comment"),
-		case::edit("edit aaa comment", "comment"),
-		case::exec("exec git commit --amend 'foo'", "new"),
-		case::fixup("fixup aaa comment", "comment"),
-		case::pick("pick aaa comment", "comment"),
-		case::reword("reword aaa comment", "comment"),
-		case::squash("squash aaa comment", "comment"),
-		case::label("label ref", "new"),
-		case::reset("reset ref", "new"),
-		case::merge("merge command", "new")
-	)]
-	fn edit_content(line: &str, expected: &str) {
+	#[rstest]
+	#[case::break_action("break", "")]
+	#[case::drop("drop aaa comment", "comment")]
+	#[case::edit("edit aaa comment", "comment")]
+	#[case::exec("exec git commit --amend 'foo'", "new")]
+	#[case::fixup("fixup aaa comment", "comment")]
+	#[case::pick("pick aaa comment", "comment")]
+	#[case::reword("reword aaa comment", "comment")]
+	#[case::squash("squash aaa comment", "comment")]
+	#[case::label("label ref", "new")]
+	#[case::reset("reset ref", "new")]
+	#[case::merge("merge command", "new")]
+	fn edit_content(#[case] line: &str, #[case] expected: &str) {
 		let mut line = Line::new(line).unwrap();
 		line.edit_content("new");
 		assert_eq!(line.get_content(), expected);
 	}
 
-	#[rstest(
-		line,
-		expected,
-		case::break_action("break", ""),
-		case::drop("drop aaa comment", "comment"),
-		case::edit("edit aaa comment", "comment"),
-		case::exec("exec git commit --amend 'foo'", "git commit --amend 'foo'"),
-		case::fixup("fixup aaa comment", "comment"),
-		case::pick("pick aaa comment", "comment"),
-		case::reword("reword aaa comment", "comment"),
-		case::squash("squash aaa comment", "comment")
-	)]
-	fn get_content(line: &str, expected: &str) {
+	#[rstest]
+	#[case::break_action("break", "")]
+	#[case::drop("drop aaa comment", "comment")]
+	#[case::edit("edit aaa comment", "comment")]
+	#[case::exec("exec git commit --amend 'foo'", "git commit --amend 'foo'")]
+	#[case::fixup("fixup aaa comment", "comment")]
+	#[case::pick("pick aaa comment", "comment")]
+	#[case::reword("reword aaa comment", "comment")]
+	#[case::squash("squash aaa comment", "comment")]
+	fn get_content(#[case] line: &str, #[case] expected: &str) {
 		assert_eq!(Line::new(line).unwrap().get_content(), expected);
 	}
 
-	#[rstest(
-		line,
-		expected,
-		case::break_action("break", Action::Break),
-		case::drop("drop aaa comment", Action::Drop),
-		case::edit("edit aaa comment", Action::Edit),
-		case::exec("exec git commit --amend 'foo'", Action::Exec),
-		case::fixup("fixup aaa comment", Action::Fixup),
-		case::pick("pick aaa comment", Action::Pick),
-		case::reword("reword aaa comment", Action::Reword),
-		case::squash("squash aaa comment", Action::Squash)
-	)]
-	fn get_action(line: &str, expected: Action) {
+	#[rstest]
+	#[case::break_action("break", Action::Break)]
+	#[case::drop("drop aaa comment", Action::Drop)]
+	#[case::edit("edit aaa comment", Action::Edit)]
+	#[case::exec("exec git commit --amend 'foo'", Action::Exec)]
+	#[case::fixup("fixup aaa comment", Action::Fixup)]
+	#[case::pick("pick aaa comment", Action::Pick)]
+	#[case::reword("reword aaa comment", Action::Reword)]
+	#[case::squash("squash aaa comment", Action::Squash)]
+	fn get_action(#[case] line: &str, #[case] expected: Action) {
 		assert_eq!(Line::new(line).unwrap().get_action(), &expected);
 	}
 
-	#[rstest(
-		line,
-		expected,
-		case::break_action("break", ""),
-		case::drop("drop aaa comment", "aaa"),
-		case::edit("edit aaa comment", "aaa"),
-		case::exec("exec git commit --amend 'foo'", ""),
-		case::fixup("fixup aaa comment", "aaa"),
-		case::pick("pick aaa comment", "aaa"),
-		case::reword("reword aaa comment", "aaa"),
-		case::squash("squash aaa comment", "aaa")
-	)]
-	fn get_hash(line: &str, expected: &str) {
+	#[rstest]
+	#[case::break_action("break", "")]
+	#[case::drop("drop aaa comment", "aaa")]
+	#[case::edit("edit aaa comment", "aaa")]
+	#[case::exec("exec git commit --amend 'foo'", "")]
+	#[case::fixup("fixup aaa comment", "aaa")]
+	#[case::pick("pick aaa comment", "aaa")]
+	#[case::reword("reword aaa comment", "aaa")]
+	#[case::squash("squash aaa comment", "aaa")]
+	fn get_hash(#[case] line: &str, #[case] expected: &str) {
 		assert_eq!(Line::new(line).unwrap().get_hash(), expected);
 	}
 
-	#[rstest(
-		line,
-		expected,
-		case::break_action("break", false),
-		case::drop("drop aaa comment", true),
-		case::edit("edit aaa comment", true),
-		case::exec("exec git commit --amend 'foo'", false),
-		case::fixup("fixup aaa comment", true),
-		case::pick("pick aaa comment", true),
-		case::reword("reword aaa comment", true),
-		case::squash("squash aaa comment", true),
-		case::label("label ref", false),
-		case::reset("reset ref", false),
-		case::merge("merge command", false)
-	)]
-	fn has_reference(line: &str, expected: bool) {
+	#[rstest]
+	#[case::break_action("break", false)]
+	#[case::drop("drop aaa comment", true)]
+	#[case::edit("edit aaa comment", true)]
+	#[case::exec("exec git commit --amend 'foo'", false)]
+	#[case::fixup("fixup aaa comment", true)]
+	#[case::pick("pick aaa comment", true)]
+	#[case::reword("reword aaa comment", true)]
+	#[case::squash("squash aaa comment", true)]
+	#[case::label("label ref", false)]
+	#[case::reset("reset ref", false)]
+	#[case::merge("merge command", false)]
+	fn has_reference(#[case] line: &str, #[case] expected: bool) {
 		assert_eq!(Line::new(line).unwrap().has_reference(), expected);
 	}
 
-	#[rstest(
-		from,
-		editable,
-		case::drop(Action::Break, false),
-		case::drop(Action::Drop, false),
-		case::edit(Action::Edit, false),
-		case::fixup(Action::Fixup, false),
-		case::pick(Action::Noop, false),
-		case::pick(Action::Pick, false),
-		case::reword(Action::Reword, false),
-		case::squash(Action::Squash, false),
-		case::squash(Action::Exec, true),
-		case::squash(Action::Label, true),
-		case::squash(Action::Reset, true),
-		case::squash(Action::Merge, true)
-	)]
-	fn is_editable(from: Action, editable: bool) {
+	#[rstest]
+	#[case::drop(Action::Break, false)]
+	#[case::drop(Action::Drop, false)]
+	#[case::edit(Action::Edit, false)]
+	#[case::fixup(Action::Fixup, false)]
+	#[case::pick(Action::Noop, false)]
+	#[case::pick(Action::Pick, false)]
+	#[case::reword(Action::Reword, false)]
+	#[case::squash(Action::Squash, false)]
+	#[case::squash(Action::Exec, true)]
+	#[case::squash(Action::Label, true)]
+	#[case::squash(Action::Reset, true)]
+	#[case::squash(Action::Merge, true)]
+	fn is_editable(#[case] from: Action, #[case] editable: bool) {
 		let line = Line::new(format!("{} aaa bbb", from.as_string()).as_str()).unwrap();
 		assert_eq!(line.is_editable(), editable);
 	}
 
-	#[rstest(
-		line,
-		case::break_action("break"),
-		case::drop("drop aaa comment"),
-		case::edit("edit aaa comment"),
-		case::exec("exec git commit --amend 'foo'"),
-		case::fixup("fixup aaa comment"),
-		case::pick("pick aaa comment"),
-		case::reword("reword aaa comment"),
-		case::squash("squash aaa comment")
-	)]
-	fn to_text(line: &str) {
+	#[rstest]
+	#[case::break_action("break")]
+	#[case::drop("drop aaa comment")]
+	#[case::edit("edit aaa comment")]
+	#[case::exec("exec git commit --amend 'foo'")]
+	#[case::fixup("fixup aaa comment")]
+	#[case::pick("pick aaa comment")]
+	#[case::reword("reword aaa comment")]
+	#[case::squash("squash aaa comment")]
+	fn to_text(#[case] line: &str) {
 		assert_eq!(Line::new(line).unwrap().to_text(), line);
 	}
 }

--- a/src/view/src/util.rs
+++ b/src/view/src/util.rs
@@ -24,17 +24,14 @@ mod tests {
 	use super::*;
 	use crate::testutil::with_view_sender;
 
-	#[rstest(
-		meta_event,
-		action,
-		case::scroll_left(MetaEvent::ScrollLeft, "ScrollLeft"),
-		case::scroll_right(MetaEvent::ScrollRight, "ScrollRight"),
-		case::scroll_down(MetaEvent::ScrollDown, "ScrollDown"),
-		case::scroll_up(MetaEvent::ScrollUp, "ScrollUp"),
-		case::jump_down(MetaEvent::ScrollJumpDown, "PageDown"),
-		case::jump_up(MetaEvent::ScrollJumpUp, "PageUp")
-	)]
-	fn handle_view_data_scroll_event(meta_event: MetaEvent, action: &str) {
+	#[rstest]
+	#[case::scroll_left(MetaEvent::ScrollLeft, "ScrollLeft")]
+	#[case::scroll_right(MetaEvent::ScrollRight, "ScrollRight")]
+	#[case::scroll_down(MetaEvent::ScrollDown, "ScrollDown")]
+	#[case::scroll_up(MetaEvent::ScrollUp, "ScrollUp")]
+	#[case::jump_down(MetaEvent::ScrollJumpDown, "PageDown")]
+	#[case::jump_up(MetaEvent::ScrollJumpUp, "PageUp")]
+	fn handle_view_data_scroll_event(#[case] meta_event: MetaEvent, #[case] action: &str) {
 		with_view_sender(|context| {
 			let event = Event::from(meta_event);
 			assert_eq!(handle_view_data_scroll(event, &context.sender), Some(event));


### PR DESCRIPTION
# Description

rstest added a better format in a recent update. This updates to use the latest version of rstest and migrates the existing usage to use the new format.