### PR TITLE
Fix lint errors flagged by nightly clippy

### DIFF
--- a/scripts/add-lints.bash
+++ b/scripts/add-lints.bash
@@ -99,6 +99,3 @@ for f in "${files[@]}"; do
 		p
 	' "$f"
 done
-
-
-

--- a/src/config/src/git_config.rs
+++ b/src/config/src/git_config.rs
@@ -38,13 +38,10 @@ pub struct GitConfig {
 
 impl GitConfig {
 	pub(super) fn new(git_config: &Config) -> Result<Self> {
-		let comment_char = get_string(git_config, "core.commentChar", "#")?;
-		let comment_char = if comment_char.as_str().eq("auto") {
-			String::from("#")
+		let mut comment_char = get_string(git_config, "core.commentChar", "#")?;
+		if comment_char.as_str().eq("auto") {
+			comment_char = String::from("#");
 		}
-		else {
-			comment_char
-		};
 
 		let git_diff_renames = get_string(git_config, "diff.renames", "true")?.to_lowercase();
 		let (diff_renames, diff_copies) = match git_diff_renames.to_lowercase().as_str() {

--- a/src/core/src/components/edit/mod.rs
+++ b/src/core/src/components/edit/mod.rs
@@ -72,9 +72,9 @@ impl Edit {
 		let description = self.description.as_ref();
 		self.view_data.update_view_data(|updater| {
 			updater.clear();
-			if let Some(description) = description {
+			if let Some(desc) = description {
 				updater.push_leading_line(ViewLine::from(vec![LineSegment::new_with_color(
-					description.as_str(),
+					desc.as_str(),
 					DisplayColor::IndicatorColor,
 				)]));
 				updater.push_leading_line(ViewLine::new_empty_line());

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -109,8 +109,8 @@ use crate::{
 
 #[inline]
 #[must_use]
-pub fn run(args: Vec<OsString>) -> Exit {
-	match Args::try_from(args) {
+pub fn run(os_args: Vec<OsString>) -> Exit {
+	match Args::try_from(os_args) {
 		Err(err) => err,
 		Ok(args) => {
 			match *args.mode() {

--- a/src/core/src/modules/external_editor/mod.rs
+++ b/src/core/src/modules/external_editor/mod.rs
@@ -194,14 +194,13 @@ impl ExternalEditor {
 	}
 
 	fn set_state(&mut self, result: ProcessResult, new_state: ExternalEditorState) -> ProcessResult {
-		let result = match new_state {
+		self.state = new_state;
+		match self.state {
 			ExternalEditorState::Active => {
 				result.external_command(self.external_command.0.clone(), self.external_command.1.clone())
 			},
 			ExternalEditorState::Empty | ExternalEditorState::Error(_) => result,
-		};
-		self.state = new_state;
-		result
+		}
 	}
 
 	fn undo_and_edit(&mut self, result: ProcessResult, todo_file: &mut TodoFile) -> ProcessResult {

--- a/src/core/src/modules/show_commit/commit.rs
+++ b/src/core/src/modules/show_commit/commit.rs
@@ -47,21 +47,18 @@ fn load_commit_state(hash: &str, config: &LoadCommitDiffOptions) -> Result<Commi
 	let date = Local.timestamp(commit.time().seconds(), 0);
 	let body = commit.message().map(String::from);
 	let author = User::new(commit.author().name(), commit.author().email());
-	let committer = User::new(commit.committer().name(), commit.committer().email());
-	let committer = if committer == author {
-		User::new(None, None)
+	let mut committer = User::new(commit.committer().name(), commit.committer().email());
+	if committer == author {
+		committer = User::new(None, None);
 	}
-	else {
-		committer
-	};
 	let mut number_files_changed = 0;
 	let mut insertions = 0;
 	let mut deletions = 0;
 
-	let mut diff_options = DiffOptions::new();
+	let mut empty_diff_options = DiffOptions::new();
 
 	// include_unmodified added to find copies from unmodified files
-	let diff_options = diff_options
+	let diff_options = empty_diff_options
 		.context_lines(config.context_lines)
 		.ignore_filemode(false)
 		.ignore_whitespace(config.ignore_whitespace)
@@ -73,8 +70,8 @@ fn load_commit_state(hash: &str, config: &LoadCommitDiffOptions) -> Result<Commi
 		.interhunk_lines(config.interhunk_lines)
 		.minimal(true);
 
-	let mut diff_find_options = DiffFindOptions::new();
-	let diff_find_options = diff_find_options
+	let mut empty_diff_find_options = DiffFindOptions::new();
+	let diff_find_options = empty_diff_find_options
 		.renames(config.renames)
 		.renames_from_rewrites(config.renames)
 		.rewrites(config.renames)

--- a/src/core/src/modules/show_commit/user.rs
+++ b/src/core/src/modules/show_commit/user.rs
@@ -19,17 +19,15 @@ impl User {
 	/// The user if formatted with "Name \<Email\>", which matches the Git CLI. If name or email are
 	/// `None` then they are omitted from the result. If neither are set, `None` is returned.
 	pub(super) fn to_string(&self) -> Option<String> {
-		if let Some(name) = self.name.as_ref() {
-			if let Some(email) = self.email.as_ref() {
-				Some(format!("{} <{}>", name, email))
-			}
-			else {
-				Some(String::from(name))
-			}
-		}
-		else {
-			self.email.as_ref().map(|email| format!("<{}>", email))
-		}
+		self.name.as_ref().map_or_else(
+			|| self.email.as_ref().map(|email| format!("<{}>", email)),
+			|name| {
+				self.email.as_ref().map_or_else(
+					|| Some(String::from(name)),
+					|email| Some(format!("{} <{}>", name, email)),
+				)
+			},
+		)
 	}
 }
 

--- a/src/core/src/modules/show_commit/view_builder.rs
+++ b/src/core/src/modules/show_commit/view_builder.rs
@@ -53,15 +53,16 @@ impl ViewBuilder {
 		}
 	}
 
-	fn replace_whitespace(&self, s: &str, visible: bool) -> String {
-		let s = if visible {
-			s.replace(" ", self.visible_space_string.as_str())
+	fn replace_whitespace(&self, value: &str, visible: bool) -> String {
+		if visible {
+			value
+				.replace(" ", self.visible_space_string.as_str())
 				.replace("\t", self.visible_tab_string.as_str())
 		}
 		else {
-			s.replace("\t", self.invisible_tab_string.as_str())
-		};
-		s.replace("\n", "")
+			value.replace("\t", self.invisible_tab_string.as_str())
+		}
+		.replace("\n", "")
 	}
 
 	fn build_leading_summary(commit: &Commit, is_full_width: bool) -> ViewLine {

--- a/src/display/src/utils.rs
+++ b/src/display/src/utils.rs
@@ -14,13 +14,13 @@ pub(super) fn detect_color_mode(number_of_colors: u16) -> ColorMode {
 
 	// VTE based terms should all be setting COLORTERM, but just in case
 	if let Ok(vte_version) = var("VTE_VERSION") {
-		let vte_version = vte_version.parse::<i32>().unwrap_or(0);
+		let parsed_version = vte_version.parse::<i32>().unwrap_or(0);
 
-		if vte_version >= 3600 {
+		if parsed_version >= 3600 {
 			// version 0.36.00
 			return ColorMode::TrueColor;
 		}
-		else if vte_version > 0 {
+		else if parsed_version > 0 {
 			return ColorMode::EightBit;
 		}
 	}

--- a/src/input/src/event.rs
+++ b/src/input/src/event.rs
@@ -22,8 +22,8 @@ impl From<crossterm::event::Event> for Event {
 	#[inline]
 	fn from(event: crossterm::event::Event) -> Self {
 		match event {
-			crossterm::event::Event::Key(event) => Self::Key(event),
-			crossterm::event::Event::Mouse(event) => Self::Mouse(event),
+			crossterm::event::Event::Key(evt) => Self::Key(evt),
+			crossterm::event::Event::Mouse(evt) => Self::Mouse(evt),
 			crossterm::event::Event::Resize(width, height) => Self::Resize(width, height),
 		}
 	}

--- a/src/todo_file/src/lib.rs
+++ b/src/todo_file/src/lib.rs
@@ -50,6 +50,7 @@
 #![deny(clippy::all, clippy::cargo, clippy::nursery, clippy::pedantic, clippy::restriction)]
 #![allow(
 	clippy::blanket_clippy_restriction_lints,
+	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::redundant_pub_crate,

--- a/src/view/src/line_segment.rs
+++ b/src/view/src/line_segment.rs
@@ -121,7 +121,7 @@ impl LineSegment {
 			let graphemes = UnicodeSegmentation::graphemes(self.text.as_str(), true);
 
 			let skip_length = RefCell::new(0);
-			let graphemes = graphemes.skip_while(|v| {
+			let graphemes_itr = graphemes.skip_while(|v| {
 				let len = grapheme_column_width(*v);
 				let value = *skip_length.borrow();
 				if value + len > left {
@@ -135,7 +135,7 @@ impl LineSegment {
 
 			if segment_length - *skip_length.borrow() >= max_width {
 				let take_length = RefCell::new(0);
-				let partial_line = graphemes
+				let partial_line = graphemes_itr
 					.take_while(|v| {
 						let len = grapheme_column_width(v);
 						let value = *take_length.borrow();
@@ -151,7 +151,7 @@ impl LineSegment {
 				SegmentPartial::new(partial_line.as_str(), take_length.into_inner())
 			}
 			else {
-				let partial_line = graphemes.collect::<String>();
+				let partial_line = graphemes_itr.collect::<String>();
 				SegmentPartial::new(partial_line.as_str(), segment_length - skip_length.into_inner())
 			}
 		}

--- a/src/view/src/render_slice/mod.rs
+++ b/src/view/src/render_slice/mod.rs
@@ -403,7 +403,7 @@ impl RenderSlice {
 		let left = self.scroll_position.get_left_position();
 
 		view_lines.iter().skip(start).take(end).for_each(|line| {
-			let mut start = 0;
+			let mut cursor = 0;
 			let mut left_start = 0;
 			let mut segments = vec![];
 			// window width can be zero when there is a scrollbar and a view width of 1
@@ -414,7 +414,7 @@ impl RenderSlice {
 						left_start = left;
 					}
 
-					let partial = segment.get_partial_segment(left_start, window_width - start);
+					let partial = segment.get_partial_segment(left_start, window_width - cursor);
 
 					if partial.get_length() > 0 {
 						segments.push(LineSegment::new_with_color_and_style(
@@ -425,8 +425,8 @@ impl RenderSlice {
 							segment.is_reversed(),
 						));
 
-						start += partial.get_length();
-						if start >= window_width {
+						cursor += partial.get_length();
+						if cursor >= window_width {
 							break;
 						}
 						left_start = 0;
@@ -436,10 +436,10 @@ impl RenderSlice {
 					}
 				}
 
-				if start < window_width {
+				if cursor < window_width {
 					if let Some(padding) = line.get_padding().as_ref() {
 						segments.push(LineSegment::new_with_color_and_style(
-							padding.get_content().repeat(window_width - start).as_str(),
+							padding.get_content().repeat(window_width - cursor).as_str(),
 							padding.get_color(),
 							padding.is_dimmed(),
 							padding.is_underlined(),

--- a/src/view/src/thread.rs
+++ b/src/view/src/thread.rs
@@ -16,14 +16,13 @@ const MINIMUM_TICK_RATE: Duration = Duration::from_millis(20); // ~50 Hz update
 /// # Panics
 /// This may panic if there is an unexpected error in the processing of the `View`, i.e. a bug.
 #[inline]
-pub fn spawn_view_thread<T: Tui + Send + 'static>(view: View<T>) -> (Sender, JoinHandle<()>) {
+pub fn spawn_view_thread<T: Tui + Send + 'static>(mut view: View<T>) -> (Sender, JoinHandle<()>) {
 	let (sender, receiver) = mpsc::channel();
 	let view_sender = Sender::new(sender.clone());
 	let view_render_slice = view_sender.clone_render_slice();
 	let crashed = view_sender.clone_poisoned();
 
 	let thread = spawn(move || {
-		let mut view = view;
 		let mut last_render_time = Instant::now() + MINIMUM_TICK_RATE;
 		let mut should_render = true;
 		for msg in receiver {


### PR DESCRIPTION
Resolves most lint errors in the nightly version of clippy. Most of these were due to variable shadowing and pretty nitpicky imo, but it was a good opportunity to clean up a few small things and bring the code into compliance with future lint rules.

The one I couldn't fix is [`clippy::mod_module_files`](https://rust-lang.github.io/rust-clippy/master/index.html#mod_module_files) which bans mod.rs files and will require moving a bunch of stuff around. If you think that's worth doing maybe it can be done in a separate PR. 


