### PR TITLE
Add original values to Line

### DIFF
--- a/src/core/src/modules/external_editor/tests.rs
+++ b/src/core/src/modules/external_editor/tests.rs
@@ -60,8 +60,8 @@ fn activate() {
 			Artifact::ExternalCommand((String::from("editor"), vec![String::from(todo_path.as_str())]))
 		);
 		assert_eq!(module.todo_file.lock().get_lines_owned(), vec![
-			Line::new("pick aaa comment1").unwrap(),
-			Line::new("drop bbb comment2").unwrap()
+			Line::parse("pick aaa comment1").unwrap(),
+			Line::parse("drop bbb comment2").unwrap()
 		]);
 		assert!(!module.lines.is_empty());
 		assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
@@ -223,8 +223,8 @@ fn empty_edit_undo_and_edit() {
 			);
 			assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 			assert_eq!(module.todo_file.lock().get_lines_owned(), vec![
-				Line::new("pick aaa comment").unwrap(),
-				Line::new("drop bbb comment").unwrap()
+				Line::parse("pick aaa comment").unwrap(),
+				Line::parse("drop bbb comment").unwrap()
 			]);
 		},
 	);
@@ -387,7 +387,7 @@ fn error_restore_and_abort() {
 			Artifact::ChangeState(State::List)
 		);
 		assert_eq!(module.todo_file.lock().get_lines_owned(), vec![
-			Line::new("pick aaa comment").unwrap()
+			Line::parse("pick aaa comment").unwrap()
 		]);
 	});
 }
@@ -407,7 +407,7 @@ fn error_undo_modifications_and_reedit() {
 		);
 		assert_external_editor_state_eq!(module.state, ExternalEditorState::Active);
 		assert_eq!(module.todo_file.lock().get_lines_owned(), vec![
-			Line::new("pick aaa comment").unwrap()
+			Line::parse("pick aaa comment").unwrap()
 		]);
 	});
 }

--- a/src/core/src/modules/list/tests/render.rs
+++ b/src/core/src/modules/list/tests/render.rs
@@ -117,7 +117,7 @@ fn noop_list() {
 		let mut module = create_list(&Config::new(), test_context.take_todo_file());
 		let mut todo_file = module.todo_file.lock();
 		todo_file.remove_lines(0, 0);
-		todo_file.add_line(0, Line::new("noop").unwrap());
+		todo_file.add_line(0, Line::parse("noop").unwrap());
 		drop(todo_file);
 
 		let view_data = test_context.build_view_data(&mut module);

--- a/src/core/src/process/tests.rs
+++ b/src/core/src/process/tests.rs
@@ -198,12 +198,12 @@ fn write_todo_file() {
 			process
 				.todo_file
 				.lock()
-				.set_lines(vec![Line::new("fixup ddd comment").unwrap()]);
+				.set_lines(vec![Line::parse("fixup ddd comment").unwrap()]);
 			process.write_todo_file().unwrap();
 			process.todo_file.lock().load_file().unwrap();
 			assert_eq!(
 				process.todo_file.lock().get_line(0).unwrap(),
-				&Line::new("fixup ddd comment").unwrap()
+				&Line::parse("fixup ddd comment").unwrap()
 			);
 		},
 	);

--- a/src/core/src/testutil/action_line.rs
+++ b/src/core/src/testutil/action_line.rs
@@ -9,7 +9,7 @@ lazy_static! {
 
 fn parse_rendered_action_line(rendered: &str) -> Result<Line, ParseError> {
 	let cleaned_line = FORMAT_REGEX.replace_all(rendered, "").replace(" > ", "");
-	Line::new(cleaned_line.as_ref())
+	Line::parse(cleaned_line.as_ref())
 }
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub(crate) struct ActionPattern {
 impl ActionPattern {
 	fn new(line: &str, selected: bool) -> Self {
 		Self {
-			line: Line::new(line).expect("Expected valid pick"),
+			line: Line::parse(line).expect("Expected valid pick"),
 			selected,
 		}
 	}

--- a/src/todo_file/src/history/tests.rs
+++ b/src/todo_file/src/history/tests.rs
@@ -36,17 +36,17 @@ macro_rules! assert_history_items {
 
 fn create_lines() -> Vec<Line> {
 	vec![
-		Line::new("pick aaa c1").unwrap(),
-		Line::new("pick bbb c2").unwrap(),
-		Line::new("pick ccc c3").unwrap(),
-		Line::new("pick ddd c4").unwrap(),
-		Line::new("pick eee c5").unwrap(),
+		Line::parse("pick aaa c1").unwrap(),
+		Line::parse("pick bbb c2").unwrap(),
+		Line::parse("pick ccc c3").unwrap(),
+		Line::parse("pick ddd c4").unwrap(),
+		Line::parse("pick eee c5").unwrap(),
 	]
 }
 
 macro_rules! assert_todo_lines {
 	($lines:expr, $($arg:expr),*) => {
-		let expected = vec![$( Line::new($arg).unwrap(), )*];
+		let expected = vec![$( Line::parse($arg).unwrap(), )*];
 		pretty_assertions::assert_str_eq!(
 			$lines.iter().map(Line::to_text).collect::<Vec<String>>().join("\n"),
 			expected.iter().map(Line::to_text).collect::<Vec<String>>().join("\n")
@@ -229,7 +229,7 @@ fn undo_redo_add_range_end_index_at_bottom() {
 #[test]
 fn undo_redo_remove_start() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_remove(0, 0, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_remove(0, 0, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 0, 0));
 	assert_todo_lines!(
@@ -255,7 +255,7 @@ fn undo_redo_remove_start() {
 #[test]
 fn undo_redo_remove_end() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_remove(5, 5, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_remove(5, 5, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 5, 5));
 	assert_todo_lines!(
@@ -281,7 +281,7 @@ fn undo_redo_remove_end() {
 #[test]
 fn undo_redo_remove_middle() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_remove(2, 2, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_remove(2, 2, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 2, 2));
 	assert_todo_lines!(
@@ -308,8 +308,8 @@ fn undo_redo_remove_middle() {
 fn undo_redo_remove_range_start_index_top() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_remove(0, 1, vec![
-		Line::new("drop xxx cx").unwrap(),
-		Line::new("drop yyy cy").unwrap(),
+		Line::parse("drop xxx cx").unwrap(),
+		Line::parse("drop yyy cy").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 0, 1));
@@ -338,8 +338,8 @@ fn undo_redo_remove_range_start_index_top() {
 fn undo_redo_remove_range_start_index_bottom() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_remove(6, 5, vec![
-		Line::new("drop xxx cx").unwrap(),
-		Line::new("drop yyy cy").unwrap(),
+		Line::parse("drop xxx cx").unwrap(),
+		Line::parse("drop yyy cy").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 6, 5));
@@ -368,8 +368,8 @@ fn undo_redo_remove_range_start_index_bottom() {
 fn undo_redo_remove_range_end_index_top() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_remove(1, 0, vec![
-		Line::new("drop xxx cx").unwrap(),
-		Line::new("drop yyy cy").unwrap(),
+		Line::parse("drop xxx cx").unwrap(),
+		Line::parse("drop yyy cy").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 1, 0));
@@ -398,8 +398,8 @@ fn undo_redo_remove_range_end_index_top() {
 fn undo_redo_remove_range_end_index_bottom() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_remove(5, 6, vec![
-		Line::new("drop xxx cx").unwrap(),
-		Line::new("drop yyy cy").unwrap(),
+		Line::parse("drop xxx cx").unwrap(),
+		Line::parse("drop yyy cy").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Remove, 5, 6));
@@ -702,7 +702,7 @@ fn undo_redo_swap_down_range_up_index_end() {
 #[test]
 fn undo_redo_modify_single_index_start() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_modify(0, 0, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_modify(0, 0, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 0, 0));
 	assert_todo_lines!(
@@ -727,7 +727,7 @@ fn undo_redo_modify_single_index_start() {
 #[test]
 fn undo_redo_modify_single_index_end() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_modify(4, 4, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_modify(4, 4, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 4, 4));
 	assert_todo_lines!(
@@ -752,7 +752,7 @@ fn undo_redo_modify_single_index_end() {
 #[test]
 fn undo_redo_modify_single_index_middle() {
 	let mut history = History::new(10);
-	history.record(HistoryItem::new_modify(2, 2, vec![Line::new("drop xxx cx").unwrap()]));
+	history.record(HistoryItem::new_modify(2, 2, vec![Line::parse("drop xxx cx").unwrap()]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 2, 2));
 	assert_todo_lines!(
@@ -778,9 +778,9 @@ fn undo_redo_modify_single_index_middle() {
 fn undo_redo_modify_range_down_index_start() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_modify(0, 2, vec![
-		Line::new("drop xx1 c1").unwrap(),
-		Line::new("drop xx2 c2").unwrap(),
-		Line::new("drop xx3 c3").unwrap(),
+		Line::parse("drop xx1 c1").unwrap(),
+		Line::parse("drop xx2 c2").unwrap(),
+		Line::parse("drop xx3 c3").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 0, 2));
@@ -807,9 +807,9 @@ fn undo_redo_modify_range_down_index_start() {
 fn undo_redo_modify_range_down_index_end() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_modify(2, 4, vec![
-		Line::new("drop xx1 c1").unwrap(),
-		Line::new("drop xx2 c2").unwrap(),
-		Line::new("drop xx3 c3").unwrap(),
+		Line::parse("drop xx1 c1").unwrap(),
+		Line::parse("drop xx2 c2").unwrap(),
+		Line::parse("drop xx3 c3").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 2, 4));
@@ -836,9 +836,9 @@ fn undo_redo_modify_range_down_index_end() {
 fn undo_redo_modify_range_up_index_start() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_modify(2, 0, vec![
-		Line::new("drop xx1 c1").unwrap(),
-		Line::new("drop xx2 c2").unwrap(),
-		Line::new("drop xx3 c3").unwrap(),
+		Line::parse("drop xx1 c1").unwrap(),
+		Line::parse("drop xx2 c2").unwrap(),
+		Line::parse("drop xx3 c3").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 2, 0));
@@ -865,9 +865,9 @@ fn undo_redo_modify_range_up_index_start() {
 fn undo_redo_modify_range_up_index_end() {
 	let mut history = History::new(10);
 	history.record(HistoryItem::new_modify(4, 2, vec![
-		Line::new("drop xx1 c1").unwrap(),
-		Line::new("drop xx2 c2").unwrap(),
-		Line::new("drop xx3 c3").unwrap(),
+		Line::parse("drop xx1 c1").unwrap(),
+		Line::parse("drop xx2 c2").unwrap(),
+		Line::parse("drop xx3 c3").unwrap(),
 	]));
 	let mut lines = create_lines();
 	assert_some_eq!(history.undo(&mut lines), (Operation::Modify, 4, 2));

--- a/src/todo_file/src/lib.rs
+++ b/src/todo_file/src/lib.rs
@@ -224,7 +224,7 @@ impl TodoFile {
 					None
 				}
 				else {
-					Some(Line::new(l).map_err(|err| {
+					Some(Line::parse(l).map_err(|err| {
 						IoError::FileRead {
 							file: self.filepath.clone(),
 							cause: FileReadErrorCause::from(err),
@@ -492,7 +492,7 @@ mod tests {
 	use super::*;
 
 	fn create_line(line: &str) -> Line {
-		Line::new(line).unwrap()
+		Line::parse(line).unwrap()
 	}
 
 	fn create_and_load_todo_file(file_contents: &[&str]) -> (TodoFile, NamedTempFile) {

--- a/src/todo_file/src/testutil.rs
+++ b/src/todo_file/src/testutil.rs
@@ -96,7 +96,7 @@ where C: FnOnce(TodoFileTestContext) {
 		.unwrap();
 
 	let mut todo_file = TodoFile::new(git_todo_file.path().to_str().unwrap(), 1, "#");
-	todo_file.set_lines(lines.iter().map(|l| Line::new(l).unwrap()).collect());
+	todo_file.set_lines(lines.iter().map(|l| Line::parse(l).unwrap()).collect());
 	callback(TodoFileTestContext {
 		git_todo_file: RefCell::new(git_todo_file),
 		todo_file,


### PR DESCRIPTION
This adds to the Line struct, the original action, content, and option. This includes a refactor in how Line's are constructed, and a rename of the line parse function from new to parse.