### PR TITLE
Make clear that visual mode is for selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Key bindings can be customized, see [configuration](readme/customization.md#key-
 | `f`         | Normal/Diff | Set selected commit(s) to be fixed-up     |
 | `d`         | Normal/Diff | Set selected commit(s) to be dropped      |
 | `E`         | Normal      | Edit the command of an editable action    |
-| `v`         | Normal/Diff | Enter and exit visual mode                |
+| `v`         | Normal/Diff | Enter and exit visual mode (for selection)|
 | `I`         | Normal      | Insert a new line                         |
 | `Delete`    | Normal/Diff | Remove selected lines                     |
 | `!`         | Normal/Diff | Open todo file in external editor         |

--- a/src/core/src/modules/list/tests/help.rs
+++ b/src/core/src/modules/list/tests/help.rs
@@ -49,7 +49,7 @@ fn normal_mode_help() {
 				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
 				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
 				"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
-				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual mode",
+				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Enter visual selection mode",
 				"{TRAILING}",
 				"{IndicatorColor}Press any key to close"
 			);
@@ -112,7 +112,7 @@ fn visual_mode_help() {
 				"{IndicatorColor} Controlz{Normal,Dimmed}|{Normal}Undo the last change",
 				"{IndicatorColor} Controly{Normal,Dimmed}|{Normal}Redo the previous undone change",
 				"{IndicatorColor} !       {Normal,Dimmed}|{Normal}Open the todo file in the default editor",
-				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual mode",
+				"{IndicatorColor} v       {Normal,Dimmed}|{Normal}Exit visual selection mode",
 				"{TRAILING}",
 				"{IndicatorColor}Press any key to close"
 			);

--- a/src/core/src/modules/list/utils.rs
+++ b/src/core/src/modules/list/utils.rs
@@ -150,12 +150,12 @@ fn build_help_lines(key_bindings: &KeyBindings, selector: HelpLinesSelector) -> 
 		),
 		(
 			&key_bindings.toggle_visual_mode,
-			"Enter visual mode",
+			"Enter visual selection mode",
 			HelpLinesSelector::Normal,
 		),
 		(
 			&key_bindings.toggle_visual_mode,
-			"Exit visual mode",
+			"Exit visual selection mode",
 			HelpLinesSelector::Visual,
 		),
 	];


### PR DESCRIPTION
For non-vim users, it may be not obvious, that visual mode is used for selection of lines.

Thanks a lot for developing and maintaining this valuable tool. :clap: 