### PR TITLE
Rename core events action_event

### DIFF
--- a/src/core/src/events/meta_event.rs
+++ b/src/core/src/events/meta_event.rs
@@ -66,7 +66,7 @@ pub(crate) enum MetaEvent {
 	Yes,
 	/// The external command was successful meta event.
 	ExternalCommandSuccess,
-	/// the external command was an error meta event.
+	/// The external command was an error meta event.
 	ExternalCommandError,
 }
 

--- a/src/core/src/events/mod.rs
+++ b/src/core/src/events/mod.rs
@@ -1,7 +1,7 @@
-mod action_event;
 mod app_key_bindings;
+mod meta_event;
 
-pub(crate) use self::{action_event::MetaEvent, app_key_bindings::AppKeyBindings};
+pub(crate) use self::{app_key_bindings::AppKeyBindings, meta_event::MetaEvent};
 
 pub(crate) type KeyBindings = input::KeyBindings<AppKeyBindings, MetaEvent>;
 pub(crate) type Event = input::Event<MetaEvent>;


### PR DESCRIPTION
This file did not match the enum it defined.