### PR TITLE
Fix races in tests

### DIFF
--- a/src/core/src/process/thread.rs
+++ b/src/core/src/process/thread.rs
@@ -43,8 +43,9 @@ impl<ModuleProvider: module::ModuleProvider + Send + 'static> Threadable for Thr
 
 				if !process.is_exit_status_kill() {
 					if let Err(err) = process.write_todo_file() {
-						notifier.error(err);
 						process.handle_results(Results::from(ExitStatus::FileWriteError));
+						notifier.error(err);
+						return;
 					}
 				}
 

--- a/src/view/src/thread/mod.rs
+++ b/src/view/src/thread/mod.rs
@@ -86,7 +86,7 @@ impl<ViewTui: Tui + Send + 'static> Thread<ViewTui> {
 
 				let render_slice = state.render_slice();
 				let update_receiver = state.update_receiver();
-				let mut last_render_time = Instant::now() + MINIMUM_TICK_RATE;
+				let mut last_render_time = Instant::now();
 				let mut should_render = true;
 
 				for msg in update_receiver {
@@ -351,12 +351,8 @@ mod tests {
 
 		with_view(TestCrossTerm {}, |view| {
 			let thread = Thread::new(view);
-			let state = thread.state();
-			let view_data = ViewData::new(|_| {});
-
 			let tester = ThreadableTester::new();
 			tester.start_threadable(&thread, MAIN_THREAD_NAME);
-			let _ = state.render(&view_data);
 			tester.wait_for_status(&Status::Error(anyhow!("Error")));
 		});
 	}


### PR DESCRIPTION
When an error occurred in the process thread, it was notifying the runtime of the error condition before handling the error. This meant this in some cases, the runtime would shutdown threads before the process thread had handled the error. Since the error state is supposed to be final, it is wrong for the application to attempt to process data after reaching that state.

In some cases, the test would try to render too quickly, and before a new render could occur. This would result in a render not occurring and the thread not entering an error state causing a timeout in the test.
