### PR TITLE
Add full errors to the todo_file crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,11 +537,11 @@ dependencies = [
 name = "girt-todo-file"
 version = "2.2.0"
 dependencies = [
- "anyhow",
  "claim",
  "rstest",
  "rustc_version",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -1151,6 +1151,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/core/src/modules/external_editor/mod.rs
+++ b/src/core/src/modules/external_editor/mod.rs
@@ -37,7 +37,7 @@ impl Module for ExternalEditor {
 	fn activate(&mut self, todo_file: &TodoFile, _: State) -> Results {
 		let mut results = Results::new();
 		if let Err(err) = todo_file.write_file() {
-			results.error_with_return(err, State::List);
+			results.error_with_return(err.into(), State::List);
 			return results;
 		}
 
@@ -102,7 +102,7 @@ impl Module for ExternalEditor {
 									results.state(State::List);
 								}
 							},
-							Err(e) => self.set_state(&mut results, ExternalEditorState::Error(e)),
+							Err(e) => self.set_state(&mut results, ExternalEditorState::Error(e.into())),
 						}
 					},
 					Event::MetaEvent(MetaEvent::ExternalCommandError) => {
@@ -141,7 +141,7 @@ impl Module for ExternalEditor {
 							todo_file.set_lines(self.lines.clone());
 							results.state(State::List);
 							if let Err(err) = todo_file.write_file() {
-								results.error(err);
+								results.error(err.into());
 							}
 						},
 						Action::UndoAndEdit => {
@@ -212,7 +212,7 @@ impl ExternalEditor {
 	fn undo_and_edit(&mut self, results: &mut Results, todo_file: &mut TodoFile) {
 		todo_file.set_lines(self.lines.clone());
 		if let Err(err) = todo_file.write_file() {
-			results.error_with_return(err, State::List);
+			results.error_with_return(err.into(), State::List);
 			return;
 		}
 		self.set_state(results, ExternalEditorState::Active);

--- a/src/core/src/modules/external_editor/tests.rs
+++ b/src/core/src/modules/external_editor/tests.rs
@@ -75,10 +75,7 @@ fn activate_write_file_fail() {
 		test_context.set_todo_file_readonly();
 		assert_results!(
 			test_context.activate(&mut module, State::List),
-			Artifact::Error(
-				anyhow!("Error opening file: {}: Permission denied (os error 13)", todo_path),
-				Some(State::List)
-			)
+			Artifact::Error(anyhow!("Unable to read file `{}`", todo_path), Some(State::List))
 		);
 	});
 }
@@ -307,17 +304,14 @@ fn editor_reload_error() {
 			);
 			assert_external_editor_state_eq!(
 				module.state,
-				ExternalEditorState::Error(
-					anyhow!("Error reading file: {}", todo_path).context("No such file or directory (os error 2)")
-				)
+				ExternalEditorState::Error(anyhow!("Unable to read file `{}`", todo_path))
 			);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
 				"{TITLE}",
 				"{LEADING}",
-				"{Normal}No such file or directory (os error 2)",
-				format!("{{Normal}}Error reading file: {}", todo_path),
+				format!("{{Normal}}Unable to read file `{}`", todo_path),
 				"",
 				"{BODY}",
 				"{Normal}1) Abort rebase",

--- a/src/core/src/process/mod.rs
+++ b/src/core/src/process/mod.rs
@@ -136,7 +136,7 @@ impl<ModuleProvider: module::ModuleProvider> Process<ModuleProvider> {
 	}
 
 	pub(crate) fn write_todo_file(&self) -> Result<()> {
-		self.rebase_todo.lock().write_file()
+		self.rebase_todo.lock().write_file().map_err(Error::from)
 	}
 
 	fn deactivate(&self, state: State) -> Results {

--- a/src/todo_file/Cargo.toml
+++ b/src/todo_file/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 name = "todo_file"
 
 [dependencies]
-anyhow = "1.0"
+thiserror = "1.0.31"
 
 [dev-dependencies]
 claim = { git = "https://github.com/Turbo87/rust-claim.git", rev = "23892a3" }

--- a/src/todo_file/src/action.rs
+++ b/src/todo_file/src/action.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use anyhow::{anyhow, Error};
+use crate::errors::ParseError;
 
 /// Describes an rebase action.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -85,7 +85,7 @@ impl Display for Action {
 }
 
 impl TryFrom<&str> for Action {
-	type Error = Error;
+	type Error = ParseError;
 
 	#[inline]
 	fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -102,7 +102,7 @@ impl TryFrom<&str> for Action {
 			"label" | "l" => Ok(Self::Label),
 			"reset" | "t" => Ok(Self::Reset),
 			"merge" | "m" => Ok(Self::Merge),
-			_ => Err(anyhow!("Invalid action: {}", s)),
+			_ => Err(ParseError::InvalidAction(String::from(s))),
 		}
 	}
 }
@@ -162,9 +162,10 @@ mod tests {
 
 	#[test]
 	fn action_try_from_invalid() {
+		let invalid = String::from("invalid");
 		assert_eq!(
-			Action::try_from("invalid").unwrap_err().to_string(),
-			"Invalid action: invalid"
+			Action::try_from(invalid.as_str()).unwrap_err(),
+			ParseError::InvalidAction(invalid)
 		);
 	}
 

--- a/src/todo_file/src/errors/io.rs
+++ b/src/todo_file/src/errors/io.rs
@@ -1,0 +1,89 @@
+use std::{io, path::PathBuf};
+
+use thiserror::Error;
+
+use crate::errors::ParseError;
+
+/// The cause of a `FileRead` error
+#[derive(Error, Debug)]
+#[non_exhaustive]
+#[allow(variant_size_differences)]
+pub enum FileReadErrorCause {
+	/// Caused by an io error
+	#[error(transparent)]
+	IoError(#[from] io::Error),
+	/// Caused by a parse error
+	#[error(transparent)]
+	ParseError(#[from] ParseError),
+}
+
+impl PartialEq for FileReadErrorCause {
+	#[inline]
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(&Self::IoError(ref self_err), &Self::IoError(ref other_err)) => self_err.kind() == other_err.kind(),
+			(&Self::ParseError(ref self_err), &Self::ParseError(ref other_err)) => self_err == other_err,
+			_ => false,
+		}
+	}
+}
+
+/// IO baser errors
+#[derive(Error, Debug, PartialEq)]
+#[non_exhaustive]
+#[allow(clippy::module_name_repetitions)]
+pub enum IoError {
+	/// The file could not be read
+	#[error("Unable to read file `{file}`")]
+	FileRead {
+		/// The file path that failed to read
+		file: PathBuf,
+		/// The reason for the read error
+		cause: FileReadErrorCause,
+	},
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn partial_eq_file_read_error_cause_different_cause() {
+		assert_ne!(
+			FileReadErrorCause::IoError(io::Error::from(io::ErrorKind::Other)),
+			FileReadErrorCause::ParseError(ParseError::InvalidAction(String::from("action")))
+		);
+	}
+
+	#[test]
+	fn partial_eq_file_read_error_cause_io_error_same_kind() {
+		assert_eq!(
+			FileReadErrorCause::IoError(io::Error::from(io::ErrorKind::Other)),
+			FileReadErrorCause::IoError(io::Error::from(io::ErrorKind::Other))
+		);
+	}
+
+	#[test]
+	fn partial_eq_file_read_error_cause_io_error_different_kind() {
+		assert_ne!(
+			FileReadErrorCause::IoError(io::Error::from(io::ErrorKind::Other)),
+			FileReadErrorCause::IoError(io::Error::from(io::ErrorKind::NotFound))
+		);
+	}
+
+	#[test]
+	fn partial_eq_file_read_error_cause_different_parse_error() {
+		assert_ne!(
+			FileReadErrorCause::ParseError(ParseError::InvalidAction(String::from("action"))),
+			FileReadErrorCause::ParseError(ParseError::InvalidLine(String::from("line"))),
+		);
+	}
+
+	#[test]
+	fn partial_eq_file_read_error_cause_same_parse_error() {
+		assert_eq!(
+			FileReadErrorCause::ParseError(ParseError::InvalidAction(String::from("action"))),
+			FileReadErrorCause::ParseError(ParseError::InvalidAction(String::from("action"))),
+		);
+	}
+}

--- a/src/todo_file/src/errors/mod.rs
+++ b/src/todo_file/src/errors/mod.rs
@@ -1,0 +1,12 @@
+//! Git Interactive Rebase Tool - Todo File Module Errors
+//!
+//! # Description
+//! This module contains error types used in the Todo File Module.
+
+mod io;
+mod parse;
+
+pub use self::{
+	io::{FileReadErrorCause, IoError},
+	parse::ParseError,
+};

--- a/src/todo_file/src/errors/parse.rs
+++ b/src/todo_file/src/errors/parse.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+/// Parsing errors
+#[derive(Error, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+#[allow(clippy::module_name_repetitions)]
+pub enum ParseError {
+	/// The provided action string is not one of the allowed values
+	#[error("The action `{0}` is not valid")]
+	InvalidAction(String),
+	/// The provided line is not valid
+	#[error("The line `{0}` is not valid")]
+	InvalidLine(String),
+}


### PR DESCRIPTION
This replaces all of the anyhow based errors in the todo_file crate with full errors using thiserror.