### PR TITLE
A few cleanup tasks from the 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [2.3.0] - 2022-10-13
+## [2.3.0] - 2023-07-19
 ### Added
 - Support for update-ref action ([#801](https://github.com/MitMaro/git-interactive-rebase-tool/pull/801))
 - Search in the list view ([#797](https://github.com/MitMaro/git-interactive-rebase-tool/pull/797))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Native cross-platform full feature terminal based [sequence editor][git-sequence
 
 [![Git Interactive Rebase Tool](/docs/assets/images/girt-demo.gif?raw=true)](https://youtu.be/q3tzb-gQC0w)
 
+**This is the documentation for the development build. For the current stable release, please use the [2.3.x documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/2.3.0/README.md).**
+
 ## Table of Contents
 
 * [Features](./README.md#features)

--- a/scripts/publish.bash
+++ b/scripts/publish.bash
@@ -14,8 +14,8 @@ fi
 
 # order is based on dependency graph
 crates=(
-	"src/git"
 	"src/testutils"
+	"src/git"
 	"src/config"
 	"src/display"
 	"src/todo_file"


### PR DESCRIPTION
This change includes:

- Fix the date on the change log
- Add development docs notice to the readme
- Fix an ordering issue in the publish script