### PR TITLE
Lint was renamed

### DIFF
--- a/src/todo_file/src/lib.rs
+++ b/src/todo_file/src/lib.rs
@@ -26,7 +26,7 @@
 	missing_docs,
 	non_ascii_idents,
 	noop_method_call,
-	or_patterns_back_compat,
+	rust_2021_incompatible_or_patterns,
 	pointer_structural_match,
 	semicolon_in_expressions_from_macros,
 	single_use_lifetimes,


### PR DESCRIPTION
Prevents building with default `#[deny(warnings)]`.