### PR TITLE
Remove trailing spaces in render assertions

### DIFF
--- a/src/core/src/components/confirm/tests.rs
+++ b/src/core/src/components/confirm/tests.rs
@@ -11,6 +11,9 @@ fn render() {
 		String::from("X"),
 	]);
 	assert_rendered_output!(
+		Options AssertRenderOptions {
+			ignore_trailing_whitespace: false
+		},
 		module.get_view_data(),
 		"{TITLE}",
 		"{BODY}",

--- a/src/core/src/components/edit/tests.rs
+++ b/src/core/src/components/edit/tests.rs
@@ -10,6 +10,9 @@ fn with_description() {
 	module.set_description("Description");
 	let view_data = module.get_view_data();
 	assert_rendered_output!(
+		Options AssertRenderOptions {
+			ignore_trailing_whitespace: false
+		},
 		view_data,
 		"{TITLE}",
 		"{LEADING}",
@@ -29,6 +32,9 @@ fn with_label() {
 	module.set_label("Label: ");
 	let view_data = module.get_view_data();
 	assert_rendered_output!(
+		Options AssertRenderOptions {
+			ignore_trailing_whitespace: false
+		},
 		view_data,
 		"{TITLE}",
 		"{BODY}",
@@ -46,6 +52,9 @@ fn with_label_and_description() {
 	module.set_label("Label: ");
 	let view_data = module.get_view_data();
 	assert_rendered_output!(
+		Options AssertRenderOptions {
+			ignore_trailing_whitespace: false
+		},
 		view_data,
 		"{TITLE}",
 		"{LEADING}",
@@ -66,6 +75,9 @@ fn move_cursor_end() {
 		let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",
@@ -181,6 +193,9 @@ fn move_cursor_to_end() {
 			let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 			let view_data = module.get_view_data();
 			assert_rendered_output!(
+				Options AssertRenderOptions {
+					ignore_trailing_whitespace: false
+				},
 				view_data,
 				"{TITLE}",
 				"{BODY}",
@@ -206,6 +221,9 @@ fn move_cursor_on_empty_content() {
 			let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 			let view_data = module.get_view_data();
 			assert_rendered_output!(
+				Options AssertRenderOptions {
+					ignore_trailing_whitespace: false
+				},
 				view_data,
 				"{TITLE}",
 				"{BODY}",
@@ -243,6 +261,9 @@ fn move_cursor_attempt_past_end() {
 		let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",
@@ -297,6 +318,9 @@ fn add_character_end() {
 		let _ = module.handle_event(&context.event_handler);
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",
@@ -391,6 +415,9 @@ fn add_character_uppercase() {
 			let _ = module.handle_event(&context.event_handler);
 			let view_data = module.get_view_data();
 			assert_rendered_output!(
+				Options AssertRenderOptions {
+					ignore_trailing_whitespace: false
+				},
 				view_data,
 				"{TITLE}",
 				"{BODY}",
@@ -410,6 +437,9 @@ fn backspace_at_end() {
 		let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",
@@ -502,6 +532,9 @@ fn delete_at_end() {
 		let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",
@@ -520,6 +553,9 @@ fn delete_last_character() {
 		let _ = context.for_each_event(|event_handler| module.handle_event(event_handler));
 		let view_data = module.get_view_data();
 		assert_rendered_output!(
+			Options AssertRenderOptions {
+				ignore_trailing_whitespace: false
+			},
 			view_data,
 			"{TITLE}",
 			"{BODY}",

--- a/src/core/src/modules/confirm_abort/mod.rs
+++ b/src/core/src/modules/confirm_abort/mod.rs
@@ -64,6 +64,9 @@ mod tests {
 			let mut module = create_confirm_abort();
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
+				Options AssertRenderOptions {
+					ignore_trailing_whitespace: false
+				},
 				view_data,
 				"{TITLE}",
 				"{BODY}",

--- a/src/core/src/modules/confirm_rebase/mod.rs
+++ b/src/core/src/modules/confirm_rebase/mod.rs
@@ -58,6 +58,9 @@ mod tests {
 			let mut module = create_confirm_rebase();
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
+				Options AssertRenderOptions {
+					ignore_trailing_whitespace: false
+				},
 				view_data,
 				"{TITLE}",
 				"{BODY}",

--- a/src/core/src/modules/insert/tests.rs
+++ b/src/core/src/modules/insert/tests.rs
@@ -70,7 +70,7 @@ fn edit_render_exec() {
 				"{IndicatorColor}Enter contents of the new line. Empty content cancels creation of a new line.",
 				"",
 				"{BODY}",
-				"{Normal,Dimmed}exec {Normal}foo{Normal,Underline} ",
+				"{Normal,Dimmed}exec {Normal}foo{Normal,Underline}",
 				"{TRAILING}",
 				"{IndicatorColor}Enter to finish"
 			);
@@ -106,7 +106,7 @@ fn edit_render_pick() {
 				"{IndicatorColor}Enter contents of the new line. Empty content cancels creation of a new line.",
 				"",
 				"{BODY}",
-				"{Normal,Dimmed}pick {Normal}abc{Normal,Underline} ",
+				"{Normal,Dimmed}pick {Normal}abc{Normal,Underline}",
 				"{TRAILING}",
 				"{IndicatorColor}Enter to finish"
 			);
@@ -145,7 +145,7 @@ fn edit_render_label() {
 				"{IndicatorColor}Enter contents of the new line. Empty content cancels creation of a new line.",
 				"",
 				"{BODY}",
-				"{Normal,Dimmed}label {Normal}foo{Normal,Underline} ",
+				"{Normal,Dimmed}label {Normal}foo{Normal,Underline}",
 				"{TRAILING}",
 				"{IndicatorColor}Enter to finish"
 			);
@@ -184,7 +184,7 @@ fn edit_render_reset() {
 				"{IndicatorColor}Enter contents of the new line. Empty content cancels creation of a new line.",
 				"",
 				"{BODY}",
-				"{Normal,Dimmed}reset {Normal}foo{Normal,Underline} ",
+				"{Normal,Dimmed}reset {Normal}foo{Normal,Underline}",
 				"{TRAILING}",
 				"{IndicatorColor}Enter to finish"
 			);
@@ -223,7 +223,7 @@ fn edit_render_merge() {
 				"{IndicatorColor}Enter contents of the new line. Empty content cancels creation of a new line.",
 				"",
 				"{BODY}",
-				"{Normal,Dimmed}merge {Normal}foo{Normal,Underline} ",
+				"{Normal,Dimmed}merge {Normal}foo{Normal,Underline}",
 				"{TRAILING}",
 				"{IndicatorColor}Enter to finish"
 			);

--- a/src/core/src/modules/list/tests.rs
+++ b/src/core/src/modules/list/tests.rs
@@ -49,7 +49,7 @@ fn render_full() {
 				"{Normal}   {ActionExec}exec   {Normal}echo 'foo'",
 				"{Normal}   {ActionPick}pick   {Normal}dddddddd {Normal}comment 4",
 				"{Normal}   {ActionReword}reword {Normal}eeeeeeee {Normal}comment 5",
-				"{Normal}   {ActionBreak}break  ",
+				"{Normal}   {ActionBreak}break",
 				"{Normal}   {ActionSquash}squash {Normal}ffffffff {Normal}comment 6",
 				"{Normal}   {ActionEdit}edit   {Normal}11111111 {Normal}comment 7",
 				"{Normal}   {ActionLabel}label  {Normal}ref",
@@ -92,7 +92,7 @@ fn render_compact() {
 				"{Normal} {ActionExec}x {Normal}echo 'foo'",
 				"{Normal} {ActionPick}p {Normal}ddd {Normal}comment 4",
 				"{Normal} {ActionReword}r {Normal}eee {Normal}comment 5",
-				"{Normal} {ActionBreak}b ",
+				"{Normal} {ActionBreak}b",
 				"{Normal} {ActionSquash}s {Normal}fff {Normal}comment 6",
 				"{Normal} {ActionEdit}e {Normal}111 {Normal}comment 7",
 				"{Normal} {ActionLabel}l {Normal}ref",
@@ -855,7 +855,7 @@ fn change_selected_line_toggle_break_above_existing() {
 				"{TITLE}{HELP}",
 				"{BODY}",
 				"{Selected}{Normal} > {ActionPick}pick   {Normal}aaa      {Normal}c1{Normal}{Pad( )}",
-				"{Normal}   {ActionBreak}break  "
+				"{Normal}   {ActionBreak}break"
 			);
 		},
 	);
@@ -2245,7 +2245,7 @@ fn edit_mode_render() {
 			"{IndicatorColor}Modifying line: exec foo",
 			"",
 			"{BODY}",
-			"{Normal,Dimmed}exec {Normal}foo{Normal,Underline} ",
+			"{Normal,Dimmed}exec {Normal}foo{Normal,Underline}",
 			"{TRAILING}",
 			"{IndicatorColor}Enter to finish"
 		);

--- a/src/core/src/modules/show_commit/tests.rs
+++ b/src/core/src/modules/show_commit/tests.rs
@@ -891,7 +891,7 @@ fn render_diff_show_both_whitespace() {
 		|test_context| {
 			let mut config = Config::new();
 			config.diff_show_whitespace = DiffShowWhitespaceSetting::Both;
-			config.diff_tab_symbol = String::from("#");
+			config.diff_tab_symbol = String::from("#>");
 			config.diff_space_symbol = String::from("%");
 			config.diff_tab_width = 2;
 			let mut module = ShowCommit::new(&config);
@@ -914,16 +914,16 @@ fn render_diff_show_both_whitespace() {
 				"",
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
 				"{Normal,Dimmed}{Pad(┈)}",
-				"{Normal}1{Normal} {Normal}1{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    content",
-				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}# # ",
-				"{Normal}3{Normal} {Normal}3{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    \
-				 content{DiffWhitespaceColor}# # ",
+				"{Normal}1{Normal} {Normal}1{Normal}| {DiffWhitespaceColor}#>#>{DiffContextColor}sp tabs    content",
+				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}#>#>",
+				"{Normal}3{Normal} {Normal}3{Normal}| {DiffWhitespaceColor}#>#>{DiffContextColor}sp tabs    \
+				 content{DiffWhitespaceColor}#>#>",
 				"{Normal}4{Normal} {Normal}4{Normal}| {DiffWhitespaceColor}%%%%{DiffContextColor}sp tabs    content",
 				"{Normal}5{Normal} {Normal}5{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}%%%%",
 				"{Normal}6{Normal} {Normal}6{Normal}| {DiffWhitespaceColor}%%%%{DiffContextColor}sp tabs    \
 				 content{DiffWhitespaceColor}%%%%",
-				"{Normal}7{Normal} {Normal}7{Normal}| {DiffWhitespaceColor}%# # %{DiffContextColor}sp tabs    \
-				 content{DiffWhitespaceColor}# %%# "
+				"{Normal}7{Normal} {Normal}7{Normal}| {DiffWhitespaceColor}%#>#>%{DiffContextColor}sp tabs    \
+				 content{DiffWhitespaceColor}#>%%#>"
 			);
 		},
 	);
@@ -961,15 +961,15 @@ fn render_diff_show_leading_whitespace() {
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
 				"{Normal,Dimmed}{Pad(┈)}",
 				"{Normal}1{Normal} {Normal}1{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    content",
-				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}    ",
+				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}",
 				"{Normal}3{Normal} {Normal}3{Normal}| {DiffWhitespaceColor}# # {DiffContextColor}sp tabs    \
-				 content{DiffWhitespaceColor}    ",
+				 content{DiffWhitespaceColor}",
 				"{Normal}4{Normal} {Normal}4{Normal}| {DiffWhitespaceColor}%%%%{DiffContextColor}sp tabs    content",
-				"{Normal}5{Normal} {Normal}5{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}    ",
+				"{Normal}5{Normal} {Normal}5{Normal}| {DiffContextColor}sp tabs    content{DiffWhitespaceColor}",
 				"{Normal}6{Normal} {Normal}6{Normal}| {DiffWhitespaceColor}%%%%{DiffContextColor}sp tabs    \
-				 content{DiffWhitespaceColor}    ",
+				 content{DiffWhitespaceColor}",
 				"{Normal}7{Normal} {Normal}7{Normal}| {DiffWhitespaceColor}%# # %{DiffContextColor}sp tabs    \
-				 content{DiffWhitespaceColor}      "
+				 content{DiffWhitespaceColor}"
 			);
 		},
 	);
@@ -1007,12 +1007,12 @@ fn render_diff_show_no_whitespace() {
 				"{Normal,Dimmed}@@{DiffContextColor} -1,7 +1,7 {Normal,Dimmed}@@{DiffContextColor} context",
 				"{Normal,Dimmed}{Pad(┈)}",
 				"{Normal}1{Normal} {Normal}1{Normal}| {DiffContextColor}    sp tabs    content",
-				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content    ",
-				"{Normal}3{Normal} {Normal}3{Normal}| {DiffContextColor}    sp tabs    content    ",
+				"{Normal}2{Normal} {Normal}2{Normal}| {DiffContextColor}sp tabs    content",
+				"{Normal}3{Normal} {Normal}3{Normal}| {DiffContextColor}    sp tabs    content",
 				"{Normal}4{Normal} {Normal}4{Normal}| {DiffContextColor}    sp tabs    content",
-				"{Normal}5{Normal} {Normal}5{Normal}| {DiffContextColor}sp tabs    content    ",
-				"{Normal}6{Normal} {Normal}6{Normal}| {DiffContextColor}    sp tabs    content    ",
-				"{Normal}7{Normal} {Normal}7{Normal}| {DiffContextColor}      sp tabs    content      "
+				"{Normal}5{Normal} {Normal}5{Normal}| {DiffContextColor}sp tabs    content",
+				"{Normal}6{Normal} {Normal}6{Normal}| {DiffContextColor}    sp tabs    content",
+				"{Normal}7{Normal} {Normal}7{Normal}| {DiffContextColor}      sp tabs    content"
 			);
 		},
 	);

--- a/src/core/src/process/tests.rs
+++ b/src/core/src/process/tests.rs
@@ -391,7 +391,7 @@ fn handle_process_result_external_command_not_executable() {
 			view_data,
 			"{TITLE}",
 			"{BODY}",
-			format!("{{Normal}}Unable to run {} ", command),
+			format!("{{Normal}}Unable to run {}", command),
 			if cfg!(windows) {
 				"{Normal}%1 is not a valid Win32 application. (os error 193)"
 			}
@@ -431,7 +431,7 @@ fn handle_process_result_external_command_executable_not_found() {
 			view_data,
 			"{TITLE}",
 			"{BODY}",
-			format!("{{Normal}}Unable to run {} ", command),
+			format!("{{Normal}}Unable to run {}", command),
 			if cfg!(windows) {
 				"{Normal}The system cannot find the file specified. (os error 2)"
 			}

--- a/src/view/src/render_slice/tests.rs
+++ b/src/view/src/render_slice/tests.rs
@@ -1,7 +1,7 @@
 use display::DisplayColor;
 
 use super::*;
-use crate::testutil::{_assert_rendered_output, render_view_line};
+use crate::testutil::{_assert_rendered_output, render_view_line, AssertRenderOptions};
 
 fn assert_rendered(render_slice: &RenderSlice, expected: &[&str]) {
 	let mut output = vec![];
@@ -49,6 +49,7 @@ fn assert_rendered(render_slice: &RenderSlice, expected: &[&str]) {
 		}
 	}
 	_assert_rendered_output(
+		AssertRenderOptions::default(),
 		&output,
 		&expected.iter().map(|s| String::from(*s)).collect::<Vec<String>>(),
 	);


### PR DESCRIPTION
# Description

Trailing whitespace when asserting rendering results is often tricky, breaks formatting, and often does not add to the test. This updates the assert_rendered_output macro to by default trim trailing whitespace, adds an option to include it, and updates the existing tests accordingly.