### PR TITLE
Cleanup and refactor EditContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "claim"
+version = "0.5.0"
+source = "git+https://github.com/Turbo87/rust-claim.git?rev=23892a3#23892a345d38e1434303143a73033925284ad04d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +538,7 @@ name = "girt-todo-file"
 version = "2.2.0"
 dependencies = [
  "anyhow",
+ "claim",
  "rstest",
  "rustc_version",
  "tempfile",

--- a/src/todo_file/Cargo.toml
+++ b/src/todo_file/Cargo.toml
@@ -18,6 +18,7 @@ name = "todo_file"
 anyhow = "1.0"
 
 [dev-dependencies]
+claim = { git = "https://github.com/Turbo87/rust-claim.git", rev = "23892a3" }
 rstest = "0.13.0"
 tempfile = "3.3.0"
 

--- a/src/todo_file/src/edit_content.rs
+++ b/src/todo_file/src/edit_content.rs
@@ -30,54 +30,56 @@ impl EditContext {
 	#[must_use]
 	#[inline]
 	pub fn content(mut self, content: &str) -> Self {
-		self.content = Some(content.to_owned());
+		self.content = Some(String::from(content));
 		self
 	}
 
 	/// Get the action.
 	#[must_use]
 	#[inline]
-	pub const fn get_action(&self) -> &Option<Action> {
-		&self.action
+	pub const fn get_action(&self) -> Option<Action> {
+		self.action
 	}
 
 	/// Get the content.
 	#[must_use]
 	#[inline]
-	pub const fn get_content(&self) -> &Option<String> {
-		&self.content
+	pub fn get_content(&self) -> Option<&str> {
+		self.content.as_deref()
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use claim::{assert_none, assert_some_eq};
+
 	use super::*;
 
 	#[test]
 	fn empty() {
 		let edit_context = EditContext::new();
-		assert_eq!(edit_context.get_action(), &None);
-		assert_eq!(edit_context.get_content(), &None);
+		assert_none!(edit_context.get_action());
+		assert_none!(edit_context.get_content());
 	}
 
 	#[test]
 	fn with_action() {
 		let edit_context = EditContext::new().action(Action::Break);
-		assert_eq!(edit_context.get_action(), &Some(Action::Break));
-		assert_eq!(edit_context.get_content(), &None);
+		assert_some_eq!(edit_context.get_action(), Action::Break);
+		assert_none!(edit_context.get_content(),);
 	}
 
 	#[test]
 	fn with_content() {
 		let edit_context = EditContext::new().content("test content");
-		assert_eq!(edit_context.get_action(), &None);
-		assert_eq!(edit_context.get_content(), &Some(String::from("test content")));
+		assert_none!(edit_context.get_action());
+		assert_some_eq!(edit_context.get_content(), "test content");
 	}
 
 	#[test]
 	fn with_content_and_action() {
 		let edit_context = EditContext::new().action(Action::Edit).content("test content");
-		assert_eq!(edit_context.get_action(), &Some(Action::Edit));
-		assert_eq!(edit_context.get_content(), &Some(String::from("test content")));
+		assert_some_eq!(edit_context.get_action(), Action::Edit);
+		assert_some_eq!(edit_context.get_content(), "test content");
 	}
 }


### PR DESCRIPTION
EditContext was returning references to `Option`s when it should instead return `Option`s containing references. In the case of `Action`, it implements `Copy` so instead can be returned as a simple copy.

The tests have been updated to take advantage of of rust-claim.