### PR TITLE
Bump macOS build time to 15 minutes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -100,7 +100,7 @@ jobs:
   macos:
     name: macos
     runs-on: [ macos-latest ]
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
GitHub actions have gotten significantly slower, and 10 minutes is no longer sufficient for the macOS build to complete.