### PR TITLE
Add before/after_build functions to edit component

### DIFF
--- a/src/core/src/components/edit/tests.rs
+++ b/src/core/src/components/edit/tests.rs
@@ -4,28 +4,6 @@ use view::assert_rendered_output;
 use super::*;
 
 #[test]
-fn with_description() {
-	let mut module = Edit::new();
-	module.set_content("foobar");
-	module.set_description("Description");
-	let view_data = module.get_view_data();
-	assert_rendered_output!(
-		Options AssertRenderOptions {
-			ignore_trailing_whitespace: false
-		},
-		view_data,
-		"{TITLE}",
-		"{LEADING}",
-		"{IndicatorColor}Description",
-		"",
-		"{BODY}",
-		"{Normal}foobar{Normal,Underline} ",
-		"{TRAILING}",
-		"{IndicatorColor}Enter to finish"
-	);
-}
-
-#[test]
 fn with_label() {
 	let mut module = Edit::new();
 	module.set_content("foobar");
@@ -45,23 +23,27 @@ fn with_label() {
 }
 
 #[test]
-fn with_label_and_description() {
+fn with_before_and_after_build() {
 	let mut module = Edit::new();
 	module.set_content("foobar");
-	module.set_description("Description");
-	module.set_label("Label: ");
-	let view_data = module.get_view_data();
+	let view_data = module.build_view_data(
+		|updater| {
+			updater.push_line(ViewLine::from("Before"));
+		},
+		|updater| {
+			updater.push_line(ViewLine::from("After"));
+		},
+	);
 	assert_rendered_output!(
 		Options AssertRenderOptions {
 			ignore_trailing_whitespace: false
 		},
 		view_data,
 		"{TITLE}",
-		"{LEADING}",
-		"{IndicatorColor}Description",
-		"",
 		"{BODY}",
-		"{Normal,Dimmed}Label: {Normal}foobar{Normal,Underline} ",
+		"{Normal}Before",
+		"{Normal}foobar{Normal,Underline} ",
+		"{Normal}After",
 		"{TRAILING}",
 		"{IndicatorColor}Enter to finish"
 	);

--- a/src/core/src/modules/list/mod.rs
+++ b/src/core/src/modules/list/mod.rs
@@ -45,7 +45,23 @@ impl Module for List {
 		match self.state {
 			ListState::Normal => self.get_normal_mode_view_data(todo_file, context),
 			ListState::Visual => self.get_visual_mode_view_data(todo_file, context),
-			ListState::Edit => self.edit.get_view_data(),
+			ListState::Edit => {
+				if let Some(selected_line) = todo_file.get_selected_line() {
+					if selected_line.is_editable() {
+						return self.edit.build_view_data(
+							|updater| {
+								updater.push_leading_line(ViewLine::from(LineSegment::new_with_color(
+									format!("Modifying line: {}", selected_line.to_text()).as_str(),
+									DisplayColor::IndicatorColor,
+								)));
+								updater.push_leading_line(ViewLine::new_empty_line());
+							},
+							|_| {},
+						);
+					}
+				}
+				self.edit.get_view_data()
+			},
 		}
 	}
 
@@ -343,8 +359,6 @@ impl List {
 								self.edit.set_content(selected_line.get_content());
 								self.edit
 									.set_label(format!("{} ", selected_line.get_action().as_string()).as_str());
-								self.edit
-									.set_description(format!("Modifying line: {}", selected_line.to_text()).as_str());
 							}
 						}
 					},


### PR DESCRIPTION
Replace description in the edit component with before and after build functions.