### PR TITLE
Remove proc-macro2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,6 @@ dependencies = [
  "girt-git",
  "girt-testutils",
  "lazy_static",
- "proc-macro2",
  "rstest",
  "rustc_version",
  "serial_test",

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -17,7 +17,6 @@ name = "config"
 [dependencies]
 thiserror = "1.0.43"
 girt-git = {version = "2.3.0", path = "../../src/git"}
-proc-macro2 = "1.0.66" # TODO: remove override of indirect dependency
 
 [dev-dependencies]
 claims = "0.7.1"

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -152,8 +152,6 @@ mod utils;
 mod testutils;
 
 use git::Repository;
-// TODO: remove override of indirect dependency
-use proc_macro2 as _;
 
 use self::utils::{get_bool, get_diff_ignore_whitespace, get_diff_show_whitespace, get_string, get_unsigned_integer};
 pub use self::{


### PR DESCRIPTION
A direct dependency on proc-macro2 was added to address a compile issue, now that the project compiles successfully without the direct dependency, it has been removed.