### PR TITLE
Add dev task to cargo-make

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,6 +2,15 @@
 skip_core_tasks = true
 default_to_workspace = false
 
+[tasks.dev]
+dependencies = [
+	"build",
+	"test",
+	"docs",
+	"lint",
+	"format",
+]
+
 [tasks.build]
 dependencies = ["update-rust-stable"]
 toolchain = "stable"


### PR DESCRIPTION
The dev task runs all tasks that would normally be run during development.