### PR TITLE
Refactor TodoFile to use an options struct

### DIFF
--- a/src/core/src/application.rs
+++ b/src/core/src/application.rs
@@ -7,7 +7,7 @@ use git::Repository;
 use input::{Event, EventHandler, EventReaderFn};
 use parking_lot::Mutex;
 use runtime::{Runtime, ThreadStatuses, Threadable};
-use todo_file::TodoFile;
+use todo_file::{TodoFile, TodoFileOptions};
 use view::View;
 
 use crate::{
@@ -153,7 +153,10 @@ where ModuleProvider: module::ModuleProvider + Send + 'static
 	}
 
 	fn load_todo_file(filepath: &str, config: &Config) -> Result<TodoFile, Exit> {
-		let mut todo_file = TodoFile::new(filepath, config.undo_limit, config.git.comment_char.as_str());
+		let mut todo_file = TodoFile::new(
+			filepath,
+			TodoFileOptions::new(config.undo_limit, config.git.comment_char.as_str()),
+		);
 		todo_file
 			.load_file()
 			.map_err(|err| Exit::new(ExitStatus::FileReadError, err.to_string().as_str()))?;

--- a/src/todo_file/src/testutil.rs
+++ b/src/todo_file/src/testutil.rs
@@ -7,7 +7,7 @@ use std::{
 
 use tempfile::{Builder, NamedTempFile};
 
-use crate::{Line, TodoFile};
+use crate::{Line, TodoFile, TodoFileOptions};
 
 /// Context for `with_todo_file`
 pub struct TodoFileTestContext {
@@ -95,7 +95,7 @@ where C: FnOnce(TodoFileTestContext) {
 		.tempfile_in(git_repo_dir.as_path())
 		.unwrap();
 
-	let mut todo_file = TodoFile::new(git_todo_file.path().to_str().unwrap(), 1, "#");
+	let mut todo_file = TodoFile::new(git_todo_file.path().to_str().unwrap(), TodoFileOptions::new(1, "#"));
 	todo_file.set_lines(lines.iter().map(|l| Line::parse(l).unwrap()).collect());
 	callback(TodoFileTestContext {
 		git_todo_file: RefCell::new(git_todo_file),

--- a/src/todo_file/src/todo_file_options.rs
+++ b/src/todo_file/src/todo_file_options.rs
@@ -1,0 +1,18 @@
+/// Options for `TodoFile`
+#[derive(Debug, Clone)]
+pub struct TodoFileOptions {
+	pub(crate) undo_limit: u32,
+	pub(crate) comment_prefix: String,
+}
+
+impl TodoFileOptions {
+	/// Create a new instance of `TodoFileOptions`
+	#[must_use]
+	#[inline]
+	pub fn new(undo_limit: u32, comment_prefix: &str) -> Self {
+		Self {
+			undo_limit,
+			comment_prefix: String::from(comment_prefix),
+		}
+	}
+}


### PR DESCRIPTION
The TodoFile struct was using discrete options in the new function, but this is not sustainable as new options are added. This adds a new TodoFileOptions struct, that contains the TodoFile options.