### PR TITLE
Add ExitStatus::None in the core crate

### DIFF
--- a/src/core/src/module/exit_status.rs
+++ b/src/core/src/module/exit_status.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExitStatus {
+	None,
 	Abort,
 	ConfigError,
 	FileReadError,
@@ -16,7 +17,7 @@ impl ExitStatus {
 			Self::ConfigError => 1,
 			Self::FileReadError => 2,
 			Self::FileWriteError => 3,
-			Self::Good => 0,
+			Self::None | Self::Good => 0,
 			Self::StateError => 4,
 			Self::Kill => 6,
 		}
@@ -30,6 +31,7 @@ mod tests {
 	use super::*;
 
 	#[rstest]
+	#[case::abort(ExitStatus::None, 0)]
 	#[case::abort(ExitStatus::Abort, 5)]
 	#[case::config_error(ExitStatus::ConfigError, 1)]
 	#[case::file_read_error(ExitStatus::FileReadError, 2)]

--- a/src/core/src/process/tests.rs
+++ b/src/core/src/process/tests.rs
@@ -216,7 +216,7 @@ fn handle_results_with_return_error() {
 		results.error_with_return(anyhow!("Test error"), State::ExternalEditor);
 		process.handle_results(&mut create_default_test_module_handler(), results);
 		assert_eq!(process.state, State::Error);
-		assert!(process.exit_status.is_none());
+		assert_eq!(process.exit_status, ExitStatus::None);
 	});
 }
 
@@ -246,7 +246,7 @@ fn handle_results_exit_event() {
 		let mut results = Results::new();
 		results.event(Event::from(StandardEvent::Exit));
 		process.handle_results(&mut create_default_test_module_handler(), results);
-		assert_eq!(process.exit_status, Some(ExitStatus::Abort));
+		assert_eq!(process.exit_status, ExitStatus::Abort);
 	});
 }
 
@@ -256,7 +256,7 @@ fn handle_results_kill_event() {
 		let mut results = Results::new();
 		results.event(Event::from(StandardEvent::Kill));
 		process.handle_results(&mut create_default_test_module_handler(), results);
-		assert_eq!(process.exit_status, Some(ExitStatus::Kill));
+		assert_eq!(process.exit_status, ExitStatus::Kill);
 	});
 }
 
@@ -290,7 +290,7 @@ fn handle_results_other_event() {
 		let mut results = Results::new();
 		results.event(Event::from('a'));
 		process.handle_results(&mut create_default_test_module_handler(), results);
-		assert_eq!(process.exit_status, None);
+		assert_eq!(process.exit_status, ExitStatus::None);
 		assert_eq!(process.state, State::List);
 	});
 }


### PR DESCRIPTION
Add a None variant to the `ExitStatus` enum, and replace usages of `Option<ExitStatus>` in the process module.