### PR TITLE
Add Operation::Load to History

### DIFF
--- a/src/todo_file/src/history/history_item.rs
+++ b/src/todo_file/src/history/history_item.rs
@@ -9,6 +9,15 @@ pub(crate) struct HistoryItem {
 }
 
 impl HistoryItem {
+	pub(crate) const fn new_load() -> Self {
+		Self {
+			operation: Operation::Load,
+			start_index: 0,
+			end_index: 0,
+			lines: vec![],
+		}
+	}
+
 	pub(crate) fn new_modify(start_index: usize, end_index: usize, lines: Vec<Line>) -> Self {
 		Self {
 			operation: Operation::Modify,

--- a/src/todo_file/src/history/mod.rs
+++ b/src/todo_file/src/history/mod.rs
@@ -23,13 +23,14 @@ impl History {
 	pub(crate) fn new(limit: u32) -> Self {
 		Self {
 			redo_history: VecDeque::new(),
-			undo_history: VecDeque::new(),
+			undo_history: VecDeque::from([HistoryItem::new_load()]),
 			limit: limit.try_into().expect("History limit is too large"),
 		}
 	}
 
 	pub(crate) fn apply_operation(lines: &mut Vec<Line>, operation: &HistoryItem) -> HistoryItem {
 		match operation.operation {
+			Operation::Load => HistoryItem::new_load(),
 			Operation::Modify => {
 				let range = if operation.end_index <= operation.start_index {
 					operation.end_index..=operation.start_index
@@ -73,32 +74,40 @@ impl History {
 		}
 	}
 
-	pub(crate) fn undo(&mut self, current: &mut Vec<Line>) -> Option<(usize, usize)> {
-		self.undo_history.pop_back().map(|operation| {
-			let history = Self::apply_operation(current, &operation);
+	pub(crate) fn undo(&mut self, current: &mut Vec<Line>) -> Option<(Operation, usize, usize)> {
+		self.undo_history.pop_back().map(|history_item| {
+			let history = Self::apply_operation(current, &history_item);
+			// do not remove load operation from undo history, as it acts as a sentinel value
+			if history.operation == Operation::Load {
+				self.undo_history.push_back(history_item);
+				return (history.operation, history.start_index, history.end_index);
+			}
 			let update_range = Self::get_last_index_range(&history, current.len());
 			self.redo_history.push_back(history);
-			update_range
+			(history_item.operation, update_range.0, update_range.1)
 		})
 	}
 
-	pub(crate) fn redo(&mut self, current: &mut Vec<Line>) -> Option<(usize, usize)> {
-		self.redo_history.pop_back().map(|operation| {
-			let history = Self::apply_operation(current, &operation);
+	pub(crate) fn redo(&mut self, current: &mut Vec<Line>) -> Option<(Operation, usize, usize)> {
+		self.redo_history.pop_back().map(|history_item| {
+			// the load operation is not handled here, as it is in `undo` because the load operation should never be
+			// added to the redo history
+			let history = Self::apply_operation(current, &history_item);
 			let update_range = Self::get_last_index_range(&history, current.len());
 			self.undo_history.push_back(history);
-			update_range
+			(history_item.operation, update_range.0, update_range.1)
 		})
 	}
 
 	pub(crate) fn reset(&mut self) {
 		self.undo_history.clear();
+		self.undo_history.push_back(HistoryItem::new_load());
 		self.redo_history.clear();
 	}
 
 	fn get_last_index_range(history_item: &HistoryItem, list_length: usize) -> (usize, usize) {
 		match history_item.operation {
-			Operation::Add | Operation::Modify => (history_item.start_index, history_item.end_index),
+			Operation::Add | Operation::Modify | Operation::Load => (history_item.start_index, history_item.end_index),
 			Operation::Remove => {
 				let index = min(history_item.start_index, history_item.end_index);
 				if index == 0 || list_length == 0 {

--- a/src/todo_file/src/history/operation.rs
+++ b/src/todo_file/src/history/operation.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Operation {
+	Load,
 	Modify,
 	SwapUp,
 	SwapDown,


### PR DESCRIPTION
Add to the todo_file History a load operation tracker, that will acts as a sentinel value for the start of the undo history queue. This will enable hooking into the start of the history queue. In order to expose the additional information, the Operation is now returned from the History undo/redo methods.