### PR TITLE
Fix sharing of ThreadStatus

### DIFF
--- a/src/runtime/src/installer.rs
+++ b/src/runtime/src/installer.rs
@@ -16,10 +16,10 @@ pub struct Installer {
 }
 
 impl Installer {
-	pub(crate) fn new(sender: Sender<(String, Status)>) -> Self {
+	pub(crate) fn new(thread_statuses: ThreadStatuses, sender: Sender<(String, Status)>) -> Self {
 		Self {
 			sender,
-			thread_statuses: ThreadStatuses::new(),
+			thread_statuses,
 			ops: RefCell::new(HashMap::new()),
 		}
 	}
@@ -94,7 +94,7 @@ mod tests {
 	#[test]
 	fn test() {
 		let (sender, _receiver) = unbounded();
-		let installer = Installer::new(sender);
+		let installer = Installer::new(ThreadStatuses::new(), sender);
 
 		let thread = Thread::new();
 		thread.install(&installer);
@@ -109,7 +109,7 @@ mod tests {
 	#[test]
 	fn debug() {
 		let (sender, _receiver) = unbounded();
-		let installer = Installer::new(sender);
+		let installer = Installer::new(ThreadStatuses::new(), sender);
 		assert_eq!(
 			format!("{installer:?}"),
 			"Installer { sender: Sender { .. }, thread_statuses: ThreadStatuses { statuses: Mutex { data: {} } }, .. }"

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -21,10 +21,9 @@ impl<'runtime> Runtime<'runtime> {
 	/// Create a new instances of the `Runtime`.
 	#[inline]
 	#[must_use]
-	pub fn new() -> Self {
+	pub fn new(thread_statuses: ThreadStatuses) -> Self {
 		let (sender, receiver) = unbounded();
 
-		let thread_statuses = ThreadStatuses::new();
 		thread_statuses.register_thread(RUNTIME_THREAD_NAME, Status::Waiting);
 
 		Self {
@@ -54,7 +53,7 @@ impl<'runtime> Runtime<'runtime> {
 	/// Returns and error if any of the threads registered to the runtime produce an error.
 	#[inline]
 	pub fn join(&self) -> Result<(), RuntimeError> {
-		let installer = Installer::new(self.sender.clone());
+		let installer = Installer::new(self.thread_statuses.clone(), self.sender.clone());
 		{
 			let threadables = self.threadables.lock();
 			for threadable in threadables.iter() {
@@ -166,7 +165,7 @@ mod tests {
 			}
 		}
 
-		let runtime = Runtime::new();
+		let runtime = Runtime::new(ThreadStatuses::new());
 		let mut thread = Thread::new();
 		runtime.register(&mut thread);
 		runtime.join().unwrap();
@@ -223,7 +222,7 @@ mod tests {
 			}
 		}
 
-		let runtime = Runtime::new();
+		let runtime = Runtime::new(ThreadStatuses::new());
 		let mut thread1 = Thread1::new();
 		let mut thread2 = Thread2::new();
 		runtime.register(&mut thread1);
@@ -283,7 +282,7 @@ mod tests {
 			}
 		}
 
-		let runtime = Runtime::new();
+		let runtime = Runtime::new(ThreadStatuses::new());
 		let mut thread1 = Thread1::new();
 		let mut thread2 = Thread2::new();
 		runtime.register(&mut thread1);
@@ -344,7 +343,7 @@ mod tests {
 			}
 		}
 
-		let runtime = Runtime::new();
+		let runtime = Runtime::new(ThreadStatuses::new());
 		let mut thread1 = Thread1::new();
 		let mut thread2 = Thread2::new();
 		runtime.register(&mut thread1);
@@ -404,7 +403,7 @@ mod tests {
 			}
 		}
 
-		let runtime = Runtime::new();
+		let runtime = Runtime::new(ThreadStatuses::new());
 		let mut thread1 = Thread1::new();
 		let mut thread2 = Thread2::new();
 		runtime.register(&mut thread1);

--- a/src/runtime/src/testutils/mod.rs
+++ b/src/runtime/src/testutils/mod.rs
@@ -75,7 +75,7 @@ impl ThreadableTester {
 	#[allow(clippy::missing_panics_doc)]
 	pub fn start_threadable<Threadable: crate::Threadable>(&self, theadable: &Threadable, thread_name: &str) {
 		self.ended.store(false, Ordering::Release);
-		let installer = Installer::new(self.sender.clone());
+		let installer = Installer::new(ThreadStatuses::new(), self.sender.clone());
 		theadable.install(&installer);
 		let mut ops = installer.into_ops();
 		let op = ops.remove(thread_name).expect("Expected to find thead");


### PR DESCRIPTION
Application was creating two instances of Runtime, the first instance was only being used to create a ThreadStatus that was passed to Process. The second instance was the real Runtime, that would handle all the thread management and status tracking. The problem, was that Process had an incorrect copy of ThreadStatus, so the status checks Process performed were not completing. This resulted in things like the External Editor functionality stalling, when it was waiting for thread status updated.

This change creates a single instance of the ThreadStatus that is shared across the Process and Runtime.