### PR TITLE
Refactor Application thread ownership

### DIFF
--- a/src/core/src/editor.rs
+++ b/src/core/src/editor.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[cfg(not(tarpaulin_include))]
 pub(crate) fn run(args: &Args) -> Exit {
-	let application: Application<Modules, _, _> = match Application::new(args, read_event, CrossTerm::new()) {
+	let mut application: Application<Modules> = match Application::new(args, read_event, CrossTerm::new()) {
 		Ok(app) => app,
 		Err(exit) => return exit,
 	};


### PR DESCRIPTION
Change how the application manages the ownership of threads, to reduce the amount of initialization the handles during running.