### PR TITLE
Update crossterm to 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/src/core/src/components/confirm/mod.rs
+++ b/src/core/src/components/confirm/mod.rs
@@ -4,7 +4,7 @@ mod tests;
 
 use captur::capture;
 pub(crate) use confirmed::Confirmed;
-use input::{InputOptions, KeyCode, KeyEvent};
+use input::{InputOptions, KeyCode, KeyEvent, KeyModifiers};
 use lazy_static::lazy_static;
 use view::{ViewData, ViewLine};
 
@@ -41,7 +41,12 @@ impl Confirm {
 	pub(crate) fn read_event(event: Event, key_bindings: &KeyBindings) -> Event {
 		if let Event::Key(key) = event {
 			if let KeyCode::Char(c) = key.code {
-				let event_lower = Event::Key(KeyEvent::new(KeyCode::Char(c.to_ascii_lowercase()), key.modifiers));
+				let mut event_lower_modifiers = key.modifiers;
+				event_lower_modifiers.remove(KeyModifiers::SHIFT);
+				let event_lower = Event::Key(KeyEvent::new(
+					KeyCode::Char(c.to_ascii_lowercase()),
+					event_lower_modifiers,
+				));
 				let event_upper = Event::Key(KeyEvent::new(KeyCode::Char(c.to_ascii_uppercase()), key.modifiers));
 
 				return if key_bindings.custom.confirm_yes.contains(&event_lower)

--- a/src/display/Cargo.toml
+++ b/src/display/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 name = "display"
 
 [dependencies]
-crossterm = "0.24.0"
+crossterm = "0.25.0"
 thiserror = "1.0.32"
 girt-config = {version = "2.2.0", path = "../config"}
 

--- a/src/input/Cargo.toml
+++ b/src/input/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 bitflags = "1.3.2"
 captur = "0.1.0"
 crossbeam-channel = "0.5.6"
-crossterm = "0.24.0"
+crossterm = "0.25.0"
 parking_lot = "0.12.1"
 girt-config = {version = "2.2.0", path = "../config"}
 girt-runtime = {version = "0.1.0", path = "../runtime"}

--- a/src/input/src/event.rs
+++ b/src/input/src/event.rs
@@ -1,6 +1,6 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{KeyCode, MouseEvent};
 
-use super::StandardEvent;
+use crate::{KeyEvent, StandardEvent};
 
 /// An event, either from an input device, system change or action event.
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy)]
@@ -24,15 +24,21 @@ impl<CustomEvent: crate::CustomEvent> From<crossterm::event::Event> for Event<Cu
 	#[inline]
 	fn from(event: crossterm::event::Event) -> Self {
 		match event {
-			crossterm::event::Event::Key(mut evt) => {
-				if let KeyCode::Char(_) = evt.code {
-					evt.modifiers.remove(KeyModifiers::SHIFT);
-				}
-				Self::Key(evt)
-			},
+			crossterm::event::Event::Key(evt) => Self::Key(KeyEvent::from(evt)),
 			crossterm::event::Event::Mouse(evt) => Self::Mouse(evt),
 			crossterm::event::Event::Resize(width, height) => Self::Resize(width, height),
+			// ignore these events for now, as we don't need them
+			crossterm::event::Event::FocusGained
+			| crossterm::event::Event::FocusLost
+			| crossterm::event::Event::Paste(_) => Self::None,
 		}
+	}
+}
+
+impl<CustomEvent: crate::CustomEvent> From<KeyEvent> for Event<CustomEvent> {
+	#[inline]
+	fn from(key_event: KeyEvent) -> Self {
+		Self::Key(key_event)
 	}
 }
 
@@ -46,42 +52,47 @@ impl<CustomEvent: crate::CustomEvent> From<StandardEvent> for Event<CustomEvent>
 impl<CustomEvent: crate::CustomEvent> From<KeyCode> for Event<CustomEvent> {
 	#[inline]
 	fn from(code: KeyCode) -> Self {
-		Self::Key(KeyEvent {
-			code,
-			modifiers: KeyModifiers::empty(),
-		})
+		Self::Key(KeyEvent::from(code))
 	}
 }
 
 impl<CustomEvent: crate::CustomEvent> From<char> for Event<CustomEvent> {
 	#[inline]
 	fn from(c: char) -> Self {
-		Self::Key(KeyEvent {
-			code: KeyCode::Char(c),
-			modifiers: KeyModifiers::empty(),
-		})
+		Self::Key(KeyEvent::from(KeyCode::Char(c)))
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use crossterm::event::MouseEventKind;
+	use crossterm::{
+		event as ct_event,
+		event::{KeyModifiers, MouseEventKind},
+	};
 
 	use super::*;
 	use crate::testutil::local::Event;
 
 	#[test]
 	fn from_crossterm_key_event() {
-		let key_event = KeyEvent::new(KeyCode::Null, KeyModifiers::empty());
-		let event = Event::from(crossterm::event::Event::Key(key_event));
-		assert_eq!(event, Event::Key(key_event));
+		let event = Event::from(ct_event::Event::Key(ct_event::KeyEvent::new(
+			KeyCode::Null,
+			KeyModifiers::empty(),
+		)));
+		assert_eq!(event, Event::Key(KeyEvent::new(KeyCode::Null, KeyModifiers::empty())));
 	}
 
 	#[test]
-	fn from_crossterm_key_event_char_with_shift_modifier() {
-		let key_event = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::SHIFT);
-		let event = Event::from(crossterm::event::Event::Key(key_event));
-		assert_eq!(event, Event::Key(KeyEvent::from(KeyCode::Char('?'))));
+	fn from_crossterm_key_event_char_with_modifier() {
+		let event = Event::from(ct_event::Event::Key(ct_event::KeyEvent::new(
+			KeyCode::Char('?'),
+			KeyModifiers::SHIFT,
+		)));
+
+		assert_eq!(
+			event,
+			Event::Key(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::SHIFT))
+		);
 	}
 
 	#[test]
@@ -100,6 +111,24 @@ mod tests {
 	fn from_crossterm_resize_event() {
 		let event = Event::from(crossterm::event::Event::Resize(100, 100));
 		assert_eq!(event, Event::Resize(100, 100));
+	}
+
+	#[test]
+	fn from_crossterm_focused_gained_event() {
+		let event = Event::from(crossterm::event::Event::FocusGained);
+		assert_eq!(event, Event::None);
+	}
+
+	#[test]
+	fn from_crossterm_focused_lost_event() {
+		let event = Event::from(crossterm::event::Event::FocusLost);
+		assert_eq!(event, Event::None);
+	}
+
+	#[test]
+	fn from_crossterm_paste_event() {
+		let event = Event::from(crossterm::event::Event::Paste(String::from("test")));
+		assert_eq!(event, Event::None);
 	}
 
 	#[test]

--- a/src/input/src/event_handler.rs
+++ b/src/input/src/event_handler.rs
@@ -1,5 +1,5 @@
-use super::{Event, KeyCode, KeyEvent, KeyModifiers};
-use crate::{key_bindings::KeyBindings, InputOptions, StandardEvent};
+use super::{Event, KeyCode, KeyModifiers};
+use crate::{key_bindings::KeyBindings, InputOptions, KeyEvent, StandardEvent};
 
 /// A handler for reading and processing events.
 #[allow(missing_debug_implementations)]

--- a/src/input/src/key_bindings.rs
+++ b/src/input/src/key_bindings.rs
@@ -1,4 +1,4 @@
-use super::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crate::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 /// Represents a mapping between an input event and an action.
 #[derive(Debug)]
@@ -76,7 +76,6 @@ pub fn map_keybindings<CustomEvent: crate::CustomEvent>(bindings: &[String]) -> 
 				},
 				k => {
 					// printable characters cannot use shift
-					modifiers.remove(KeyModifiers::SHIFT);
 					KeyCode::Char(k.chars().next().expect("Expected only one character from Char KeyCode"))
 				},
 			};
@@ -124,10 +123,10 @@ mod tests {
 	fn map_keybindings_with_modifiers() {
 		assert_eq!(
 			map_keybindings::<TestEvent>(&[String::from("ControlAltShiftUp")]),
-			vec![Event::Key(KeyEvent {
-				code: KeyCode::Up,
-				modifiers: KeyModifiers::all()
-			})]
+			vec![Event::Key(KeyEvent::new(
+				KeyCode::Up,
+				KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+			))]
 		);
 	}
 

--- a/src/input/src/key_event.rs
+++ b/src/input/src/key_event.rs
@@ -1,0 +1,43 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Represents a key event.
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy)]
+#[allow(clippy::exhaustive_structs)]
+pub struct KeyEvent {
+	/// The key itself.
+	pub code: KeyCode,
+	/// Additional key modifiers.
+	pub modifiers: KeyModifiers,
+}
+
+impl KeyEvent {
+	/// Creates a new `KeyEvent` with `code` and `modifiers`.
+	#[must_use]
+	#[inline]
+	pub fn new(mut code: KeyCode, mut modifiers: KeyModifiers) -> Self {
+		// ensure that uppercase characters always have SHIFT
+		if let KeyCode::Char(c) = code {
+			if c.is_ascii_uppercase() {
+				modifiers.insert(KeyModifiers::SHIFT);
+			}
+			else if modifiers.contains(KeyModifiers::SHIFT) {
+				code = KeyCode::Char(c.to_ascii_uppercase());
+			}
+		}
+		Self { code, modifiers }
+	}
+}
+
+impl From<crossterm::event::KeyEvent> for KeyEvent {
+	#[inline]
+	fn from(key_event: crossterm::event::KeyEvent) -> Self {
+		Self::new(key_event.code, key_event.modifiers)
+	}
+}
+
+impl From<KeyCode> for KeyEvent {
+	#[inline]
+	fn from(code: KeyCode) -> Self {
+		Self::new(code, KeyModifiers::empty())
+	}
+}

--- a/src/input/src/lib.rs
+++ b/src/input/src/lib.rs
@@ -92,12 +92,13 @@ mod event_handler;
 mod event_provider;
 mod input_options;
 mod key_bindings;
+mod key_event;
 mod standard_event;
 #[cfg(not(tarpaulin_include))]
 pub mod testutil;
 mod thread;
 
-pub use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+pub use crossterm::event::{Event as RawEvent, KeyCode, KeyModifiers, MouseEvent, MouseEventKind};
 
 pub use self::{
 	custom_event::CustomEvent,
@@ -107,6 +108,7 @@ pub use self::{
 	event_provider::{read_event, EventReaderFn},
 	input_options::InputOptions,
 	key_bindings::{map_keybindings, KeyBindings},
+	key_event::KeyEvent,
 	standard_event::StandardEvent,
 	thread::{State, Thread, THREAD_NAME},
 };

--- a/src/input/src/testutil.rs
+++ b/src/input/src/testutil.rs
@@ -55,18 +55,8 @@ pub fn create_test_keybindings<TestKeybinding: crate::CustomKeybinding, CustomEv
 	custom_key_bindings: TestKeybinding,
 ) -> KeyBindings<TestKeybinding, CustomEvent> {
 	KeyBindings {
-		redo: vec![Event::Key({
-			KeyEvent {
-				code: KeyCode::Char('y'),
-				modifiers: KeyModifiers::CONTROL,
-			}
-		})],
-		undo: vec![Event::Key({
-			KeyEvent {
-				code: KeyCode::Char('z'),
-				modifiers: KeyModifiers::CONTROL,
-			}
-		})],
+		redo: vec![Event::from(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL))],
+		undo: vec![Event::from(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL))],
 		scroll_down: map_keybindings(&[String::from("Down")]),
 		scroll_end: map_keybindings(&[String::from("End")]),
 		scroll_home: map_keybindings(&[String::from("Home")]),
@@ -139,7 +129,12 @@ where
 			None => Ok(None),
 			Some(event) => {
 				match event {
-					Event::Key(key) => Ok(Some(c_event::Event::Key(key))),
+					Event::Key(key) => {
+						Ok(Some(c_event::Event::Key(c_event::KeyEvent::new(
+							key.code,
+							key.modifiers,
+						))))
+					},
 					Event::Mouse(mouse_event) => Ok(Some(c_event::Event::Mouse(mouse_event))),
 					Event::None => Ok(None),
 					Event::Resize(width, height) => Ok(Some(c_event::Event::Resize(width, height))),

--- a/src/input/src/thread/mod.rs
+++ b/src/input/src/thread/mod.rs
@@ -101,11 +101,14 @@ where
 #[cfg(test)]
 mod tests {
 	use anyhow::anyhow;
-	use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+	use crossterm::event::{KeyCode, KeyModifiers};
 	use runtime::{testutils::ThreadableTester, Status};
 
 	use super::*;
-	use crate::testutil::local::{create_event_reader, TestEvent};
+	use crate::{
+		testutil::local::{create_event_reader, TestEvent},
+		KeyEvent,
+	};
 
 	#[test]
 	fn set_pause_resume() {


### PR DESCRIPTION
In order to upgrade crossterm, the KeyEvent struct from crossterm was
replaced with a custom version that does not implement some of the new
features added to the struct.