### PR TITLE
Add SOURCE_DATE_EPOCH to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,15 @@ An addition to the report printed to the CLI, an HTML report can be found in the
 
 ### Release
 
-##### Building
+#### Debian Building
 
     cargo make deb
 
 A deb file will be written to `target/debian/interactive-rebase-tool_*.deb`.
+
+#### Reproducible Builds
+
+Providing a [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/#idm55) environment variable with a valid UNIX timestamp, defined in seconds, will ensure a reproducible build.
 
 ## Related Projects
 

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -1,6 +1,7 @@
+use std::env;
 use std::process;
 
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 use rustc_version::{version_meta, Channel};
 
 fn main() {
@@ -16,7 +17,12 @@ fn main() {
 	if let Some(rev) = git_revision_hash() {
 		println!("cargo:rustc-env=GIRT_BUILD_GIT_HASH={rev}");
 	}
-	println!("cargo:rustc-env=GIRT_BUILD_DATE={}", Utc::now().format("%Y-%m-%d"));
+
+	let now = match env::var("SOURCE_DATE_EPOCH") {
+		Ok(val) => { Utc.timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap() }
+		Err(_) => Utc::now(),
+	};
+	println!("cargo:rustc-env=GIRT_BUILD_DATE={}", now.format("%Y-%m-%d"));
 }
 
 fn git_revision_hash() -> Option<String> {

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::process;
+use std::{env, process};
 
 use chrono::{TimeZone, Utc};
 use rustc_version::{version_meta, Channel};
@@ -18,11 +17,12 @@ fn main() {
 		println!("cargo:rustc-env=GIRT_BUILD_GIT_HASH={rev}");
 	}
 
-	let now = match env::var("SOURCE_DATE_EPOCH") {
-		Ok(val) => { Utc.timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap() }
+	// Use provided SOURCE_DATE_EPOCH to make builds reproducible
+	let build_date = match env::var("SOURCE_DATE_EPOCH") {
+		Ok(val) => Utc.timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap(),
 		Err(_) => Utc::now(),
 	};
-	println!("cargo:rustc-env=GIRT_BUILD_DATE={}", now.format("%Y-%m-%d"));
+	println!("cargo:rustc-env=GIRT_BUILD_DATE={}", build_date.format("%Y-%m-%d"));
 }
 
 fn git_revision_hash() -> Option<String> {


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).