### PR TITLE
Fix action_line macro selected assertion

### DIFF
--- a/src/core/src/modules/list/tests/change_action.rs
+++ b/src/core/src/modules/list/tests/change_action.rs
@@ -41,9 +41,9 @@ fn visual_mode_action_change_to_drop() {
 			assert_rendered_output!(
 				Body view_data,
 				action_line!(Pick "aaa", "c1"),
-				action_line!(Drop "aaa", "c2"),
-				action_line!(Drop "aaa", "c3"),
-				action_line!(Drop "aaa", "c4"),
+				action_line!(Selected Drop "aaa", "c2"),
+				action_line!(Selected Drop "aaa", "c3"),
+				action_line!(Selected Drop "aaa", "c4"),
 				action_line!(Pick "aaa", "c5")
 			);
 		},
@@ -260,7 +260,7 @@ fn normal_mode_action_change_to_squash() {
 			_ = test_context.handle_all_events(&mut module);
 			let view_data = test_context.build_view_data(&mut module);
 			assert_rendered_output!(
-				Body view_data, action_line!(Squash "aaa", "c1")
+				Body view_data, action_line!(Selected Squash "aaa", "c1")
 			);
 		},
 	);
@@ -290,9 +290,9 @@ fn visual_mode_action_change_to_squash() {
 			assert_rendered_output!(
 				Body view_data,
 				action_line!(Pick "aaa", "c1"),
-				action_line!(Squash "aaa", "c2"),
-				action_line!(Squash "aaa", "c3"),
-				action_line!(Squash "aaa", "c4"),
+				action_line!(Selected Squash "aaa", "c2"),
+				action_line!(Selected Squash "aaa", "c3"),
+				action_line!(Selected Squash "aaa", "c4"),
 				action_line!(Pick "aaa", "c5")
 			);
 		},

--- a/src/core/src/testutil/action_line.rs
+++ b/src/core/src/testutil/action_line.rs
@@ -73,7 +73,12 @@ impl ActionPattern {
 
 impl LinePattern for ActionPattern {
 	fn matches(&self, rendered: &str) -> bool {
-		if self.selected && !rendered.contains("{Selected}") {
+		if rendered.contains("{Selected}") {
+			if !self.selected {
+				return false;
+			}
+		}
+		else if self.selected {
 			return false;
 		}
 
@@ -101,10 +106,10 @@ impl LinePattern for ActionPattern {
 
 	fn expected(&self) -> String {
 		if self.selected {
-			format!("> {}", replace_invisibles(self.line.to_text().as_str()))
+			replace_invisibles(format!(">  {}", self.line.to_text()).as_str())
 		}
 		else {
-			format!("  {}", replace_invisibles(self.line.to_text().as_str()))
+			replace_invisibles(format!("  {}", self.line.to_text()).as_str())
 		}
 	}
 
@@ -113,7 +118,7 @@ impl LinePattern for ActionPattern {
 		else {
 			return String::from(rendered);
 		};
-		if self.selected {
+		if rendered.contains("{Selected}") {
 			replace_invisibles(format!("> {}", actual_line_parsed.to_text()).as_str())
 		}
 		else {


### PR DESCRIPTION
The action_line macro was not correctly asserting that unselected lines were not selected. This updates the assertion to check selection on unselected line, fixes some error output formatting around selected lines, and fixes the few tests that were not using the correct selected action line.