### PR TITLE
Run pull request workflow against master

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,11 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  pull_request:
+  # run CI/CD against master as well, to generate cache
+  push:
+    branches:
+      - master
 
 jobs:
   linux:


### PR DESCRIPTION
GitHub actions cache only works across branches when the cache is generated on the main or base branch.