### PR TITLE
Add option to render pinned segments during test

### DIFF
--- a/src/core/src/modules/list/mod.rs
+++ b/src/core/src/modules/list/mod.rs
@@ -388,7 +388,7 @@ impl List {
 					}
 					let mut view_line = ViewLine::new_with_pinned_segments(
 						get_todo_line_segments(line, search_term, todo_line_segment_options),
-						if *line.get_action() == Action::Exec { 2 } else { 3 },
+						if line.has_reference() { 2 } else { 3 },
 					)
 					.set_selected(selected_index == index || selected_line);
 

--- a/src/core/src/modules/list/tests/change_action.rs
+++ b/src/core/src/modules/list/tests/change_action.rs
@@ -4,6 +4,48 @@ use super::*;
 use crate::testutil::module_test;
 
 #[test]
+fn pinned_segments() {
+	module_test(
+		&[
+			"break",
+			"drop aaa c1",
+			"edit aaa c1",
+			"fixup aaa c1",
+			"pick aaa c1",
+			"reword aaa c1",
+			"squash aaa c1",
+			"exec command",
+			"label reference",
+			"reset reference",
+			"merge command",
+		],
+		&[Event::from(MetaEvent::ActionDrop)],
+		|mut test_context| {
+			let mut module = List::new(&Config::new());
+			let _ = test_context.handle_all_events(&mut module);
+			let view_data = test_context.build_view_data(&mut module);
+			assert_rendered_output!(
+				Options AssertRenderOptions::INCLUDE_PINNED | AssertRenderOptions::EXCLUDE_STYLE,
+				view_data,
+				"{TITLE}{HELP}",
+				"{BODY}",
+				"{Pin(3)}{Selected} > break  {Pad( )}",
+				"{Pin(2)}   drop   aaa      c1",
+				"{Pin(2)}   edit   aaa      c1",
+				"{Pin(2)}   fixup  aaa      c1",
+				"{Pin(2)}   pick   aaa      c1",
+				"{Pin(2)}   reword aaa      c1",
+				"{Pin(2)}   squash aaa      c1",
+				"{Pin(3)}   exec   command",
+				"{Pin(3)}   label  reference",
+				"{Pin(3)}   reset  reference",
+				"{Pin(3)}   merge  command"
+			);
+		},
+	);
+}
+
+#[test]
 fn normal_mode_action_change_to_drop() {
 	module_test(
 		&["pick aaa c1"],

--- a/src/view/src/render_slice/tests.rs
+++ b/src/view/src/render_slice/tests.rs
@@ -30,21 +30,21 @@ fn assert_rendered(render_slice: &RenderSlice, expected: &[&str]) {
 		if leading_line_count > 0 {
 			output.push(String::from("{LEADING}"));
 			for line in leading_lines {
-				output.push(render_view_line(line));
+				output.push(render_view_line(line, None));
 			}
 		}
 
 		if lines_count > 0 {
 			output.push(String::from("{BODY}"));
 			for line in body_lines {
-				output.push(render_view_line(line));
+				output.push(render_view_line(line, None));
 			}
 		}
 
 		if trailing_line_count > 0 {
 			output.push(String::from("{TRAILING}"));
 			for line in trailing_lines {
-				output.push(render_view_line(line));
+				output.push(render_view_line(line, None));
 			}
 		}
 	}

--- a/src/view/src/thread/state.rs
+++ b/src/view/src/thread/state.rs
@@ -289,7 +289,7 @@ mod tests {
 				.state
 				.render(&ViewData::new(|updater| updater.push_line(ViewLine::from("Foo"))));
 			assert_eq!(
-				render_view_line(context.state.render_slice().lock().get_lines().first().unwrap()),
+				render_view_line(context.state.render_slice().lock().get_lines().first().unwrap(), None),
 				"{Normal}Foo"
 			);
 		});


### PR DESCRIPTION
There was no way to test how many segments were pinned during test renders. This adds an option to the render macro to render an indicator of the number of pinned sections and adds a test for an incorrectly pinned render.