### PR TITLE
Remove use of std:convert::{TryInto, TryFrom}

### DIFF
--- a/src/config/src/color.rs
+++ b/src/config/src/color.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{anyhow, Error};
 
 /// Represents a color.

--- a/src/config/src/git_config.rs
+++ b/src/config/src/git_config.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{anyhow, Error, Result};
 use git::Config;
 

--- a/src/config/src/key_bindings.rs
+++ b/src/config/src/key_bindings.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{Error, Result};
 use git::Config;
 

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -83,8 +83,6 @@
 //! This module is used to handle the loading of configuration from the Git config system.
 //!
 //! ```
-//! use std::convert::TryFrom;
-//!
 //! use config::Config;
 //! use git::Repository;
 //! let config = Config::try_from(&Repository::open_from_env().unwrap());
@@ -104,8 +102,6 @@ mod utils;
 
 #[cfg(test)]
 mod testutils;
-
-use std::convert::TryFrom;
 
 use anyhow::{Error, Result};
 use git::Repository;

--- a/src/config/src/theme.rs
+++ b/src/config/src/theme.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{Error, Result};
 use git::Config;
 

--- a/src/config/src/utils.rs
+++ b/src/config/src/utils.rs
@@ -1,7 +1,4 @@
-use std::{
-	convert::{TryFrom, TryInto},
-	env,
-};
+use std::env;
 
 use anyhow::{anyhow, Result};
 use git::{Config, ErrorCode};

--- a/src/core/src/arguments.rs
+++ b/src/core/src/arguments.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, ffi::OsString};
+use std::ffi::OsString;
 
 use pico_args::Arguments;
 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -100,7 +100,7 @@ mod tests;
 pub mod testutil;
 mod version;
 
-use std::{convert::TryFrom, ffi::OsString};
+use std::ffi::OsString;
 
 use crate::{
 	arguments::{Args, Mode},

--- a/src/todo_file/src/action.rs
+++ b/src/todo_file/src/action.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{anyhow, Error};
 
 /// Describes an rebase action.

--- a/src/todo_file/src/line.rs
+++ b/src/todo_file/src/line.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anyhow::{anyhow, Result};
 
 use super::action::Action;


### PR DESCRIPTION
With Rust 2021, these have been added to the prelude, so are no longer needed.