### PR TITLE
Move Help keybindings to input crate

### DIFF
--- a/src/core/src/components/help/tests.rs
+++ b/src/core/src/components/help/tests.rs
@@ -3,13 +3,10 @@ use rstest::rstest;
 use view::{assert_rendered_output, testutil::with_view_state};
 
 use super::*;
-use crate::testutil::create_test_keybindings;
 
 fn handle_event(help: &mut Help, event: Event) {
-	let key_bindings = &create_test_keybindings();
-	if let Some(evt) = help.read_event(event, key_bindings) {
-		with_view_state(|context| help.handle_event(evt, &context.state));
-	}
+	let evt = Help::read_event(event).unwrap_or(event);
+	with_view_state(|context| help.handle_event(evt, &context.state));
 }
 
 #[test]

--- a/src/core/src/events/app_key_bindings.rs
+++ b/src/core/src/events/app_key_bindings.rs
@@ -35,8 +35,6 @@ pub(crate) struct AppKeyBindings {
 	pub(crate) force_abort: Vec<Event>,
 	/// Key bindings for forcing a rebase.
 	pub(crate) force_rebase: Vec<Event>,
-	/// Key bindings for showing help.
-	pub(crate) help: Vec<Event>,
 	/// Key bindings for inserting a line.
 	pub(crate) insert_line: Vec<Event>,
 	/// Key bindings for moving down.
@@ -88,7 +86,6 @@ impl CustomKeybinding for AppKeyBindings {
 			edit: map_keybindings(&key_bindings.edit),
 			force_abort: map_keybindings(&key_bindings.force_abort),
 			force_rebase: map_keybindings(&key_bindings.force_rebase),
-			help: map_keybindings(&key_bindings.help),
 			insert_line: map_keybindings(&key_bindings.insert_line),
 			move_down: map_keybindings(&key_bindings.move_down),
 			move_down_step: map_keybindings(&key_bindings.move_down_step),

--- a/src/core/src/events/meta_event.rs
+++ b/src/core/src/events/meta_event.rs
@@ -56,8 +56,6 @@ pub(crate) enum MetaEvent {
 	SwapSelectedUp,
 	/// The toggle visual mode meta event.
 	ToggleVisualMode,
-	/// The help meta event.
-	Help,
 	/// The insert line meta event.
 	InsertLine,
 	/// The no meta event.

--- a/src/core/src/modules/list/mod.rs
+++ b/src/core/src/modules/list/mod.rs
@@ -22,7 +22,9 @@ use crate::{
 };
 
 // TODO Remove `union` call when bitflags/bitflags#180 is resolved
-const INPUT_OPTIONS: InputOptions = InputOptions::UNDO_REDO.union(InputOptions::RESIZE);
+const INPUT_OPTIONS: InputOptions = InputOptions::UNDO_REDO
+	.union(InputOptions::RESIZE)
+	.union(InputOptions::HELP);
 
 #[derive(Debug, PartialEq, Eq)]
 enum ListState {
@@ -94,8 +96,7 @@ impl Module for List {
 		select!(
 			default || Self::read_event_default(event, key_bindings),
 			|| (self.state == ListState::Edit).then(|| event),
-			|| self.normal_mode_help.read_event(event, key_bindings),
-			|| self.visual_mode_help.read_event(event, key_bindings)
+			|| Help::read_event(event)
 		)
 	}
 }
@@ -459,7 +460,6 @@ impl List {
 					MetaEvent::Delete => self.delete(rebase_todo),
 					MetaEvent::ForceAbort => self.force_abort(&mut results, rebase_todo),
 					MetaEvent::ForceRebase => self.force_rebase(&mut results),
-					MetaEvent::Help => self.help(),
 					MetaEvent::MoveCursorDown => self.move_cursor_down(rebase_todo, 1),
 					MetaEvent::MoveCursorEnd => self.move_cursor_end(rebase_todo),
 					MetaEvent::MoveCursorHome => self.move_cursor_home(rebase_todo),
@@ -478,6 +478,7 @@ impl List {
 			},
 			Event::Standard(standard_event) => {
 				match standard_event {
+					StandardEvent::Help => self.help(),
 					StandardEvent::Redo => self.redo(rebase_todo),
 					StandardEvent::Undo => self.undo(rebase_todo),
 					_ => return None,

--- a/src/core/src/modules/list/tests.rs
+++ b/src/core/src/modules/list/tests.rs
@@ -2299,58 +2299,62 @@ fn scroll_left() {
 
 #[test]
 fn normal_mode_help() {
-	module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-		let mut module = List::new(&Config::new());
-		module.state = ListState::Normal;
-		let _ = test_context.handle_all_events(&mut module);
-		let view_data = test_context.build_view_data(&mut module);
-		assert_rendered_output!(
-			view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-			"{BODY}",
-			"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
-			"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
-			"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
-			"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
-			"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
-			"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
-			"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
-			"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
-			"{IndicatorColor} q       {Normal,Dimmed}|{Normal}Abort interactive rebase",
-			"{IndicatorColor} Q       {Normal,Dimmed}|{Normal}Immediately abort interactive rebase",
-			"{IndicatorColor} w       {Normal,Dimmed}|{Normal}Write interactive rebase file",
-			"{IndicatorColor} W       {Normal,Dimmed}|{Normal}Immediately write interactive rebase file",
-			"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual mode",
-			"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-			"{IndicatorColor} c       {Normal,Dimmed}|{Normal}Show commit information",
-			"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commit down",
-			"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commit up",
-			"{IndicatorColor} b       {Normal,Dimmed}|{Normal}Toggle break action",
-			"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commit to be picked",
-			"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commit to be reworded",
-			"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commit to be edited",
-			"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commit to be squashed",
-			"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commit to be fixed-up",
-			"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commit to be dropped",
-			"{IndicatorColor} E       {Normal,Dimmed}|{Normal}Edit an exec action's command",
-			"{IndicatorColor} I       {Normal,Dimmed}|{Normal}Insert a new line",
-			"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected line",
-			"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
-			"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
-			"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
-			"{TRAILING}",
-			"{IndicatorColor}Press any key to close"
-		);
-	});
+	module_test(
+		&["pick aaa c1"],
+		&[Event::from(StandardEvent::Help)],
+		|mut test_context| {
+			let mut module = List::new(&Config::new());
+			module.state = ListState::Normal;
+			let _ = test_context.handle_all_events(&mut module);
+			let view_data = test_context.build_view_data(&mut module);
+			assert_rendered_output!(
+				view_data,
+				"{TITLE}",
+				"{LEADING}",
+				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+				"{BODY}",
+				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
+				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
+				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
+				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
+				"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
+				"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
+				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
+				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
+				"{IndicatorColor} q       {Normal,Dimmed}|{Normal}Abort interactive rebase",
+				"{IndicatorColor} Q       {Normal,Dimmed}|{Normal}Immediately abort interactive rebase",
+				"{IndicatorColor} w       {Normal,Dimmed}|{Normal}Write interactive rebase file",
+				"{IndicatorColor} W       {Normal,Dimmed}|{Normal}Immediately write interactive rebase file",
+				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual mode",
+				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+				"{IndicatorColor} c       {Normal,Dimmed}|{Normal}Show commit information",
+				"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commit down",
+				"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commit up",
+				"{IndicatorColor} b       {Normal,Dimmed}|{Normal}Toggle break action",
+				"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commit to be picked",
+				"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commit to be reworded",
+				"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commit to be edited",
+				"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commit to be squashed",
+				"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commit to be fixed-up",
+				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commit to be dropped",
+				"{IndicatorColor} E       {Normal,Dimmed}|{Normal}Edit an exec action's command",
+				"{IndicatorColor} I       {Normal,Dimmed}|{Normal}Insert a new line",
+				"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected line",
+				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
+				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
+				"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
+				"{TRAILING}",
+				"{IndicatorColor}Press any key to close"
+			);
+		},
+	);
 }
 
 #[test]
 fn normal_mode_help_event() {
 	module_test(
 		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Help), Event::from(KeyCode::Enter)],
+		&[Event::from(StandardEvent::Help), Event::from(KeyCode::Enter)],
 		|mut test_context| {
 			let mut module = List::new(&Config::new());
 			module.state = ListState::Normal;
@@ -2362,49 +2366,53 @@ fn normal_mode_help_event() {
 
 #[test]
 fn visual_mode_help() {
-	module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-		let mut module = List::new(&Config::new());
-		module.state = ListState::Visual;
-		let _ = test_context.handle_all_events(&mut module);
-		let view_data = test_context.build_view_data(&mut module);
-		assert_rendered_output!(
-			view_data,
-			"{TITLE}",
-			"{LEADING}",
-			"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-			"{BODY}",
-			"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
-			"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
-			"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
-			"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
-			"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
-			"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
-			"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
-			"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
-			"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-			"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commits down",
-			"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commits up",
-			"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commits to be picked",
-			"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commits to be reworded",
-			"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commits to be edited",
-			"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commits to be squashed",
-			"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commits to be fixed-up",
-			"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commits to be dropped",
-			"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected lines",
-			"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
-			"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
-			"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual mode",
-			"{TRAILING}",
-			"{IndicatorColor}Press any key to close"
-		);
-	});
+	module_test(
+		&["pick aaa c1"],
+		&[Event::from(StandardEvent::Help)],
+		|mut test_context| {
+			let mut module = List::new(&Config::new());
+			module.state = ListState::Visual;
+			let _ = test_context.handle_all_events(&mut module);
+			let view_data = test_context.build_view_data(&mut module);
+			assert_rendered_output!(
+				view_data,
+				"{TITLE}",
+				"{LEADING}",
+				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+				"{BODY}",
+				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Move selection up",
+				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Move selection down",
+				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Move selection up 5 lines",
+				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Move selection down 5 lines",
+				"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Move selection to top of the list",
+				"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Move selection to end of the list",
+				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll content to the left",
+				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll content to the right",
+				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+				"{IndicatorColor} j       {Normal,Dimmed}|{Normal}Move selected commits down",
+				"{IndicatorColor} k       {Normal,Dimmed}|{Normal}Move selected commits up",
+				"{IndicatorColor} p       {Normal,Dimmed}|{Normal}Set selected commits to be picked",
+				"{IndicatorColor} r       {Normal,Dimmed}|{Normal}Set selected commits to be reworded",
+				"{IndicatorColor} e       {Normal,Dimmed}|{Normal}Set selected commits to be edited",
+				"{IndicatorColor} s       {Normal,Dimmed}|{Normal}Set selected commits to be squashed",
+				"{IndicatorColor} f       {Normal,Dimmed}|{Normal}Set selected commits to be fixed-up",
+				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Set selected commits to be dropped",
+				"{IndicatorColor} Delete  {Normal,Dimmed}|{Normal}Completely remove the selected lines",
+				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
+				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
+				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual mode",
+				"{TRAILING}",
+				"{IndicatorColor}Press any key to close"
+			);
+		},
+	);
 }
 
 #[test]
 fn visual_mode_help_event() {
 	module_test(
 		&["pick aaa c1"],
-		&[Event::from(MetaEvent::Help), Event::from(KeyCode::Enter)],
+		&[Event::from(StandardEvent::Help), Event::from(KeyCode::Enter)],
 		|mut test_context| {
 			let mut module = List::new(&Config::new());
 			module.state = ListState::Visual;

--- a/src/core/src/modules/show_commit/mod.rs
+++ b/src/core/src/modules/show_commit/mod.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Error};
 use captur::capture;
 use config::{Config, DiffIgnoreWhitespaceSetting, DiffShowWhitespaceSetting};
 use git::{CommitDiff, CommitDiffLoaderOptions, Repository};
-use input::InputOptions;
+use input::{InputOptions, StandardEvent};
 use todo_file::TodoFile;
 use view::{RenderContext, ViewData};
 
@@ -28,7 +28,9 @@ use crate::{
 };
 
 // TODO Remove `union` call when bitflags/bitflags#180 is resolved
-const INPUT_OPTIONS: InputOptions = InputOptions::UNDO_REDO.union(InputOptions::MOVEMENT);
+const INPUT_OPTIONS: InputOptions = InputOptions::UNDO_REDO
+	.union(InputOptions::MOVEMENT)
+	.union(InputOptions::HELP);
 
 pub(crate) struct ShowCommit {
 	commit_diff_loader_options: CommitDiffLoaderOptions,
@@ -127,7 +129,7 @@ impl Module for ShowCommit {
 					.then(|| Event::from(MetaEvent::ShowDiff))
 					.unwrap_or(event)
 			},
-			|| { self.help.read_event(event, key_bindings) }
+			|| { Help::read_event(event) }
 		)
 	}
 
@@ -153,7 +155,7 @@ impl Module for ShowCommit {
 						ShowCommitState::Diff => ShowCommitState::Overview,
 					}
 				},
-				Event::MetaEvent(meta_event) if meta_event == MetaEvent::Help => self.help.set_active(),
+				Event::Standard(standard_event) if standard_event == StandardEvent::Help => self.help.set_active(),
 				Event::Key(_) => {
 					active_view_data.update_view_data(|updater| updater.clear());
 					if self.state == ShowCommitState::Diff {

--- a/src/core/src/modules/show_commit/tests.rs
+++ b/src/core/src/modules/show_commit/tests.rs
@@ -1157,40 +1157,48 @@ fn handle_event_resize() {
 #[test]
 fn render_help() {
 	with_temp_repository(|repo| {
-		module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-			let mut module = ShowCommit::new(&Config::new(), repo);
-			let _ = test_context.handle_all_events(&mut module);
-			assert_rendered_output!(
-				test_context.build_view_data(&mut module),
-				"{TITLE}",
-				"{LEADING}",
-				"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
-				"{BODY}",
-				"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Scroll up",
-				"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Scroll down",
-				"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Scroll up half a page",
-				"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Scroll down half a page",
-				"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Scroll to the top",
-				"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Scroll to the bottom",
-				"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll right",
-				"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll left",
-				"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Show full diff",
-				"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
-				"{TRAILING}",
-				"{IndicatorColor}Press any key to close"
-			);
-		});
+		module_test(
+			&["pick aaa c1"],
+			&[Event::from(StandardEvent::Help)],
+			|mut test_context| {
+				let mut module = ShowCommit::new(&Config::new(), repo);
+				let _ = test_context.handle_all_events(&mut module);
+				assert_rendered_output!(
+					test_context.build_view_data(&mut module),
+					"{TITLE}",
+					"{LEADING}",
+					"{Normal,Underline} Key      Action{Normal,Underline}{Pad( )}",
+					"{BODY}",
+					"{IndicatorColor} Up      {Normal,Dimmed}|{Normal}Scroll up",
+					"{IndicatorColor} Down    {Normal,Dimmed}|{Normal}Scroll down",
+					"{IndicatorColor} PageUp  {Normal,Dimmed}|{Normal}Scroll up half a page",
+					"{IndicatorColor} PageDown{Normal,Dimmed}|{Normal}Scroll down half a page",
+					"{IndicatorColor} Home    {Normal,Dimmed}|{Normal}Scroll to the top",
+					"{IndicatorColor} End     {Normal,Dimmed}|{Normal}Scroll to the bottom",
+					"{IndicatorColor} Right   {Normal,Dimmed}|{Normal}Scroll right",
+					"{IndicatorColor} Left    {Normal,Dimmed}|{Normal}Scroll left",
+					"{IndicatorColor} d       {Normal,Dimmed}|{Normal}Show full diff",
+					"{IndicatorColor} ?       {Normal,Dimmed}|{Normal}Show help",
+					"{TRAILING}",
+					"{IndicatorColor}Press any key to close"
+				);
+			},
+		);
 	});
 }
 
 #[test]
 fn handle_help_event_show() {
 	with_temp_repository(|repo| {
-		module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Help)], |mut test_context| {
-			let mut module = ShowCommit::new(&Config::new(), repo);
-			let _ = test_context.handle_all_events(&mut module);
-			assert!(module.help.is_active());
-		});
+		module_test(
+			&["pick aaa c1"],
+			&[Event::from(StandardEvent::Help)],
+			|mut test_context| {
+				let mut module = ShowCommit::new(&Config::new(), repo);
+				let _ = test_context.handle_all_events(&mut module);
+				assert!(module.help.is_active());
+			},
+		);
 	});
 }
 #[test]
@@ -1198,7 +1206,7 @@ fn handle_help_event_hide() {
 	with_temp_repository(|repo| {
 		module_test(
 			&["pick aaa c1"],
-			&[Event::from(MetaEvent::Help), Event::from('?')],
+			&[Event::from(StandardEvent::Help), Event::from('?')],
 			|mut test_context| {
 				let mut module = ShowCommit::new(&Config::new(), repo);
 				let _ = test_context.handle_all_events(&mut module);

--- a/src/core/src/testutil/create_test_keybindings.rs
+++ b/src/core/src/testutil/create_test_keybindings.rs
@@ -20,7 +20,6 @@ pub(crate) fn create_test_custom_keybindings() -> AppKeyBindings {
 		edit: vec![Event::from(KeyCode::Char('E'))],
 		force_abort: vec![Event::from(KeyCode::Char('Q'))],
 		force_rebase: vec![Event::from(KeyCode::Char('W'))],
-		help: vec![Event::from(KeyCode::Char('?'))],
 		insert_line: vec![Event::from(KeyCode::Char('I'))],
 		move_down: vec![Event::from(KeyCode::Down)],
 		move_down_step: vec![Event::from(KeyCode::PageDown)],

--- a/src/input/src/event_handler.rs
+++ b/src/input/src/event_handler.rs
@@ -49,6 +49,10 @@ impl<CustomKeybinding: crate::CustomKeybinding, CustomEvent: crate::CustomEvent>
 			}
 		}
 
+		if input_options.contains(InputOptions::HELP) && self.key_bindings.help.contains(&event) {
+			return Event::from(StandardEvent::Help);
+		}
+
 		if input_options.contains(InputOptions::UNDO_REDO) {
 			if let Some(evt) = Self::handle_undo_redo(&self.key_bindings, event) {
 				return evt;
@@ -252,6 +256,13 @@ mod tests {
 		let event_handler = EventHandler::new(bindings);
 		let result = event_handler.read_event(event, &InputOptions::MOVEMENT, |_, _| Event::from(KeyCode::Null));
 		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn help_event() {
+		let event_handler = EventHandler::new(create_test_keybindings());
+		let result = event_handler.read_event(Event::from('?'), &InputOptions::HELP, |_, _| Event::from(KeyCode::Null));
+		assert_eq!(result, Event::from(StandardEvent::Help));
 	}
 
 	#[rstest]

--- a/src/input/src/input_options.rs
+++ b/src/input/src/input_options.rs
@@ -9,5 +9,7 @@ bitflags! {
 		const RESIZE = 0b0000_0010;
 		/// Enable undo and redo input handling
 		const UNDO_REDO = 0b0000_0100;
+		/// Help input handling
+		const HELP = 0b0001_0000;
 	}
 }

--- a/src/input/src/key_bindings.rs
+++ b/src/input/src/key_bindings.rs
@@ -26,6 +26,9 @@ pub struct KeyBindings<CustomKeybinding: crate::CustomKeybinding, CustomEvent: c
 	/// Key bindings for scrolling up a step.
 	pub scroll_step_up: Vec<Event<CustomEvent>>,
 
+	/// Key bindings for help.
+	pub help: Vec<Event<CustomEvent>>,
+
 	/// Custom keybindings
 	pub custom: CustomKeybinding,
 }
@@ -102,6 +105,7 @@ impl<CustomKeybinding: crate::CustomKeybinding, CustomEvent: crate::CustomEvent>
 			scroll_up: map_keybindings(&key_bindings.scroll_up),
 			scroll_step_down: map_keybindings(&key_bindings.scroll_step_down),
 			scroll_step_up: map_keybindings(&key_bindings.scroll_step_up),
+			help: map_keybindings(&key_bindings.help),
 			custom: CustomKeybinding::new(key_bindings),
 		}
 	}

--- a/src/input/src/standard_event.rs
+++ b/src/input/src/standard_event.rs
@@ -26,4 +26,6 @@ pub enum StandardEvent {
 	ScrollTop,
 	/// The scroll to top meta event.
 	ScrollUp,
+	/// The help meta event.
+	Help,
 }

--- a/src/input/src/testutil.rs
+++ b/src/input/src/testutil.rs
@@ -65,6 +65,7 @@ pub fn create_test_keybindings<TestKeybinding: crate::CustomKeybinding, CustomEv
 		scroll_up: map_keybindings(&[String::from("Up")]),
 		scroll_step_down: map_keybindings(&[String::from("PageDown")]),
 		scroll_step_up: map_keybindings(&[String::from("PageUp")]),
+		help: map_keybindings(&[String::from("?")]),
 		custom: custom_key_bindings,
 	}
 }


### PR DESCRIPTION
Since help keybindings are reused in multiple places, they can be moved into the shared input crate as a standard input. This eliminates code reuse for handling of help keybindings.