### PR TITLE
Remove Result returns from view state

### DIFF
--- a/src/core/src/process/mod.rs
+++ b/src/core/src/process/mod.rs
@@ -132,7 +132,7 @@ impl<ModuleProvider: module::ModuleProvider> Process<ModuleProvider> {
 		let mut module_handler = self.module_handler.lock();
 		let view_data = module_handler.build_view_data(self.state(), &render_context, &rebase_todo);
 		// TODO It is not possible for this to fail. view::State should be updated to not return an error
-		self.view_state.render(view_data).expect("Render failed");
+		self.view_state.render(view_data);
 	}
 
 	pub(crate) fn write_todo_file(&self) -> Result<()> {
@@ -233,7 +233,7 @@ impl<ModuleProvider: module::ModuleProvider> Process<ModuleProvider> {
 	}
 
 	fn run_command(&self, external_command: &(String, Vec<String>)) -> Result<MetaEvent> {
-		self.view_state.stop()?;
+		self.view_state.stop();
 		self.input_state.pause();
 
 		self.thread_statuses
@@ -267,7 +267,7 @@ impl<ModuleProvider: module::ModuleProvider> Process<ModuleProvider> {
 			});
 
 		self.input_state.resume();
-		self.view_state.start()?;
+		self.view_state.start();
 		result
 	}
 

--- a/src/view/src/thread/mod.rs
+++ b/src/view/src/thread/mod.rs
@@ -42,17 +42,20 @@ impl<ViewTui: Tui + Send + 'static> Threadable for Thread<ViewTui> {
 
 	#[inline]
 	fn pause(&self) -> Result<()> {
-		self.state.stop()
+		self.state.stop();
+		Ok(())
 	}
 
 	#[inline]
 	fn resume(&self) -> Result<()> {
-		self.state.start()
+		self.state.start();
+		Ok(())
 	}
 
 	#[inline]
 	fn end(&self) -> Result<()> {
-		self.state.end()
+		self.state.end();
+		Ok(())
 	}
 }
 
@@ -81,7 +84,7 @@ impl<ViewTui: Tui + Send + 'static> Thread<ViewTui> {
 			move || {
 				capture!(notifier, state);
 				notifier.busy();
-				state.start().expect("Unexpected start failure");
+				state.start();
 				notifier.wait();
 
 				let render_slice = state.render_slice();
@@ -138,8 +141,7 @@ impl<ViewTui: Tui + Send + 'static> Thread<ViewTui> {
 				let mut time = Instant::now();
 				while !state.is_ended() {
 					notifier.busy();
-					// an error here is okay, since the main thread will also error and end this thread
-					let _result = state.refresh();
+					state.refresh();
 					notifier.wait();
 					loop {
 						sleep(time.saturating_duration_since(Instant::now()));


### PR DESCRIPTION
The view thread state returned a Result for any state update that used the internal state update channel to message on the update. While the send call technically returns a Result that could be an error, it will always be successfully since an unbounded channel cannot have a send error.