### PR TITLE
Use shared reference to TodoFile in core crate

### DIFF
--- a/src/core/src/module/mod.rs
+++ b/src/core/src/module/mod.rs
@@ -9,7 +9,6 @@ mod tests;
 use anyhow::Error;
 use input::InputOptions;
 use lazy_static::lazy_static;
-use todo_file::TodoFile;
 use view::{RenderContext, ViewData};
 
 pub(crate) use self::{
@@ -30,7 +29,7 @@ lazy_static! {
 }
 
 pub(crate) trait Module: Send {
-	fn activate(&mut self, _rebase_todo: &TodoFile, _previous_state: State) -> Results {
+	fn activate(&mut self, _previous_state: State) -> Results {
 		Results::new()
 	}
 
@@ -38,7 +37,7 @@ pub(crate) trait Module: Send {
 		Results::new()
 	}
 
-	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, _render_context: &RenderContext) -> &ViewData {
 		&DEFAULT_VIEW_DATA
 	}
 
@@ -50,7 +49,7 @@ pub(crate) trait Module: Send {
 		event
 	}
 
-	fn handle_event(&mut self, _event: Event, _view_state: &view::State, _rebase_todo: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, _event: Event, _view_state: &view::State) -> Results {
 		Results::new()
 	}
 

--- a/src/core/src/module/module_provider.rs
+++ b/src/core/src/module/module_provider.rs
@@ -1,10 +1,14 @@
+use std::sync::Arc;
+
 use config::Config;
 use git::Repository;
+use parking_lot::Mutex;
+use todo_file::TodoFile;
 
 use super::{Module, State};
 
 pub(crate) trait ModuleProvider {
-	fn new(config: &Config, repository: Repository) -> Self;
+	fn new(config: &Config, repository: Repository, todo_file: &Arc<Mutex<TodoFile>>) -> Self;
 
 	fn get_mut_module(&mut self, _state: State) -> &mut dyn Module;
 

--- a/src/core/src/module/tests.rs
+++ b/src/core/src/module/tests.rs
@@ -11,15 +11,8 @@ impl Module for TestModule {}
 
 #[test]
 fn default_trait_method_activate() {
-	module_test(&[], &[], |context| {
-		let mut module = TestModule {};
-		assert!(
-			module
-				.activate(context.todo_file_context.todo_file(), State::List)
-				.artifact()
-				.is_none()
-		);
-	});
+	let mut module = TestModule {};
+	assert!(module.activate(State::List).artifact().is_none());
 }
 
 #[test]
@@ -32,7 +25,7 @@ fn default_trait_method_deactivate() {
 fn default_trait_method_build_view_data() {
 	module_test(&[], &[], |context| {
 		let mut module = TestModule {};
-		let view_data = module.build_view_data(&context.render_context, context.todo_file_context.todo_file());
+		let view_data = module.build_view_data(&context.render_context);
 		assert!(view_data.is_empty());
 	});
 }
@@ -52,13 +45,9 @@ fn default_trait_method_read_event() {
 
 #[test]
 fn default_trait_method_handle_event() {
-	module_test(&[], &[], |mut context| {
+	module_test(&[], &[], |context| {
 		let mut module = TestModule {};
-		let mut result = module.handle_event(
-			Event::from('a'),
-			&context.view_context.state,
-			context.todo_file_context.todo_file_mut(),
-		);
+		let mut result = module.handle_event(Event::from('a'), &context.view_context.state);
 		assert!(result.artifact().is_none());
 	});
 }

--- a/src/core/src/modules/confirm_abort/mod.rs
+++ b/src/core/src/modules/confirm_abort/mod.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use input::InputOptions;
+use parking_lot::Mutex;
 use todo_file::TodoFile;
 use view::{RenderContext, ViewData};
 
@@ -11,10 +14,11 @@ use crate::{
 
 pub(crate) struct ConfirmAbort {
 	dialog: Confirm,
+	todo_file: Arc<Mutex<TodoFile>>,
 }
 
 impl Module for ConfirmAbort {
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, _: &RenderContext) -> &ViewData {
 		self.dialog.get_view_data()
 	}
 
@@ -26,12 +30,12 @@ impl Module for ConfirmAbort {
 		Confirm::read_event(event, key_bindings)
 	}
 
-	fn handle_event(&mut self, event: Event, _: &view::State, rebase_todo: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, event: Event, _: &view::State) -> Results {
 		let confirmed = self.dialog.handle_event(event);
 		let mut results = Results::new();
 		match confirmed {
 			Confirmed::Yes => {
-				rebase_todo.set_lines(vec![]);
+				self.todo_file.lock().set_lines(vec![]);
 				results.exit_status(ExitStatus::Good);
 			},
 			Confirmed::No => {
@@ -44,9 +48,10 @@ impl Module for ConfirmAbort {
 }
 
 impl ConfirmAbort {
-	pub(crate) fn new(confirm_yes: &[String], confirm_no: &[String]) -> Self {
+	pub(crate) fn new(confirm_yes: &[String], confirm_no: &[String], todo_file: Arc<Mutex<TodoFile>>) -> Self {
 		Self {
 			dialog: Confirm::new("Are you sure you want to abort", confirm_yes, confirm_no),
+			todo_file,
 		}
 	}
 }
@@ -59,14 +64,18 @@ mod tests {
 	use super::*;
 	use crate::{assert_results, events::MetaEvent, process::Artifact, testutil::module_test};
 
-	fn create_confirm_abort() -> ConfirmAbort {
-		ConfirmAbort::new(&[String::from("y")], &[String::from("n")])
+	fn create_confirm_abort(todo_file: TodoFile) -> ConfirmAbort {
+		ConfirmAbort::new(
+			&[String::from("y")],
+			&[String::from("n")],
+			Arc::new(Mutex::new(todo_file)),
+		)
 	}
 
 	#[test]
 	fn build_view_data() {
-		module_test(&["pick aaa comment"], &[], |test_context| {
-			let mut module = create_confirm_abort();
+		module_test(&["pick aaa comment"], &[], |mut test_context| {
+			let mut module = create_confirm_abort(test_context.take_todo_file());
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::INCLUDE_TRAILING_WHITESPACE,
@@ -77,20 +86,19 @@ mod tests {
 			);
 		});
 	}
-
 	#[test]
 	fn handle_event_yes() {
 		module_test(
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::Yes)],
 			|mut test_context| {
-				let mut module = create_confirm_abort();
+				let mut module = create_confirm_abort(test_context.take_todo_file());
 				assert_results!(
 					test_context.handle_event(&mut module),
 					Artifact::Event(Event::from(MetaEvent::Yes)),
 					Artifact::ExitStatus(ExitStatus::Good)
 				);
-				assert!(test_context.todo_file_context.todo_file().is_empty());
+				assert!(module.todo_file.lock().is_empty());
 			},
 		);
 	}
@@ -101,7 +109,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(MetaEvent::No)],
 			|mut test_context| {
-				let mut module = create_confirm_abort();
+				let mut module = create_confirm_abort(test_context.take_todo_file());
 				assert_results!(
 					test_context.handle_event(&mut module),
 					Artifact::Event(Event::from(MetaEvent::No)),
@@ -117,7 +125,7 @@ mod tests {
 			&["pick aaa comment"],
 			&[Event::from(KeyCode::Null)],
 			|mut test_context| {
-				let mut module = create_confirm_abort();
+				let mut module = create_confirm_abort(test_context.take_todo_file());
 				assert_results!(
 					test_context.handle_event(&mut module),
 					Artifact::Event(Event::from(KeyCode::Null))

--- a/src/core/src/modules/confirm_rebase/mod.rs
+++ b/src/core/src/modules/confirm_rebase/mod.rs
@@ -1,5 +1,4 @@
 use input::InputOptions;
-use todo_file::TodoFile;
 use view::{RenderContext, ViewData};
 
 use crate::{
@@ -14,7 +13,7 @@ pub(crate) struct ConfirmRebase {
 }
 
 impl Module for ConfirmRebase {
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, _: &RenderContext) -> &ViewData {
 		self.dialog.get_view_data()
 	}
 
@@ -26,7 +25,7 @@ impl Module for ConfirmRebase {
 		Confirm::read_event(event, key_bindings)
 	}
 
-	fn handle_event(&mut self, event: Event, _: &view::State, _: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, event: Event, _: &view::State) -> Results {
 		let confirmed = self.dialog.handle_event(event);
 		let mut results = Results::new();
 		match confirmed {
@@ -49,7 +48,6 @@ impl ConfirmRebase {
 		}
 	}
 }
-
 #[cfg(test)]
 mod tests {
 	use input::KeyCode;
@@ -89,7 +87,6 @@ mod tests {
 					Artifact::Event(Event::from(MetaEvent::Yes)),
 					Artifact::ExitStatus(ExitStatus::Good)
 				);
-				assert!(!test_context.todo_file_context.todo_file().is_empty());
 			},
 		);
 	}

--- a/src/core/src/modules/error/mod.rs
+++ b/src/core/src/modules/error/mod.rs
@@ -2,7 +2,6 @@ use captur::capture;
 use display::DisplayColor;
 use input::InputOptions;
 use lazy_static::lazy_static;
-use todo_file::TodoFile;
 use view::{LineSegment, RenderContext, ViewData, ViewLine};
 
 use crate::{
@@ -22,12 +21,12 @@ pub(crate) struct Error {
 }
 
 impl Module for Error {
-	fn activate(&mut self, _: &TodoFile, previous_state: State) -> Results {
+	fn activate(&mut self, previous_state: State) -> Results {
 		self.return_state = previous_state;
 		Results::new()
 	}
 
-	fn build_view_data(&mut self, _: &RenderContext, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, _: &RenderContext) -> &ViewData {
 		&self.view_data
 	}
 
@@ -35,7 +34,7 @@ impl Module for Error {
 		&INPUT_OPTIONS
 	}
 
-	fn handle_event(&mut self, event: Event, view_state: &view::State, _: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, event: Event, view_state: &view::State) -> Results {
 		let mut results = Results::new();
 		if handle_view_data_scroll(event, view_state).is_none() {
 			if let Event::Key(_) = event {

--- a/src/core/src/modules/insert/tests.rs
+++ b/src/core/src/modules/insert/tests.rs
@@ -4,18 +4,22 @@ use view::assert_rendered_output;
 use super::*;
 use crate::{assert_results, events::Event, process::Artifact, testutil::module_test};
 
+fn create_insert(todo_file: TodoFile) -> Insert {
+	Insert::new(Arc::new(Mutex::new(todo_file)))
+}
+
 #[test]
 fn activate() {
-	module_test(&[], &[], |test_context| {
-		let mut module = Insert::new();
+	module_test(&[], &[], |mut test_context| {
+		let mut module = create_insert(test_context.take_todo_file());
 		assert_results!(test_context.activate(&mut module, State::List));
 	});
 }
 
 #[test]
 fn render_prompt() {
-	module_test(&[], &[], |test_context| {
-		let mut module = Insert::new();
+	module_test(&[], &[], |mut test_context| {
+		let mut module = create_insert(test_context.take_todo_file());
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
 			view_data,
@@ -40,7 +44,7 @@ fn render_prompt() {
 #[test]
 fn prompt_cancel() {
 	module_test(&[], &[Event::from('q')], |mut test_context| {
-		let mut module = Insert::new();
+		let mut module = create_insert(test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from('q')),
@@ -61,7 +65,7 @@ fn edit_render_exec() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -80,15 +84,7 @@ fn edit_render_exec() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"exec foo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "exec foo");
 		},
 	);
 }
@@ -105,7 +101,7 @@ fn edit_render_pick() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -124,15 +120,7 @@ fn edit_render_pick() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"pick abc "
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "pick abc ");
 		},
 	);
 }
@@ -149,7 +137,7 @@ fn edit_render_label() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -168,15 +156,7 @@ fn edit_render_label() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"label foo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "label foo");
 		},
 	);
 }
@@ -193,7 +173,7 @@ fn edit_render_reset() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -212,15 +192,7 @@ fn edit_render_reset() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"reset foo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "reset foo");
 		},
 	);
 }
@@ -237,7 +209,7 @@ fn edit_render_merge() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -256,15 +228,7 @@ fn edit_render_merge() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"merge foo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "merge foo");
 		},
 	);
 }
@@ -281,7 +245,7 @@ fn update_ref_render_merge() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 4);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -300,15 +264,7 @@ fn update_ref_render_merge() {
 				Artifact::Event(Event::from(KeyCode::Enter)),
 				Artifact::ChangeState(State::List)
 			);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.to_text(),
-				"update-ref foo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().to_text(), "update-ref foo");
 		},
 	);
 }
@@ -325,9 +281,9 @@ fn edit_select_next_index() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
-			assert_eq!(test_context.todo_file_context.todo_file().get_selected_line_index(), 1);
+			assert_eq!(module.todo_file.lock().get_selected_line_index(), 1);
 		},
 	);
 }
@@ -338,9 +294,9 @@ fn cancel_edit() {
 		&[],
 		&[Event::from('e'), Event::from(KeyCode::Enter)],
 		|mut test_context| {
-			let mut module = Insert::new();
+			let mut module = create_insert(test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
-			assert!(test_context.todo_file_context.todo_file().is_empty());
+			assert!(module.todo_file.lock().is_empty());
 		},
 	);
 }

--- a/src/core/src/modules/list/tests/abort_and_rebase.rs
+++ b/src/core/src/modules/list/tests/abort_and_rebase.rs
@@ -7,7 +7,7 @@ fn normal_mode_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Abort)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::Abort)),
@@ -23,7 +23,7 @@ fn visual_mode_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Abort)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -40,13 +40,13 @@ fn normal_mode_force_abort() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceAbort)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ForceAbort)),
 				Artifact::ExitStatus(ExitStatus::Good)
 			);
-			assert!(test_context.todo_file_context.todo_file().is_empty());
+			assert!(module.todo_file.lock().is_empty());
 		},
 	);
 }
@@ -60,14 +60,14 @@ fn visual_mode_force_abort() {
 			Event::from(MetaEvent::ForceAbort),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ForceAbort)),
 				Artifact::ExitStatus(ExitStatus::Good)
 			);
-			assert!(test_context.todo_file_context.todo_file().is_empty());
+			assert!(module.todo_file.lock().is_empty());
 		},
 	);
 }
@@ -78,7 +78,7 @@ fn normal_mode_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::Rebase)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::Rebase)),
@@ -94,7 +94,7 @@ fn visual_mode_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode), Event::from(MetaEvent::Rebase)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -111,13 +111,13 @@ fn normal_mode_force_rebase() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ForceRebase)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ForceRebase)),
 				Artifact::ExitStatus(ExitStatus::Good)
 			);
-			assert!(!test_context.todo_file_context.todo_file().is_noop());
+			assert!(!module.todo_file.lock().is_noop());
 		},
 	);
 }
@@ -131,14 +131,14 @@ fn visual_mode_force_rebase() {
 			Event::from(MetaEvent::ForceRebase),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ForceRebase)),
 				Artifact::ExitStatus(ExitStatus::Good)
 			);
-			assert!(!test_context.todo_file_context.todo_file().is_noop());
+			assert!(!module.todo_file.lock().is_noop());
 		},
 	);
 }

--- a/src/core/src/modules/list/tests/change_action.rs
+++ b/src/core/src/modules/list/tests/change_action.rs
@@ -21,7 +21,7 @@ fn pinned_segments() {
 		],
 		&[Event::from(MetaEvent::ActionDrop)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -51,7 +51,7 @@ fn normal_mode_action_change_to_drop() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -83,7 +83,7 @@ fn visual_mode_action_change_to_drop() {
 			Event::from(MetaEvent::ActionDrop),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -107,7 +107,7 @@ fn normal_mode_action_change_to_edit() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionEdit)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -139,7 +139,7 @@ fn visual_mode_action_change_to_edit() {
 			Event::from(MetaEvent::ActionEdit),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -163,7 +163,7 @@ fn normal_mode_action_change_to_fixup() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionFixup)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -195,7 +195,7 @@ fn visual_mode_action_change_to_fixup() {
 			Event::from(MetaEvent::ActionFixup),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -219,7 +219,7 @@ fn normal_mode_action_change_to_pick() {
 		&["drop aaa c1"],
 		&[Event::from(MetaEvent::ActionPick)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -251,7 +251,7 @@ fn visual_mode_action_change_to_pick() {
 			Event::from(MetaEvent::ActionPick),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -275,7 +275,7 @@ fn normal_mode_action_change_to_reword() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionReword)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -307,7 +307,7 @@ fn visual_mode_action_change_to_reword() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -331,7 +331,7 @@ fn normal_mode_action_change_to_squash() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionSquash)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -363,7 +363,7 @@ fn visual_mode_action_change_to_squash() {
 			Event::from(MetaEvent::ActionSquash),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(

--- a/src/core/src/modules/list/tests/edit_mode.rs
+++ b/src/core/src/modules/list/tests/edit_mode.rs
@@ -10,7 +10,7 @@ fn edit_with_edit_content() {
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::Edit)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::Edit))
@@ -23,7 +23,7 @@ fn edit_with_edit_content() {
 #[test]
 fn edit_without_edit_content() {
 	module_test(&["pick aaa c1"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(MetaEvent::Edit))
@@ -35,7 +35,7 @@ fn edit_without_edit_content() {
 #[test]
 fn edit_without_selected_line() {
 	module_test(&[], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(MetaEvent::Edit))
@@ -54,18 +54,10 @@ fn handle_event() {
 			Event::from(KeyCode::Enter),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.build_view_data(&mut module);
 			let _ = test_context.handle_all_events(&mut module);
-			assert_eq!(
-				test_context
-					.todo_file_context
-					.todo_file()
-					.get_line(0)
-					.unwrap()
-					.get_content(),
-				"fo"
-			);
+			assert_eq!(module.todo_file.lock().get_line(0).unwrap().get_content(), "fo");
 			assert_eq!(module.state, ListState::Normal);
 		},
 	);
@@ -74,7 +66,7 @@ fn handle_event() {
 #[test]
 fn render() {
 	module_test(&["exec foo"], &[Event::from(MetaEvent::Edit)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		let _ = test_context.handle_all_events(&mut module);
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(

--- a/src/core/src/modules/list/tests/external_editor.rs
+++ b/src/core/src/modules/list/tests/external_editor.rs
@@ -7,7 +7,7 @@ fn normal_mode_open_external_editor() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::OpenInEditor)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::OpenInEditor)),
@@ -26,7 +26,7 @@ fn visual_mode_open_external_editor() {
 			Event::from(MetaEvent::OpenInEditor),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -48,7 +48,7 @@ fn cancels_search() {
 			Event::from(MetaEvent::OpenInEditor),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert!(!module.search_bar.is_searching());
 		},

--- a/src/core/src/modules/list/tests/help.rs
+++ b/src/core/src/modules/list/tests/help.rs
@@ -10,7 +10,7 @@ fn normal_mode_help() {
 		&["pick aaa c1"],
 		&[Event::from(StandardEvent::Help)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.state = ListState::Normal;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -63,7 +63,7 @@ fn normal_mode_help_event() {
 		&["pick aaa c1"],
 		&[Event::from(StandardEvent::Help), Event::from(KeyCode::Enter)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.state = ListState::Normal;
 			let _ = test_context.handle_all_events(&mut module);
 			assert!(!module.normal_mode_help.is_active());
@@ -77,7 +77,7 @@ fn visual_mode_help() {
 		&["pick aaa c1"],
 		&[Event::from(StandardEvent::Help)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.state = ListState::Visual;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -126,7 +126,7 @@ fn visual_mode_help_event() {
 		&["pick aaa c1"],
 		&[Event::from(StandardEvent::Help), Event::from(KeyCode::Enter)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.state = ListState::Visual;
 			let _ = test_context.handle_all_events(&mut module);
 			assert!(!module.visual_mode_help.is_active());

--- a/src/core/src/modules/list/tests/insert_line.rs
+++ b/src/core/src/modules/list/tests/insert_line.rs
@@ -4,7 +4,7 @@ use crate::{assert_results, process::Artifact, testutil::module_test};
 #[test]
 fn insert_line() {
 	module_test(&[], &[Event::from(MetaEvent::InsertLine)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(MetaEvent::InsertLine)),

--- a/src/core/src/modules/list/tests/mod.rs
+++ b/src/core/src/modules/list/tests/mod.rs
@@ -20,10 +20,14 @@ mod visual_mode;
 use super::*;
 use crate::testutil::module_test;
 
+pub(crate) fn create_list(config: &Config, todo_file: TodoFile) -> List {
+	List::new(config, Arc::new(Mutex::new(todo_file)))
+}
+
 #[test]
 fn resize() {
 	module_test(&["pick aaa c1"], &[Event::Resize(100, 200)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		let _ = test_context.handle_all_events(&mut module);
 		assert_eq!(module.height, 200);
 	});

--- a/src/core/src/modules/list/tests/movement.rs
+++ b/src/core/src/modules/list/tests/movement.rs
@@ -10,7 +10,7 @@ fn move_down_1() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -32,7 +32,7 @@ fn move_down_view_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 2],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -54,7 +54,7 @@ fn move_down_past_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown); 3],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -80,7 +80,7 @@ fn move_down_scroll_bottom_move_up_one() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -106,7 +106,7 @@ fn move_down_scroll_bottom_move_up_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -131,7 +131,7 @@ fn move_up_attempt_above_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -154,7 +154,7 @@ fn move_down_attempt_below_bottom() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorDown); 4],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -177,7 +177,7 @@ fn move_page_up_from_top() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageUp)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -205,7 +205,7 @@ fn move_page_up_from_one_page_down() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -233,7 +233,7 @@ fn move_page_up_from_one_page_down_minus_1() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -262,7 +262,7 @@ fn move_page_up_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -290,7 +290,7 @@ fn move_home() {
 			Event::from(MetaEvent::MoveCursorHome),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -313,7 +313,7 @@ fn move_end() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorEnd)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -336,7 +336,7 @@ fn move_page_down_past_bottom() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3", "pick aaa c4"],
 		&[Event::from(MetaEvent::MoveCursorPageDown); 3],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -365,7 +365,7 @@ fn move_page_down_one_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -391,7 +391,7 @@ fn move_page_down_one_page_from_bottom() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -434,7 +434,7 @@ fn mouse_scroll() {
 			}),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -456,7 +456,7 @@ fn scroll_right() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorRight)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			test_context.view_context.assert_render_action(&["ScrollRight"]);
 		},
@@ -469,7 +469,7 @@ fn scroll_left() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::MoveCursorLeft)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			test_context.view_context.assert_render_action(&["ScrollLeft"]);
 		},

--- a/src/core/src/modules/list/tests/normal_mode.rs
+++ b/src/core/src/modules/list/tests/normal_mode.rs
@@ -12,7 +12,7 @@ fn change_auto_select_next_with_next_line() {
 		|mut test_context| {
 			let mut config = Config::new();
 			config.auto_select_next = true;
-			let mut module = List::new(&config);
+			let mut module = create_list(&config, test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -32,7 +32,7 @@ fn toggle_visual_mode() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ToggleVisualMode))
@@ -46,7 +46,7 @@ fn toggle_visual_mode() {
 #[test]
 fn other_event() {
 	module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(KeyCode::Null))

--- a/src/core/src/modules/list/tests/read_event.rs
+++ b/src/core/src/modules/list/tests/read_event.rs
@@ -4,14 +4,10 @@ use rstest::rstest;
 use super::*;
 use crate::testutil::read_event_test;
 
-fn create_list_module() -> List {
-	List::new(&Config::new())
-}
-
 #[test]
 fn edit_mode_passthrough_event() {
 	read_event_test(Event::from('p'), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.state = ListState::Edit;
 		assert_eq!(context.read_event(&mut module), Event::from('p'));
 	});
@@ -20,7 +16,7 @@ fn edit_mode_passthrough_event() {
 #[test]
 fn normal_mode_help() {
 	read_event_test(Event::from('?'), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.normal_mode_help.set_active();
 		assert_eq!(context.read_event(&mut module), Event::from(StandardEvent::Help));
 	});
@@ -29,7 +25,7 @@ fn normal_mode_help() {
 #[test]
 fn visual_mode_help() {
 	read_event_test(Event::from('?'), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.visual_mode_help.set_active();
 		assert_eq!(context.read_event(&mut module), Event::from(StandardEvent::Help));
 	});
@@ -38,7 +34,7 @@ fn visual_mode_help() {
 #[test]
 fn search() {
 	read_event_test(Event::from('p'), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.search_bar.start_search(Some(""));
 		assert_eq!(context.read_event(&mut module), Event::from('p'));
 	});
@@ -65,7 +61,7 @@ fn search() {
 #[case::togglevisualmode('v', MetaEvent::ToggleVisualMode)]
 fn default_events_single_char(#[case] binding: char, #[case] expected: MetaEvent) {
 	read_event_test(Event::from(binding), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		assert_eq!(context.read_event(&mut module), Event::from(expected));
 	});
 }
@@ -82,7 +78,7 @@ fn default_events_single_char(#[case] binding: char, #[case] expected: MetaEvent
 #[case::delete(KeyCode::Delete, MetaEvent::Delete)]
 fn default_events_special(#[case] code: KeyCode, #[case] expected: MetaEvent) {
 	read_event_test(Event::from(code), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		assert_eq!(context.read_event(&mut module), Event::from(expected));
 	});
 }
@@ -93,7 +89,7 @@ fn default_events_special(#[case] code: KeyCode, #[case] expected: MetaEvent) {
 #[case::abort('p', MetaEvent::ActionPick)]
 fn fixup_events(#[case] binding: char, #[case] expected: MetaEvent) {
 	read_event_test(Event::from(binding), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.selected_line_action = Some(Action::Fixup);
 		assert_eq!(context.read_event(&mut module), Event::from(expected));
 	});
@@ -104,7 +100,7 @@ fn fixup_events(#[case] binding: char, #[case] expected: MetaEvent) {
 #[case::abort('U')]
 fn fixup_events_with_non_fixpo_event(#[case] binding: char) {
 	read_event_test(Event::from(binding), |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		module.selected_line_action = Some(Action::Pick);
 		assert_eq!(context.read_event(&mut module), Event::from(binding));
 	});
@@ -120,7 +116,7 @@ fn mouse_move_down() {
 			modifiers: KeyModifiers::empty(),
 		}),
 		|mut context| {
-			let mut module = create_list_module();
+			let mut module = create_list(&Config::new(), context.take_todo_file());
 			assert_eq!(context.read_event(&mut module), Event::from(MetaEvent::MoveCursorDown));
 		},
 	);
@@ -136,7 +132,7 @@ fn mouse_move_up() {
 			modifiers: KeyModifiers::empty(),
 		}),
 		|mut context| {
-			let mut module = create_list_module();
+			let mut module = create_list(&Config::new(), context.take_todo_file());
 			assert_eq!(context.read_event(&mut module), Event::from(MetaEvent::MoveCursorUp));
 		},
 	);
@@ -151,7 +147,7 @@ fn mouse_other() {
 		modifiers: KeyModifiers::empty(),
 	});
 	read_event_test(mouse_event, |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		assert_eq!(context.read_event(&mut module), mouse_event);
 	});
 }
@@ -159,7 +155,7 @@ fn mouse_other() {
 #[test]
 fn event_other() {
 	read_event_test(Event::None, |mut context| {
-		let mut module = create_list_module();
+		let mut module = create_list(&Config::new(), context.take_todo_file());
 		assert_eq!(context.read_event(&mut module), Event::None);
 	});
 }

--- a/src/core/src/modules/list/tests/remove_lines.rs
+++ b/src/core/src/modules/list/tests/remove_lines.rs
@@ -15,7 +15,7 @@ fn normal_mode_remove_line_first() {
 		],
 		&[Event::from(MetaEvent::Delete)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -49,7 +49,7 @@ fn normal_mode_remove_line_end() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -82,7 +82,7 @@ fn visual_mode_remove_lines_start_index_first() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -94,7 +94,7 @@ fn visual_mode_remove_lines_start_index_first() {
 			);
 			assert_eq!(
 				module.visual_index_start.unwrap(),
-				test_context.todo_file_context.todo_file().get_selected_line_index()
+				module.todo_file.lock().get_selected_line_index()
 			);
 		},
 	);
@@ -119,7 +119,7 @@ fn visual_mode_remove_lines_end_index_first() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -131,7 +131,7 @@ fn visual_mode_remove_lines_end_index_first() {
 			);
 			assert_eq!(
 				module.visual_index_start.unwrap(),
-				test_context.todo_file_context.todo_file().get_selected_line_index()
+				module.todo_file.lock().get_selected_line_index()
 			);
 		},
 	);
@@ -158,7 +158,7 @@ fn visual_mode_remove_lines_start_index_last() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -170,7 +170,7 @@ fn visual_mode_remove_lines_start_index_last() {
 			);
 			assert_eq!(
 				module.visual_index_start.unwrap(),
-				test_context.todo_file_context.todo_file().get_selected_line_index()
+				module.todo_file.lock().get_selected_line_index()
 			);
 		},
 	);
@@ -195,7 +195,7 @@ fn visual_mode_remove_lines_end_index_last() {
 			Event::from(MetaEvent::Delete),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -207,7 +207,7 @@ fn visual_mode_remove_lines_end_index_last() {
 			);
 			assert_eq!(
 				module.visual_index_start.unwrap(),
-				test_context.todo_file_context.todo_file().get_selected_line_index()
+				module.todo_file.lock().get_selected_line_index()
 			);
 		},
 	);

--- a/src/core/src/modules/list/tests/render.rs
+++ b/src/core/src/modules/list/tests/render.rs
@@ -5,8 +5,8 @@ use crate::testutil::module_test;
 
 #[test]
 fn empty_list() {
-	module_test(&[], &[], |test_context| {
-		let mut module = List::new(&Config::new());
+	module_test(&[], &[], |mut test_context| {
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
 			view_data,
@@ -37,8 +37,8 @@ fn full() {
 			"update-ref reference",
 		],
 		&[],
-		|test_context| {
-			let mut module = List::new(&Config::new());
+		|mut test_context| {
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -85,7 +85,7 @@ fn compact() {
 		&[],
 		|mut test_context| {
 			test_context.render_context.update(30, 300);
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
 				view_data,
@@ -114,12 +114,12 @@ fn compact() {
 #[test]
 fn noop_list() {
 	module_test(&["break"], &[], |mut test_context| {
-		let mut module = List::new(&Config::new());
-		test_context.todo_file_context.todo_file_mut().remove_lines(0, 0);
-		test_context
-			.todo_file_context
-			.todo_file_mut()
-			.add_line(0, Line::new("noop").unwrap());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
+		let mut todo_file = module.todo_file.lock();
+		todo_file.remove_lines(0, 0);
+		todo_file.add_line(0, Line::new("noop").unwrap());
+		drop(todo_file);
+
 		let view_data = test_context.build_view_data(&mut module);
 		assert_rendered_output!(
 			view_data,

--- a/src/core/src/modules/list/tests/search.rs
+++ b/src/core/src/modules/list/tests/search.rs
@@ -9,7 +9,7 @@ fn start_edit() {
 		&["pick aaaaaaaa comment"],
 		&[Event::from(StandardEvent::SearchStart)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -35,7 +35,7 @@ fn with_match_on_hash() {
 			Event::from('a'),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -56,7 +56,7 @@ fn with_no_match() {
 		&["pick aaaaaaaa comment1"],
 		&[Event::from(StandardEvent::SearchStart), Event::from('x')],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -81,7 +81,7 @@ fn start_with_matches_and_with_term() {
 			Event::from(StandardEvent::SearchFinish),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -106,7 +106,7 @@ fn start_with_no_matches_and_with_term() {
 			Event::from(StandardEvent::SearchFinish),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -130,7 +130,7 @@ fn start_with_no_term() {
 			Event::from(StandardEvent::SearchFinish),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -154,7 +154,7 @@ fn normal_mode_next() {
 			Event::from(StandardEvent::SearchNext),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -183,7 +183,7 @@ fn visual_mode_next() {
 			Event::from(StandardEvent::SearchNext),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -213,7 +213,7 @@ fn normal_mode_next_with_wrap() {
 			Event::from(StandardEvent::SearchNext),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -244,7 +244,7 @@ fn visual_mode_next_with_wrap() {
 			Event::from(StandardEvent::SearchNext),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -274,7 +274,7 @@ fn normal_mode_previous() {
 			Event::from(StandardEvent::SearchPrevious),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -305,7 +305,7 @@ fn visual_mode_previous() {
 			Event::from(StandardEvent::SearchPrevious),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -333,7 +333,7 @@ fn normal_mode_previous_with_wrap() {
 			Event::from(StandardEvent::SearchPrevious),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -362,7 +362,7 @@ fn visual_mode_previous_with_wrap() {
 			Event::from(StandardEvent::SearchPrevious),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -390,7 +390,7 @@ fn cancel() {
 			Event::from(StandardEvent::SearchStart),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -422,7 +422,7 @@ fn set_search_start_hint() {
 			Event::from(StandardEvent::SearchFinish),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -447,7 +447,7 @@ fn highlight_multiple() {
 		&["pick 12345678 xaxxaxxx"],
 		&[Event::from(StandardEvent::SearchStart), Event::from('x')],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -469,7 +469,7 @@ fn skip_no_content() {
 		&["break"],
 		&[Event::from(StandardEvent::SearchStart), Event::from('x')],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -494,7 +494,7 @@ fn handle_other_event() {
 			Event::from(MetaEvent::Abort),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let mut results: Vec<_> = test_context.handle_all_events(&mut module);
 			assert_results!(
 				results.remove(results.len() - 1),

--- a/src/core/src/modules/list/tests/show_commit.rs
+++ b/src/core/src/modules/list/tests/show_commit.rs
@@ -7,7 +7,7 @@ fn when_hash_available() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ShowCommit)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ShowCommit)),
@@ -20,7 +20,7 @@ fn when_hash_available() {
 #[test]
 fn when_no_selected_line() {
 	module_test(&[], &[Event::from(MetaEvent::ShowCommit)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(MetaEvent::ShowCommit))
@@ -34,7 +34,7 @@ fn do_not_when_hash_not_available() {
 		&["exec echo foo"],
 		&[Event::from(MetaEvent::ShowCommit)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			assert_results!(
 				test_context.handle_event(&mut module),
 				Artifact::Event(Event::from(MetaEvent::ShowCommit))

--- a/src/core/src/modules/list/tests/swap_lines.rs
+++ b/src/core/src/modules/list/tests/swap_lines.rs
@@ -9,7 +9,7 @@ fn normal_mode_change_swap_down() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::SwapSelectedDown)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -43,7 +43,7 @@ fn visual_mode_swap_down_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -81,7 +81,7 @@ fn visual_mode_swap_down_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -120,7 +120,7 @@ fn visual_mode_swap_down_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -157,7 +157,7 @@ fn visual_mode_swap_down_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -185,7 +185,7 @@ fn normal_mode_change_swap_up() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -219,7 +219,7 @@ fn visual_mode_swap_up_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -257,7 +257,7 @@ fn visual_mode_swap_up_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -294,7 +294,7 @@ fn visual_mode_swap_up_to_limit_from_top_to_bottom_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -333,7 +333,7 @@ fn visual_mode_swap_up_to_limit_from_bottom_to_top_selection() {
 			Event::from(MetaEvent::SwapSelectedUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(

--- a/src/core/src/modules/list/tests/toggle_break.rs
+++ b/src/core/src/modules/list/tests/toggle_break.rs
@@ -9,7 +9,7 @@ fn change_toggle_break_add() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionBreak)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -33,7 +33,7 @@ fn change_toggle_break_remove() {
 			Event::from(MetaEvent::ActionBreak),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -53,7 +53,7 @@ fn change_toggle_break_above_existing() {
 		&["pick aaa c1", "break"],
 		&[Event::from(MetaEvent::ActionBreak)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(

--- a/src/core/src/modules/list/tests/toggle_option.rs
+++ b/src/core/src/modules/list/tests/toggle_option.rs
@@ -9,10 +9,11 @@ fn on_fixup_keep_message() {
 		&["fixup aaa c1"],
 		&[Event::from(MetaEvent::FixupKeepMessage)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.activate(&mut module, State::List);
 			let _ = test_context.handle_all_events(&mut module);
-			let line = test_context.todo_file_context.todo_file().get_line(0).unwrap();
+			let todo_file = module.todo_file.lock();
+			let line = todo_file.get_line(0).unwrap();
 			assert_some_eq!(line.option(), "-C");
 		},
 	);
@@ -24,10 +25,11 @@ fn on_fixup_keep_message_with_editor() {
 		&["fixup aaa c1"],
 		&[Event::from(MetaEvent::FixupKeepMessageWithEditor)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.activate(&mut module, State::List);
 			let _ = test_context.handle_all_events(&mut module);
-			let line = test_context.todo_file_context.todo_file().get_line(0).unwrap();
+			let todo_file = module.todo_file.lock();
+			let line = todo_file.get_line(0).unwrap();
 			assert_some_eq!(line.option(), "-c");
 		},
 	);
@@ -39,12 +41,12 @@ fn after_select_line() {
 		&["fixup aaa c1", "fixup aaa c2", "fixup aaa c3"],
 		&[Event::from(MetaEvent::MoveCursorDown), Event::from('u')],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.activate(&mut module, State::List);
 			let _ = test_context.handle_all_events(&mut module);
-			assert_none!(test_context.todo_file_context.todo_file().get_line(0).unwrap().option());
-			assert_some!(test_context.todo_file_context.todo_file().get_line(1).unwrap().option());
-			assert_none!(test_context.todo_file_context.todo_file().get_line(2).unwrap().option());
+			assert_none!(module.todo_file.lock().get_line(0).unwrap().option());
+			assert_some!(module.todo_file.lock().get_line(1).unwrap().option());
+			assert_none!(module.todo_file.lock().get_line(2).unwrap().option());
 		},
 	);
 }

--- a/src/core/src/modules/list/tests/undo_redo.rs
+++ b/src/core/src/modules/list/tests/undo_redo.rs
@@ -9,7 +9,7 @@ fn normal_mode_undo() {
 		&["pick aaa c1"],
 		&[Event::from(MetaEvent::ActionDrop), Event::from(StandardEvent::Undo)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -39,7 +39,7 @@ fn normal_mode_undo_visual_mode_change() {
 			Event::from(StandardEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -64,7 +64,7 @@ fn normal_mode_redo() {
 			Event::from(StandardEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
@@ -95,7 +95,7 @@ fn normal_mode_redo_visual_mode_change() {
 			Event::from(StandardEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -121,7 +121,7 @@ fn visual_mode_undo() {
 			Event::from(StandardEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 3);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -150,7 +150,7 @@ fn visual_mode_undo_normal_mode_change() {
 			Event::from(StandardEvent::Undo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_n_events(&mut module, 3);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -181,7 +181,7 @@ fn visual_mode_redo() {
 			Event::from(StandardEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,
@@ -207,7 +207,7 @@ fn visual_mode_redo_normal_mode_change() {
 			Event::from(StandardEvent::Redo),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			assert_rendered_output!(
 				Options AssertRenderOptions::EXCLUDE_STYLE,

--- a/src/core/src/modules/list/tests/visual_mode.rs
+++ b/src/core/src/modules/list/tests/visual_mode.rs
@@ -10,7 +10,7 @@ fn start() {
 		&["pick aaa c1", "pick aaa c2", "pick aaa c3"],
 		&[Event::from(MetaEvent::ToggleVisualMode)],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -34,7 +34,7 @@ fn start_cursor_down_one() {
 			Event::from(MetaEvent::MoveCursorDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -64,7 +64,7 @@ fn start_cursor_page_down() {
 			Event::from(MetaEvent::MoveCursorPageDown),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			module.height = 4;
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
@@ -101,7 +101,7 @@ fn start_cursor_from_bottom_move_up() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -140,7 +140,7 @@ fn start_cursor_from_bottom_to_top() {
 			Event::from(MetaEvent::MoveCursorUp),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -168,7 +168,7 @@ fn action_change_top_bottom() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -196,7 +196,7 @@ fn action_change_bottom_top() {
 			Event::from(MetaEvent::ActionReword),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
@@ -220,7 +220,7 @@ fn toggle_visual_mode() {
 			Event::from(MetaEvent::ToggleVisualMode),
 		],
 		|mut test_context| {
-			let mut module = List::new(&Config::new());
+			let mut module = create_list(&Config::new(), test_context.take_todo_file());
 			let _ = test_context.handle_event(&mut module);
 			assert_results!(
 				test_context.handle_event(&mut module),
@@ -235,7 +235,7 @@ fn toggle_visual_mode() {
 #[test]
 fn other_event() {
 	module_test(&["pick aaa c1"], &[Event::from(KeyCode::Null)], |mut test_context| {
-		let mut module = List::new(&Config::new());
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		assert_results!(
 			test_context.handle_event(&mut module),
 			Artifact::Event(Event::from(KeyCode::Null))

--- a/src/core/src/modules/window_size_error/mod.rs
+++ b/src/core/src/modules/window_size_error/mod.rs
@@ -1,6 +1,5 @@
 use input::InputOptions;
 use lazy_static::lazy_static;
-use todo_file::TodoFile;
 use view::{RenderContext, ViewData, ViewLine};
 
 use crate::{
@@ -23,12 +22,12 @@ pub(crate) struct WindowSizeError {
 }
 
 impl Module for WindowSizeError {
-	fn activate(&mut self, _: &TodoFile, previous_state: State) -> Results {
+	fn activate(&mut self, previous_state: State) -> Results {
 		self.return_state = previous_state;
 		Results::new()
 	}
 
-	fn build_view_data(&mut self, context: &RenderContext, _: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, context: &RenderContext) -> &ViewData {
 		let view_width = context.width();
 		let message = if !context.is_minimum_view_width() {
 			if view_width >= SHORT_ERROR_MESSAGE.len() {
@@ -58,7 +57,7 @@ impl Module for WindowSizeError {
 		&INPUT_OPTIONS
 	}
 
-	fn handle_event(&mut self, event: Event, _: &view::State, _: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, event: Event, _: &view::State) -> Results {
 		let mut results = Results::new();
 
 		if let Event::Resize(width, height) = event {

--- a/src/core/src/process/tests.rs
+++ b/src/core/src/process/tests.rs
@@ -33,7 +33,7 @@ impl TestModule {
 }
 
 impl Module for TestModule {
-	fn activate(&mut self, _rebase_todo: &TodoFile, previous_state: State) -> Results {
+	fn activate(&mut self, previous_state: State) -> Results {
 		self.trace.lock().push(format!("activate(state = {previous_state:?})"));
 		Results::new()
 	}
@@ -43,7 +43,7 @@ impl Module for TestModule {
 		Results::new()
 	}
 
-	fn build_view_data(&mut self, _render_context: &RenderContext, _rebase_todo: &TodoFile) -> &ViewData {
+	fn build_view_data(&mut self, _render_context: &RenderContext) -> &ViewData {
 		self.trace.lock().push(String::from("build_view_data"));
 		&DEFAULT_VIEW_DATA
 	}
@@ -58,7 +58,7 @@ impl Module for TestModule {
 		event
 	}
 
-	fn handle_event(&mut self, event: Event, _view_state: &view::State, _rebase_todo: &mut TodoFile) -> Results {
+	fn handle_event(&mut self, event: Event, _view_state: &view::State) -> Results {
 		self.trace.lock().push(format!("handle_event(event = {event:?})"));
 		Results::new()
 	}
@@ -189,13 +189,13 @@ fn write_todo_file() {
 		create_default_test_module_handler(),
 		|ProcessTestContext { process, .. }| {
 			process
-				.rebase_todo
+				.todo_file
 				.lock()
 				.set_lines(vec![Line::new("fixup ddd comment").unwrap()]);
 			process.write_todo_file().unwrap();
-			process.rebase_todo.lock().load_file().unwrap();
+			process.todo_file.lock().load_file().unwrap();
 			assert_eq!(
-				process.rebase_todo.lock().get_line(0).unwrap(),
+				process.todo_file.lock().get_line(0).unwrap(),
 				&Line::new("fixup ddd comment").unwrap()
 			);
 		},

--- a/src/core/src/testutil/process_test.rs
+++ b/src/core/src/testutil/process_test.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use display::Size;
+use parking_lot::Mutex;
 use runtime::ThreadStatuses;
 use todo_file::testutil::with_todo_file;
 use view::testutil::{with_view_state, TestContext as ViewContext};
@@ -37,7 +38,7 @@ pub(crate) fn process_test<C, ModuleProvider: module::ModuleProvider + Send + 's
 					event_handler_context,
 					process: Process::new(
 						Size::new(300, 120),
-						todo_file,
+						Arc::new(Mutex::new(todo_file)),
 						module_handler,
 						input_state,
 						view_state,

--- a/src/core/src/testutil/test_module_provider.rs
+++ b/src/core/src/testutil/test_module_provider.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use config::Config;
 use git::Repository;
 use input::EventHandler;
+use parking_lot::Mutex;
+use todo_file::TodoFile;
 
 use crate::{
 	module::{Module, ModuleHandler, ModuleProvider, State},
@@ -18,7 +22,7 @@ impl<M: Module> From<M> for TestModuleProvider<M> {
 }
 
 impl<M: Module> ModuleProvider for TestModuleProvider<M> {
-	fn new(_: &Config, _: Repository) -> Self {
+	fn new(_: &Config, _: Repository, _: &Arc<Mutex<TodoFile>>) -> Self {
 		unimplemented!("Not implemented for the TestModuleProvider");
 	}
 


### PR DESCRIPTION
Previously, the TodoFile reference was passed through the Module methods, but this resulted in a messy interface, where modules that did not need to use the TodoFile reference ended up having an ignored parameter. Also, if the TodoFile needed to be accessed outside of the methods of the Module, then the modules got more complicated.

This change, adds a shared Arc<Mutex<TodoFile>> to all modules and related processing code, and removes the method references from the Module trait.