### PR TITLE
Use Acquire-Release Ordering in atomic operations

### DIFF
--- a/src/core/src/process/tests.rs
+++ b/src/core/src/process/tests.rs
@@ -122,7 +122,7 @@ fn view_sender_is_poisoned() {
 		);
 		let mut modules = create_modules();
 		let test_module = TestModule::new();
-		process.view_sender.clone_poisoned().store(true, Ordering::Relaxed);
+		process.view_sender.clone_poisoned().store(true, Ordering::Release);
 		modules.register_module(State::List, test_module);
 		assert_eq!(process.run(modules).unwrap(), ExitStatus::StateError);
 	});

--- a/src/view/src/sender.rs
+++ b/src/view/src/sender.rs
@@ -47,7 +47,7 @@ impl Sender {
 	#[inline]
 	#[must_use]
 	pub fn is_poisoned(&self) -> bool {
-		self.poisoned.load(Ordering::Relaxed)
+		self.poisoned.load(Ordering::Acquire)
 	}
 
 	/// Clone the render slice.
@@ -154,7 +154,7 @@ mod tests {
 	#[test]
 	fn poisoned() {
 		with_view_sender(|context| {
-			context.sender.clone_poisoned().store(true, Ordering::SeqCst);
+			context.sender.clone_poisoned().store(true, Ordering::Release);
 			assert!(context.sender.is_poisoned());
 		});
 	}

--- a/src/view/src/thread.rs
+++ b/src/view/src/thread.rs
@@ -52,7 +52,7 @@ pub fn spawn_view_thread<T: Tui + Send + 'static>(mut view: View<T>) -> (Sender,
 				}
 			}
 			if err {
-				crashed.store(true, Ordering::Relaxed);
+				crashed.store(true, Ordering::Release);
 			}
 		}
 	});


### PR DESCRIPTION
The chosen Ordering was previously picked based on "getting things working", and was not based on actual requirements. Technically Relaxed is fine in all cases, since the poisoned value does not have any strong data requirements. But since it is essentially acquire/release in almost all cases, it makes sense to be explicit. The one use of sequential consistent ordering in a test is confusing, and could always have been relaxed or acquire/release.