### PR TITLE
Replace Option<String> returns in git crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "claim",
  "git2",
  "lazy_static",
  "parking_lot",

--- a/src/core/src/modules/show_commit/view_builder.rs
+++ b/src/core/src/modules/show_commit/view_builder.rs
@@ -122,13 +122,13 @@ impl ViewBuilder {
 			]));
 		}
 
-		if let Some(ref summary) = *commit.summary() {
-			updater.push_lines(summary.as_str());
+		if let Some(summary) = commit.summary() {
+			updater.push_lines(summary);
 			updater.push_line(ViewLine::from(""));
 		}
 
-		if let Some(ref message) = *commit.message() {
-			updater.push_lines(message.as_str());
+		if let Some(message) = commit.message() {
+			updater.push_lines(message);
 			updater.push_line(ViewLine::from(""));
 		}
 

--- a/src/git/Cargo.toml
+++ b/src/git/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
+claim = { git = "https://github.com/Turbo87/rust-claim.git", rev = "23892a3" }
 pretty_assertions = "1.2.1"
 rstest = "0.13.0"
 serial_test = "0.7.0"

--- a/src/git/src/commit.rs
+++ b/src/git/src/commit.rs
@@ -61,15 +61,15 @@ impl Commit {
 	/// Get the commit message summary.
 	#[must_use]
 	#[inline]
-	pub const fn summary(&self) -> &Option<String> {
-		&self.summary
+	pub fn summary(&self) -> Option<&str> {
+		self.summary.as_deref()
 	}
 
 	/// Get the full commit message.
 	#[must_use]
 	#[inline]
-	pub const fn message(&self) -> &Option<String> {
-		&self.message
+	pub fn message(&self) -> Option<&str> {
+		self.message.as_deref()
 	}
 
 	fn new(commit: &git2::Commit<'_>, reference: Option<&git2::Reference<'_>>) -> Self {
@@ -119,6 +119,8 @@ impl From<&git2::Commit<'_>> for Commit {
 
 #[cfg(test)]
 mod tests {
+	use claim::assert_some_eq;
+
 	use super::*;
 	use crate::testutil::{
 		create_commit,
@@ -169,13 +171,13 @@ mod tests {
 	#[test]
 	fn summary() {
 		let commit = CommitBuilder::new("0123456789ABCDEF").summary("title").build();
-		assert_eq!(commit.summary().as_ref().unwrap(), "title");
+		assert_some_eq!(commit.summary(), "title");
 	}
 
 	#[test]
 	fn message() {
 		let commit = CommitBuilder::new("0123456789ABCDEF").message("title\n\nbody").build();
-		assert_eq!(commit.message().as_ref().unwrap(), "title\n\nbody");
+		assert_some_eq!(commit.message(), "title\n\nbody");
 	}
 
 	#[test]

--- a/src/git/src/user.rs
+++ b/src/git/src/user.rs
@@ -19,15 +19,15 @@ impl User {
 	/// Get the optional name of the user
 	#[inline]
 	#[must_use]
-	pub const fn name(&self) -> &Option<String> {
-		&self.name
+	pub fn name(&self) -> Option<&str> {
+		self.name.as_deref()
 	}
 
 	/// Get the optional email of the user
 	#[inline]
 	#[must_use]
-	pub const fn email(&self) -> &Option<String> {
-		&self.email
+	pub fn email(&self) -> Option<&str> {
+		self.email.as_deref()
 	}
 
 	/// Returns `true` if one of name or email is a `Some` value.
@@ -71,6 +71,7 @@ impl ToString for User {
 
 #[cfg(test)]
 mod tests {
+	use claim::assert_some_eq;
 	use rstest::rstest;
 
 	use super::*;
@@ -78,13 +79,13 @@ mod tests {
 	#[test]
 	fn name() {
 		let user = User::new(Some("name"), None);
-		assert_eq!(user.name(), &Some(String::from("name")));
+		assert_some_eq!(user.name(), "name");
 	}
 
 	#[test]
 	fn email() {
 		let user = User::new(None, Some("email"));
-		assert_eq!(user.email(), &Some(String::from("email")));
+		assert_some_eq!(user.email(), "email");
 	}
 
 	#[rstest]


### PR DESCRIPTION
Several function were returning `&Option<String>` instead of the more sensible `Option<&str>`. This replaces all those instances.