### PR TITLE
Fix conflict with keybindings and edit in list

### DIFF
--- a/src/core/src/modules/list/mod.rs
+++ b/src/core/src/modules/list/mod.rs
@@ -91,42 +91,47 @@ impl Module for List {
 
 	#[allow(clippy::cognitive_complexity)]
 	fn read_event(&self, event: Event, key_bindings: &KeyBindings) -> Event {
-		match event {
-			e if key_bindings.abort.contains(&e) => Event::from(MetaEvent::Abort),
-			e if key_bindings.action_break.contains(&e) => Event::from(MetaEvent::ActionBreak),
-			e if key_bindings.action_drop.contains(&e) => Event::from(MetaEvent::ActionDrop),
-			e if key_bindings.action_edit.contains(&e) => Event::from(MetaEvent::ActionEdit),
-			e if key_bindings.action_fixup.contains(&e) => Event::from(MetaEvent::ActionFixup),
-			e if key_bindings.action_pick.contains(&e) => Event::from(MetaEvent::ActionPick),
-			e if key_bindings.action_reword.contains(&e) => Event::from(MetaEvent::ActionReword),
-			e if key_bindings.action_squash.contains(&e) => Event::from(MetaEvent::ActionSquash),
-			e if key_bindings.edit.contains(&e) => Event::from(MetaEvent::Edit),
-			e if key_bindings.force_abort.contains(&e) => Event::from(MetaEvent::ForceAbort),
-			e if key_bindings.force_rebase.contains(&e) => Event::from(MetaEvent::ForceRebase),
-			e if key_bindings.insert_line.contains(&e) => Event::from(MetaEvent::InsertLine),
-			e if key_bindings.move_down.contains(&e) => Event::from(MetaEvent::MoveCursorDown),
-			e if key_bindings.move_down_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageDown),
-			e if key_bindings.move_end.contains(&e) => Event::from(MetaEvent::MoveCursorEnd),
-			e if key_bindings.move_home.contains(&e) => Event::from(MetaEvent::MoveCursorHome),
-			e if key_bindings.move_left.contains(&e) => Event::from(MetaEvent::MoveCursorLeft),
-			e if key_bindings.move_right.contains(&e) => Event::from(MetaEvent::MoveCursorRight),
-			e if key_bindings.move_selection_down.contains(&e) => Event::from(MetaEvent::SwapSelectedDown),
-			e if key_bindings.move_selection_up.contains(&e) => Event::from(MetaEvent::SwapSelectedUp),
-			e if key_bindings.move_up.contains(&e) => Event::from(MetaEvent::MoveCursorUp),
-			e if key_bindings.move_up_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageUp),
-			e if key_bindings.open_in_external_editor.contains(&e) => Event::from(MetaEvent::OpenInEditor),
-			e if key_bindings.rebase.contains(&e) => Event::from(MetaEvent::Rebase),
-			e if key_bindings.remove_line.contains(&e) => Event::from(MetaEvent::Delete),
-			e if key_bindings.show_commit.contains(&e) => Event::from(MetaEvent::ShowCommit),
-			e if key_bindings.toggle_visual_mode.contains(&e) => Event::from(MetaEvent::ToggleVisualMode),
-			Event::Mouse(mouse_event) => {
-				match mouse_event.kind {
-					MouseEventKind::ScrollDown => Event::from(MetaEvent::MoveCursorDown),
-					MouseEventKind::ScrollUp => Event::from(MetaEvent::MoveCursorUp),
+		match self.state {
+			ListState::Normal | ListState::Visual => {
+				match event {
+					e if key_bindings.abort.contains(&e) => Event::from(MetaEvent::Abort),
+					e if key_bindings.action_break.contains(&e) => Event::from(MetaEvent::ActionBreak),
+					e if key_bindings.action_drop.contains(&e) => Event::from(MetaEvent::ActionDrop),
+					e if key_bindings.action_edit.contains(&e) => Event::from(MetaEvent::ActionEdit),
+					e if key_bindings.action_fixup.contains(&e) => Event::from(MetaEvent::ActionFixup),
+					e if key_bindings.action_pick.contains(&e) => Event::from(MetaEvent::ActionPick),
+					e if key_bindings.action_reword.contains(&e) => Event::from(MetaEvent::ActionReword),
+					e if key_bindings.action_squash.contains(&e) => Event::from(MetaEvent::ActionSquash),
+					e if key_bindings.edit.contains(&e) => Event::from(MetaEvent::Edit),
+					e if key_bindings.force_abort.contains(&e) => Event::from(MetaEvent::ForceAbort),
+					e if key_bindings.force_rebase.contains(&e) => Event::from(MetaEvent::ForceRebase),
+					e if key_bindings.insert_line.contains(&e) => Event::from(MetaEvent::InsertLine),
+					e if key_bindings.move_down.contains(&e) => Event::from(MetaEvent::MoveCursorDown),
+					e if key_bindings.move_down_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageDown),
+					e if key_bindings.move_end.contains(&e) => Event::from(MetaEvent::MoveCursorEnd),
+					e if key_bindings.move_home.contains(&e) => Event::from(MetaEvent::MoveCursorHome),
+					e if key_bindings.move_left.contains(&e) => Event::from(MetaEvent::MoveCursorLeft),
+					e if key_bindings.move_right.contains(&e) => Event::from(MetaEvent::MoveCursorRight),
+					e if key_bindings.move_selection_down.contains(&e) => Event::from(MetaEvent::SwapSelectedDown),
+					e if key_bindings.move_selection_up.contains(&e) => Event::from(MetaEvent::SwapSelectedUp),
+					e if key_bindings.move_up.contains(&e) => Event::from(MetaEvent::MoveCursorUp),
+					e if key_bindings.move_up_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageUp),
+					e if key_bindings.open_in_external_editor.contains(&e) => Event::from(MetaEvent::OpenInEditor),
+					e if key_bindings.rebase.contains(&e) => Event::from(MetaEvent::Rebase),
+					e if key_bindings.remove_line.contains(&e) => Event::from(MetaEvent::Delete),
+					e if key_bindings.show_commit.contains(&e) => Event::from(MetaEvent::ShowCommit),
+					e if key_bindings.toggle_visual_mode.contains(&e) => Event::from(MetaEvent::ToggleVisualMode),
+					Event::Mouse(mouse_event) => {
+						match mouse_event.kind {
+							MouseEventKind::ScrollDown => Event::from(MetaEvent::MoveCursorDown),
+							MouseEventKind::ScrollUp => Event::from(MetaEvent::MoveCursorUp),
+							_ => event,
+						}
+					},
 					_ => event,
 				}
 			},
-			_ => event,
+			ListState::Edit => event,
 		}
 	}
 }


### PR DESCRIPTION
When editing a line, the keybinding input reading was causing any key bound to a virtual event to be ignored. This ensures that during edit mode, those keybindings are ignored.