### PR TITLE
Update macOS Homebrew package name in installation instructions

### DIFF
--- a/readme/install.md
+++ b/readme/install.md
@@ -87,11 +87,11 @@ The executable will be installed to `/usr/bin`.
 
 ### With [Homebrew](https://brew.sh/)
 
-    brew install interactive-rebase-tool
+    brew install git-interactive-rebase-tool
 
 #### Remove
 
-    brew rm interactive-rebase-tool
+    brew rm git-interactive-rebase-tool
 
 ### Manual install
 


### PR DESCRIPTION
Homebrew package was renamed in Homebrew/homebrew-core@3d3776952f99ea8efa80379aceb0af665d464c74.