### PR TITLE
Disable the mod_module_files lint

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,12 +3,14 @@ skip_core_tasks = true
 default_to_workspace = false
 
 [tasks.build]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 install_crate = false
 command = "cargo"
 args = ["build", "${@}"]
 
 [tasks.build-release]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 install_crate = false
 command = "cargo"
@@ -17,10 +19,11 @@ args = ["build", "--release", "${@}"]
 [tasks.build-deb]
 toolchain = "stable"
 command = "cargo"
-dependencies = ["build-release"]
+dependencies = ["update-rust-stable", "build-release"]
 args = ["deb"]
 
 [tasks.clean]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 install_crate = false
 command = "cargo"
@@ -52,6 +55,7 @@ dependencies = [
 ]
 
 [tasks.docs-stable]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 command = "cargo"
 args = [
@@ -62,6 +66,7 @@ args = [
 ]
 
 [tasks.docs-nightly]
+dependencies = ["update-rust-nightly"]
 toolchain = "nightly"
 ignore_errors = true
 command = "cargo"
@@ -79,6 +84,7 @@ dependencies = [
 ]
 
 [tasks.lint-stable]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 command = "cargo"
 args = [
@@ -89,6 +95,7 @@ args = [
 ]
 
 [tasks.lint-nightly]
+dependencies = ["update-rust-nightly"]
 toolchain = "nightly"
 ignore_errors = true
 command = "cargo"
@@ -100,6 +107,7 @@ args = [
 ]
 
 [tasks.format]
+dependencies = ["update-rust-nightly"]
 toolchain = "nightly"
 command = "cargo"
 args = [
@@ -111,6 +119,7 @@ args = [
 ]
 
 [tasks.licenses]
+dependencies = ["update-rust-nightly"]
 toolchain = "nightly"
 script = ['''
 cargo +nightly about generate "docs/licenses.hbs" > "docs/licenses.html"
@@ -123,7 +132,16 @@ command = "scripts/add-lints.bash"
 command = "scripts/publish.bash"
 
 [tasks.test]
+dependencies = ["update-rust-stable"]
 toolchain = "stable"
 install_crate = false
 command = "cargo"
 args = ["test", "--workspace"]
+
+[tasks.update-rust-stable]
+command = "rustup"
+args = ["update", "stable"]
+
+[tasks.update-rust-nightly]
+command = "rustup"
+args = ["update", "nightly"]

--- a/scripts/add-lints.bash
+++ b/scripts/add-lints.bash
@@ -72,6 +72,7 @@ content="\
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/display/src/lib.rs
+++ b/src/display/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/git/src/lib.rs
+++ b/src/git/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/todo_file/src/lib.rs
+++ b/src/todo_file/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/view/src/lib.rs
+++ b/src/view/src/lib.rs
@@ -53,6 +53,7 @@
 	clippy::expect_used,
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
+	clippy::mod_module_files,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]


### PR DESCRIPTION
This project uses mod.rs files, and will continue to do so. Also update the Makefile.toml file to ensure that stable and nightly Rust are updated, to catch these linting issues earlier.