### PR TITLE
Pin git2 to 0.13.21 to resolve upstream issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.22"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -276,9 +276,9 @@ checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.23+1.2.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -18,7 +18,9 @@ name = "config"
 anyhow = "1.0"
 
 [dependencies.git2]
-version = "0.13.22"
+# git2:0.13.22 pulls libgit2-sys:0.12.23+1.2.0, which causes errors on some systems
+# track: rust-lang/git2-rs#746
+version = "=0.13.21"
 default-features = false
 features = []
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -29,7 +29,9 @@ girt-todo-file = {version = "1.0.0", path = "../../src/todo_file"}
 girt-view = {version = "1.0.0", path = "../../src/view"}
 
 [dependencies.git2]
-version = "0.13.22"
+# git2:0.13.22 pulls libgit2-sys:0.12.23+1.2.0, which causes errors on some systems
+# track: rust-lang/git2-rs#746
+version = "=0.13.21"
 default-features = false
 features = []
 

--- a/src/git/Cargo.toml
+++ b/src/git/Cargo.toml
@@ -19,7 +19,9 @@ anyhow = "1.0.41"
 tempfile = "3.2.0"
 
 [dependencies.git2]
-version = "0.13.20"
+# git2:0.13.22 pulls libgit2-sys:0.12.23+1.2.0, which causes errors on some systems
+# track: rust-lang/git2-rs#746
+version = "=0.13.21"
 default-features = false
 features = []
 


### PR DESCRIPTION
# Description

Because of https://github.com/rust-lang/git2-rs/issues/746 some systems are breaking. This pins git2-rs to version 0.13.21 so that libgit2-sys:0.12.23+1.2.0 that isn't distributed to all Linux distros is used. This is only really an issue during build, since libgit2 is static linked for release builds.

Since the new features of this version bump are not used, it's safe to pin this to the older version until the new features are needed.