### PR TITLE
Disable the Clippy option_if_let_else lint

### DIFF
--- a/scripts/add-lints.bash
+++ b/scripts/add-lints.bash
@@ -73,6 +73,7 @@ content="\
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/display/src/lib.rs
+++ b/src/display/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/git/src/lib.rs
+++ b/src/git/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/todo_file/src/lib.rs
+++ b/src/todo_file/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]

--- a/src/view/src/lib.rs
+++ b/src/view/src/lib.rs
@@ -54,6 +54,7 @@
 	clippy::implicit_return,
 	clippy::missing_docs_in_private_items,
 	clippy::mod_module_files,
+	clippy::option_if_let_else,
 	clippy::redundant_pub_crate,
 	clippy::tabs_in_doc_comments
 )]


### PR DESCRIPTION
This lint has too many false positives, and in several cases produced less clear code.