### PR TITLE
Add mockable version of the TUI trait

### DIFF
--- a/src/display/src/testutil/mockable_tui.rs
+++ b/src/display/src/testutil/mockable_tui.rs
@@ -1,0 +1,157 @@
+use anyhow::Result;
+use crossterm::{
+	event::{Event, KeyCode, KeyEvent},
+	style::Colors,
+};
+
+use crate::{ColorMode, Size, Tui};
+
+/// A version of the `TUI` that provides defaults for all trait methods. This can be used to create
+/// mocked versions of the `TUI` interface, without needing to define all methods provided by the
+/// interface.
+#[allow(missing_docs, clippy::missing_errors_doc)]
+pub trait MockableTui: Tui {
+	#[inline]
+	fn get_color_mode(&self) -> ColorMode {
+		ColorMode::TwoTone
+	}
+
+	#[inline]
+	fn reset(&mut self) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn flush(&mut self) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn print(&mut self, _s: &str) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn set_color(&mut self, _colors: Colors) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn set_dim(&mut self, _dim: bool) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn set_underline(&mut self, _underline: bool) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn set_reverse(&mut self, _reverse: bool) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn read_event() -> Result<Option<Event>>
+	where Self: Sized {
+		Ok(Some(Event::Key(KeyEvent::from(KeyCode::Null))))
+	}
+
+	#[inline]
+	fn get_size(&self) -> Size {
+		Size::new(100, 100)
+	}
+
+	#[inline]
+	fn move_to_column(&mut self, _x: u16) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn move_next_line(&mut self) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn start(&mut self) -> Result<()> {
+		Ok(())
+	}
+
+	#[inline]
+	fn end(&mut self) -> Result<()> {
+		Ok(())
+	}
+}
+
+impl<T: MockableTui> Tui for T {
+	#[inline]
+	fn get_color_mode(&self) -> ColorMode {
+		<T as MockableTui>::get_color_mode(self)
+	}
+
+	#[inline]
+	fn reset(&mut self) -> Result<()> {
+		<T as MockableTui>::reset(self)
+	}
+
+	#[inline]
+	fn flush(&mut self) -> Result<()> {
+		<T as MockableTui>::flush(self)
+	}
+
+	#[inline]
+	fn print(&mut self, s: &str) -> Result<()> {
+		<T as MockableTui>::print(self, s)
+	}
+
+	#[inline]
+	fn set_color(&mut self, colors: Colors) -> Result<()> {
+		<T as MockableTui>::set_color(self, colors)
+	}
+
+	#[inline]
+	fn set_dim(&mut self, dim: bool) -> Result<()> {
+		<T as MockableTui>::set_dim(self, dim)
+	}
+
+	#[inline]
+	fn set_underline(&mut self, underline: bool) -> Result<()> {
+		<T as MockableTui>::set_underline(self, underline)
+	}
+
+	#[inline]
+	fn set_reverse(&mut self, reverse: bool) -> Result<()> {
+		<T as MockableTui>::set_reverse(self, reverse)
+	}
+
+	#[inline]
+	fn read_event() -> Result<Option<Event>>
+	where Self: Sized {
+		<T as MockableTui>::read_event()
+	}
+
+	#[inline]
+	fn get_size(&self) -> Size {
+		<T as MockableTui>::get_size(self)
+	}
+
+	#[inline]
+	fn move_to_column(&mut self, x: u16) -> Result<()> {
+		<T as MockableTui>::move_to_column(self, x)
+	}
+
+	#[inline]
+	fn move_next_line(&mut self) -> Result<()> {
+		<T as MockableTui>::move_next_line(self)
+	}
+
+	#[inline]
+	fn start(&mut self) -> Result<()> {
+		<T as MockableTui>::start(self)
+	}
+
+	#[inline]
+	fn end(&mut self) -> Result<()> {
+		<T as MockableTui>::end(self)
+	}
+}

--- a/src/display/src/testutil/mockcrossterm.rs
+++ b/src/display/src/testutil/mockcrossterm.rs
@@ -4,7 +4,11 @@ use crossterm::{
 	style::{Attribute, Attributes, Color, Colors},
 };
 
-use crate::{testutil::State, ColorMode, Size, Tui};
+use crate::{
+	testutil::{MockableTui, State},
+	ColorMode,
+	Size,
+};
 
 /// A mocked version of `CrossTerm`, useful for testing.
 #[derive(Debug)]
@@ -19,7 +23,7 @@ pub struct CrossTerm {
 	state: State,
 }
 
-impl Tui for CrossTerm {
+impl MockableTui for CrossTerm {
 	#[inline]
 	fn get_color_mode(&self) -> ColorMode {
 		self.color_mode

--- a/src/display/src/testutil/mod.rs
+++ b/src/display/src/testutil/mod.rs
@@ -1,8 +1,9 @@
 //! Utilities for writing tests that interact with the display.
+mod mockable_tui;
 mod mockcrossterm;
 mod state;
 
-pub use self::{mockcrossterm::CrossTerm, state::State};
+pub use self::{mockable_tui::MockableTui, mockcrossterm::CrossTerm, state::State};
 use crate::Display;
 
 /// Assert the the content of the Display is an expected value.


### PR DESCRIPTION
This adds a new trait, `MockableTui`, that provides default "noop" implementations of all the `TUI` trait methods. This allows for easy creation of mocked `TUI` implementations in tests.