### PR TITLE
Enable tty support on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "filedescriptor",
  "libc",
  "mio",
  "parking_lot",
@@ -196,6 +197,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/src/input/Cargo.toml
+++ b/src/input/Cargo.toml
@@ -24,6 +24,10 @@ parking_lot = "0.12.1"
 girt-config = {version = "2.3.0", path = "../config"}
 girt-runtime = {version = "2.3.0", path = "../runtime"}
 
+# Fix tty issues on MacOS
+[target.'cfg(target_os = "macos")'.dependencies]
+crossterm = { version = "0.26.1", features = ["use-dev-tty"] }
+
 [dev-dependencies]
 rstest = "0.18.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Crossterm has added tty pipe support behind a feature flag. This enables that feature flag on macOS to allow for pipes to work again. This technically creates a small performance drop on macOS, but since this application is generally not IO bounded, this should be okay.

Fixes #489 