### PR TITLE
Editing in list module ignores bound keys

### DIFF
--- a/src/core/src/modules/list/mod.rs
+++ b/src/core/src/modules/list/mod.rs
@@ -91,7 +91,8 @@ impl Module for List {
 
 	fn read_event(&self, event: Event, key_bindings: &KeyBindings) -> Event {
 		select!(
-			default || self.read_event_default(event, key_bindings),
+			default || Self::read_event_default(event, key_bindings),
+			|| (self.state == ListState::Edit).then(|| event),
 			|| self.normal_mode_help.read_event(event, key_bindings),
 			|| self.visual_mode_help.read_event(event, key_bindings)
 		)
@@ -384,54 +385,43 @@ impl List {
 	}
 
 	#[allow(clippy::cognitive_complexity)]
-	fn read_event_default(&self, event: Event, key_bindings: &KeyBindings) -> Event {
-		match self.state {
-			ListState::Normal | ListState::Visual => {
-				match event {
-					e if key_bindings.custom.abort.contains(&e) => Event::from(MetaEvent::Abort),
-					e if key_bindings.custom.action_break.contains(&e) => Event::from(MetaEvent::ActionBreak),
-					e if key_bindings.custom.action_drop.contains(&e) => Event::from(MetaEvent::ActionDrop),
-					e if key_bindings.custom.action_edit.contains(&e) => Event::from(MetaEvent::ActionEdit),
-					e if key_bindings.custom.action_fixup.contains(&e) => Event::from(MetaEvent::ActionFixup),
-					e if key_bindings.custom.action_pick.contains(&e) => Event::from(MetaEvent::ActionPick),
-					e if key_bindings.custom.action_reword.contains(&e) => Event::from(MetaEvent::ActionReword),
-					e if key_bindings.custom.action_squash.contains(&e) => Event::from(MetaEvent::ActionSquash),
-					e if key_bindings.custom.edit.contains(&e) => Event::from(MetaEvent::Edit),
-					e if key_bindings.custom.force_abort.contains(&e) => Event::from(MetaEvent::ForceAbort),
-					e if key_bindings.custom.force_rebase.contains(&e) => Event::from(MetaEvent::ForceRebase),
-					e if key_bindings.custom.insert_line.contains(&e) => Event::from(MetaEvent::InsertLine),
-					e if key_bindings.custom.move_down.contains(&e) => Event::from(MetaEvent::MoveCursorDown),
-					e if key_bindings.custom.move_down_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageDown),
-					e if key_bindings.custom.move_end.contains(&e) => Event::from(MetaEvent::MoveCursorEnd),
-					e if key_bindings.custom.move_home.contains(&e) => Event::from(MetaEvent::MoveCursorHome),
-					e if key_bindings.custom.move_left.contains(&e) => Event::from(MetaEvent::MoveCursorLeft),
-					e if key_bindings.custom.move_right.contains(&e) => Event::from(MetaEvent::MoveCursorRight),
-					e if key_bindings.custom.move_selection_down.contains(&e) => {
-						Event::from(MetaEvent::SwapSelectedDown)
-					},
-					e if key_bindings.custom.move_selection_up.contains(&e) => Event::from(MetaEvent::SwapSelectedUp),
-					e if key_bindings.custom.move_up.contains(&e) => Event::from(MetaEvent::MoveCursorUp),
-					e if key_bindings.custom.move_up_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageUp),
-					e if key_bindings.custom.open_in_external_editor.contains(&e) => {
-						Event::from(MetaEvent::OpenInEditor)
-					},
-					e if key_bindings.custom.rebase.contains(&e) => Event::from(MetaEvent::Rebase),
-					e if key_bindings.custom.remove_line.contains(&e) => Event::from(MetaEvent::Delete),
-					e if key_bindings.custom.show_commit.contains(&e) => Event::from(MetaEvent::ShowCommit),
-					e if key_bindings.custom.toggle_visual_mode.contains(&e) => {
-						Event::from(MetaEvent::ToggleVisualMode)
-					},
-					Event::Mouse(mouse_event) => {
-						match mouse_event.kind {
-							MouseEventKind::ScrollDown => Event::from(MetaEvent::MoveCursorDown),
-							MouseEventKind::ScrollUp => Event::from(MetaEvent::MoveCursorUp),
-							_ => event,
-						}
-					},
+	fn read_event_default(event: Event, key_bindings: &KeyBindings) -> Event {
+		match event {
+			e if key_bindings.custom.abort.contains(&e) => Event::from(MetaEvent::Abort),
+			e if key_bindings.custom.action_break.contains(&e) => Event::from(MetaEvent::ActionBreak),
+			e if key_bindings.custom.action_drop.contains(&e) => Event::from(MetaEvent::ActionDrop),
+			e if key_bindings.custom.action_edit.contains(&e) => Event::from(MetaEvent::ActionEdit),
+			e if key_bindings.custom.action_fixup.contains(&e) => Event::from(MetaEvent::ActionFixup),
+			e if key_bindings.custom.action_pick.contains(&e) => Event::from(MetaEvent::ActionPick),
+			e if key_bindings.custom.action_reword.contains(&e) => Event::from(MetaEvent::ActionReword),
+			e if key_bindings.custom.action_squash.contains(&e) => Event::from(MetaEvent::ActionSquash),
+			e if key_bindings.custom.edit.contains(&e) => Event::from(MetaEvent::Edit),
+			e if key_bindings.custom.force_abort.contains(&e) => Event::from(MetaEvent::ForceAbort),
+			e if key_bindings.custom.force_rebase.contains(&e) => Event::from(MetaEvent::ForceRebase),
+			e if key_bindings.custom.insert_line.contains(&e) => Event::from(MetaEvent::InsertLine),
+			e if key_bindings.custom.move_down.contains(&e) => Event::from(MetaEvent::MoveCursorDown),
+			e if key_bindings.custom.move_down_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageDown),
+			e if key_bindings.custom.move_end.contains(&e) => Event::from(MetaEvent::MoveCursorEnd),
+			e if key_bindings.custom.move_home.contains(&e) => Event::from(MetaEvent::MoveCursorHome),
+			e if key_bindings.custom.move_left.contains(&e) => Event::from(MetaEvent::MoveCursorLeft),
+			e if key_bindings.custom.move_right.contains(&e) => Event::from(MetaEvent::MoveCursorRight),
+			e if key_bindings.custom.move_selection_down.contains(&e) => Event::from(MetaEvent::SwapSelectedDown),
+			e if key_bindings.custom.move_selection_up.contains(&e) => Event::from(MetaEvent::SwapSelectedUp),
+			e if key_bindings.custom.move_up.contains(&e) => Event::from(MetaEvent::MoveCursorUp),
+			e if key_bindings.custom.move_up_step.contains(&e) => Event::from(MetaEvent::MoveCursorPageUp),
+			e if key_bindings.custom.open_in_external_editor.contains(&e) => Event::from(MetaEvent::OpenInEditor),
+			e if key_bindings.custom.rebase.contains(&e) => Event::from(MetaEvent::Rebase),
+			e if key_bindings.custom.remove_line.contains(&e) => Event::from(MetaEvent::Delete),
+			e if key_bindings.custom.show_commit.contains(&e) => Event::from(MetaEvent::ShowCommit),
+			e if key_bindings.custom.toggle_visual_mode.contains(&e) => Event::from(MetaEvent::ToggleVisualMode),
+			Event::Mouse(mouse_event) => {
+				match mouse_event.kind {
+					MouseEventKind::ScrollDown => Event::from(MetaEvent::MoveCursorDown),
+					MouseEventKind::ScrollUp => Event::from(MetaEvent::MoveCursorUp),
 					_ => event,
 				}
 			},
-			ListState::Edit => event,
+			_ => event,
 		}
 	}
 


### PR DESCRIPTION
When editing a line in the list view, all keys that were bound to a meta event were ignored and could not be inputted. This ensures that bound keys are ignored when in editing mode.