### PR TITLE
Add Modified Line exec command feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- Post modified line exec command ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/888))
+
+
 ## [2.3.0] - 2023-07-19
 ### Added
 - Support for update-ref action ([#801](https://github.com/MitMaro/git-interactive-rebase-tool/pull/801))

--- a/README.md
+++ b/README.md
@@ -76,6 +76,53 @@ Need to do something in your Git editor? Quickly shell out to your editor, make 
 
 ![Shell out to editor](/docs/assets/images/girt-external-editor.gif?raw=true)
 
+### Advanced Features
+
+#### Modified line exec command
+
+This optional feature allows for the injection of an `exec` action after modified lines, where modified is determined as a changed action, command, or reference. This can be used to amend commits to update references in the commit message or run a test suite only on modified commits.
+
+To enable this option, set the `interactive-rebase-tool.postModifiedLineExecCommand` option, providing an executable or script.
+
+```shell
+git config --global interactive-rebase-tool.postModifiedLineExecCommand "/path/to/global/script"
+```
+
+Or using repository-specific configuration, for targeted scripts.
+
+```shell
+git config --global interactive-rebase-tool.postModifiedLineExecCommand "/path/to/repo/script"
+```
+
+The first argument provided to the script will always be the action performed. Then, depending on the action, the script will be provided a different set of arguments.
+
+For `drop`, `fixup`, `edit`, `pick`, `reword` and `squash` actions, the script will additionally receive the original commit hash, for `exec` the original and new commands are provided, and for `label`, `reset`, `merge`, and `update-ref` the original label/reference and new label/reference are provided.
+
+Full example of a resulting rebase todo file, assuming that `interactive-rebase-tool.postModifiedLineExecCommand` was set to `script.sh`.
+
+```
+# original line: label onto
+label new-onto
+exec script.sh "label" "onto" "new-onto"
+
+# original line: reset onto
+reset new-onto
+exec script.sh "reset" "onto" "new-onto"
+
+pick   a12345 My feature
+# original line: pick b12345 My change
+squash b12345 My change
+exec script.sh "squash" "b12345"
+
+# original line: label branch
+label branch
+exec script.sh "label" "branch" "new-branch"
+
+# original line: exec command
+exec new-command
+exec script.sh "exec" "command" "new-command"
+```
+
 ## Setup
 
 ### Most systems

--- a/readme/customization.md
+++ b/readme/customization.md
@@ -39,17 +39,18 @@ Some values from your Git Config are directly used by this application.
 
 ## General
 
-| Key                        | Default | Type    | Description                                                                                 |
-|----------------------------|---------|---------|---------------------------------------------------------------------------------------------|
-| `autoSelectNext`           | false   | bool    | If true, auto select the next line after action modification                                |
-| `diffIgnoreBlankLines`     | none    | String¹ | If to ignore blank lines during diff.                                                       |
-| `diffIgnoreWhitespace`     | none    | String¹ | If and how to ignore whitespace during diff.                                                |
-| `diffShowWhitespace`       | both    | String² | If and how to show whitespace during diff.                                                  |
-| `diffSpaceSymbol`          | ·       | String  | The visible symbol for the space character. Only used when `diffShowWhitespace` is enabled. |
-| `diffTabSymbol`            | →       | String  | The visible symbol for the tab character. Only used when `diffShowWhitespace` is enabled.   |
-| `diffTabWidth`             | 4       | Integer | The width of the tab character                                                              |
-| `undoLimit`                | 5000    | Integer | Number of undo operations to store.                                                         |
-| `verticalSpacingCharacter` | ~       | String  | Vertical spacing character. Can be set to an empty string.                                  |
+| Key                           | Default | Type    | Description                                                                                 |
+|-------------------------------|---------|---------|---------------------------------------------------------------------------------------------|
+| `autoSelectNext`              | false   | bool    | If true, auto select the next line after action modification                                |
+| `diffIgnoreBlankLines`        | none    | String¹ | If to ignore blank lines during diff.                                                       |
+| `diffIgnoreWhitespace`        | none    | String¹ | If and how to ignore whitespace during diff.                                                |
+| `diffShowWhitespace`          | both    | String² | If and how to show whitespace during diff.                                                  |
+| `diffSpaceSymbol`             | ·       | String  | The visible symbol for the space character. Only used when `diffShowWhitespace` is enabled. |
+| `diffTabSymbol`               | →       | String  | The visible symbol for the tab character. Only used when `diffShowWhitespace` is enabled.   |
+| `diffTabWidth`                | 4       | Integer | The width of the tab character                                                              |
+| `undoLimit`                   | 5000    | Integer | Number of undo operations to store.                                                         |
+| `postModifiedLineExecCommand` |         | String  | Exec command to attach to modified lines. See [modified line exec command] for details.     |
+| `verticalSpacingCharacter`    | ~       | String  | Vertical spacing character. Can be set to an empty string.                                  |
 
 ¹ Ignore whitespace can be:
 - `change` to ignore changed whitespace in diffs, same as the [`--ignore-space-change`][diffIgnoreSpaceChange] flag
@@ -62,6 +63,7 @@ Some values from your Git Config are directly used by this application.
 - `true`, `on` or `both` to show both leading and trailing whitespace
 - `false`, `off`, `none` to show no whitespace
 
+[modified line exec command]:../README.md#modified-line-exec-command
 [diffIgnoreSpaceChange]:https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---ignore-space-change
 [diffIgnoreAllSpace]:https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---ignore-all-space
 

--- a/src/config/src/theme.rs
+++ b/src/config/src/theme.rs
@@ -2,13 +2,13 @@ use git::Config;
 
 use crate::{
 	errors::ConfigError,
-	utils::{_get_string, get_string},
+	utils::{get_optional_string, get_string},
 	Color,
 	ConfigErrorCause,
 };
 
 fn get_color(config: Option<&Config>, name: &str, default: Color) -> Result<Color, ConfigError> {
-	if let Some(value) = _get_string(config, name)? {
+	if let Some(value) = get_optional_string(config, name)? {
 		Color::try_from(value.to_lowercase().as_str()).map_err(|invalid_color_error| {
 			ConfigError::new(
 				name,

--- a/src/config/src/utils/get_bool.rs
+++ b/src/config/src/utils/get_bool.rs
@@ -1,6 +1,6 @@
 use git::{Config, ErrorCode};
 
-use crate::{utils::_get_string, ConfigError, ConfigErrorCause};
+use crate::{utils::get_optional_string, ConfigError, ConfigErrorCause};
 
 pub(crate) fn get_bool(config: Option<&Config>, name: &str, default: bool) -> Result<bool, ConfigError> {
 	if let Some(cfg) = config {
@@ -10,14 +10,14 @@ pub(crate) fn get_bool(config: Option<&Config>, name: &str, default: bool) -> Re
 			Err(e) if e.message().contains("failed to parse") => {
 				Err(ConfigError::new_with_optional_input(
 					name,
-					_get_string(config, name).ok().flatten(),
+					get_optional_string(config, name).ok().flatten(),
 					ConfigErrorCause::InvalidBoolean,
 				))
 			},
 			Err(e) => {
 				Err(ConfigError::new_with_optional_input(
 					name,
-					_get_string(config, name).ok().flatten(),
+					get_optional_string(config, name).ok().flatten(),
 					ConfigErrorCause::UnknownError(String::from(e.message())),
 				))
 			},

--- a/src/config/src/utils/get_string.rs
+++ b/src/config/src/utils/get_string.rs
@@ -2,7 +2,7 @@ use git::{Config, ErrorCode};
 
 use crate::{ConfigError, ConfigErrorCause};
 
-pub(crate) fn _get_string(config: Option<&Config>, name: &str) -> Result<Option<String>, ConfigError> {
+pub(crate) fn get_optional_string(config: Option<&Config>, name: &str) -> Result<Option<String>, ConfigError> {
 	let Some(cfg) = config
 	else {
 		return Ok(None);
@@ -24,7 +24,7 @@ pub(crate) fn _get_string(config: Option<&Config>, name: &str) -> Result<Option<
 }
 
 pub(crate) fn get_string(config: Option<&Config>, name: &str, default: &str) -> Result<String, ConfigError> {
-	Ok(_get_string(config, name)?.unwrap_or_else(|| String::from(default)))
+	Ok(get_optional_string(config, name)?.unwrap_or_else(|| String::from(default)))
 }
 
 #[cfg(test)]

--- a/src/config/src/utils/get_unsigned_integer.rs
+++ b/src/config/src/utils/get_unsigned_integer.rs
@@ -1,6 +1,6 @@
 use git::{Config, ErrorCode};
 
-use crate::{utils::_get_string, ConfigError, ConfigErrorCause};
+use crate::{utils::get_optional_string, ConfigError, ConfigErrorCause};
 
 pub(crate) fn get_unsigned_integer(config: Option<&Config>, name: &str, default: u32) -> Result<u32, ConfigError> {
 	if let Some(cfg) = config {
@@ -9,7 +9,7 @@ pub(crate) fn get_unsigned_integer(config: Option<&Config>, name: &str, default:
 				v.try_into().map_err(|_| {
 					ConfigError::new_with_optional_input(
 						name,
-						_get_string(config, name).ok().flatten(),
+						get_optional_string(config, name).ok().flatten(),
 						ConfigErrorCause::InvalidUnsignedInteger,
 					)
 				})
@@ -18,14 +18,14 @@ pub(crate) fn get_unsigned_integer(config: Option<&Config>, name: &str, default:
 			Err(e) if e.message().contains("failed to parse") => {
 				Err(ConfigError::new_with_optional_input(
 					name,
-					_get_string(config, name).ok().flatten(),
+					get_optional_string(config, name).ok().flatten(),
 					ConfigErrorCause::InvalidUnsignedInteger,
 				))
 			},
 			Err(e) => {
 				Err(ConfigError::new_with_optional_input(
 					name,
-					_get_string(config, name).ok().flatten(),
+					get_optional_string(config, name).ok().flatten(),
 					ConfigErrorCause::UnknownError(String::from(e.message())),
 				))
 			},

--- a/src/config/src/utils/mod.rs
+++ b/src/config/src/utils/mod.rs
@@ -12,6 +12,6 @@ pub(crate) use self::{
 	get_diff_rename::git_diff_renames,
 	get_diff_show_whitespace::get_diff_show_whitespace,
 	get_input::get_input,
-	get_string::{_get_string, get_string},
+	get_string::{get_optional_string, get_string},
 	get_unsigned_integer::get_unsigned_integer,
 };

--- a/src/todo_file/src/line.rs
+++ b/src/todo_file/src/line.rs
@@ -8,9 +8,7 @@ pub struct Line {
 	hash: String,
 	mutated: bool,
 	option: Option<String>,
-	original_action: Action,
-	original_content: String,
-	original_option: Option<String>,
+	original_line: Option<Box<Line>>,
 }
 
 impl Line {
@@ -25,9 +23,14 @@ impl Line {
 			hash: String::from(hash),
 			mutated: false,
 			option: original_option.clone(),
-			original_action,
-			original_content,
-			original_option,
+			original_line: Some(Box::new(Line {
+				action: original_action,
+				content: original_content,
+				hash: String::from(hash),
+				mutated: false,
+				option: original_option,
+				original_line: None,
+			})),
 		}
 	}
 
@@ -157,6 +160,13 @@ impl Line {
 		self.option = Some(String::from(option));
 	}
 
+	/// Get the original line, before any modifications
+	#[must_use]
+	#[inline]
+	pub fn original(&self) -> Option<&Line> {
+		self.original_line.as_deref()
+	}
+
 	/// Get the action of the line.
 	#[must_use]
 	#[inline]
@@ -273,9 +283,14 @@ mod tests {
 			content: String::new(),
 			mutated: false,
 			option: None,
-			original_action: Action::Pick,
-			original_content: String::new(),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Pick,
+				hash: String::from("abc123"),
+				content: String::new(),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -287,9 +302,14 @@ mod tests {
 			content: String::new(),
 			mutated: false,
 			option: None,
-			original_action: Action::Break,
-			original_content: String::new(),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Break,
+				hash: String::new(),
+				content: String::new(),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -301,9 +321,14 @@ mod tests {
 			content: String::from("command"),
 			mutated: false,
 			option: None,
-			original_action: Action::Exec,
-			original_content: String::from("command"),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Exec,
+				hash: String::new(),
+				content: String::from("command"),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -315,9 +340,14 @@ mod tests {
 			content: String::from("command"),
 			mutated: false,
 			option: None,
-			original_action: Action::Merge,
-			original_content: String::from("command"),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Merge,
+				hash: String::new(),
+				content: String::from("command"),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -329,9 +359,14 @@ mod tests {
 			content: String::from("label"),
 			mutated: false,
 			option: None,
-			original_action: Action::Label,
-			original_content: String::from("label"),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Label,
+				hash: String::new(),
+				content: String::from("label"),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -343,9 +378,14 @@ mod tests {
 			content: String::from("label"),
 			mutated: false,
 			option: None,
-			original_action: Action::Reset,
-			original_content: String::from("label"),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::Reset,
+				hash: String::new(),
+				content: String::from("label"),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 
@@ -357,9 +397,14 @@ mod tests {
 			content: String::from("reference"),
 			mutated: false,
 			option: None,
-			original_action: Action::UpdateRef,
-			original_content: String::from("reference"),
-			original_option: None,
+			original_line: Some(Box::new(Line {
+				action: Action::UpdateRef,
+				hash: String::new(),
+				content: String::from("reference"),
+				mutated: false,
+				option: None,
+				original_line: None,
+			}))
 		});
 	}
 

--- a/src/todo_file/src/todo_file_options.rs
+++ b/src/todo_file/src/todo_file_options.rs
@@ -1,8 +1,9 @@
 /// Options for `TodoFile`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TodoFileOptions {
-	pub(crate) undo_limit: u32,
 	pub(crate) comment_prefix: String,
+	pub(crate) line_changed_command: Option<String>,
+	pub(crate) undo_limit: u32,
 }
 
 impl TodoFileOptions {
@@ -11,8 +12,40 @@ impl TodoFileOptions {
 	#[inline]
 	pub fn new(undo_limit: u32, comment_prefix: &str) -> Self {
 		Self {
-			undo_limit,
 			comment_prefix: String::from(comment_prefix),
+			line_changed_command: None,
+			undo_limit,
 		}
+	}
+
+	/// Set a command to be added after each changed line
+	#[inline]
+	pub fn line_changed_command(&mut self, command: &str) {
+		self.line_changed_command = Some(String::from(command));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use claims::{assert_none, assert_some_eq};
+
+	use super::*;
+
+	#[test]
+	fn new() {
+		let options = TodoFileOptions::new(10, "#");
+
+		assert_eq!(options.undo_limit, 10);
+		assert_eq!(options.comment_prefix, "#");
+		assert_none!(options.line_changed_command);
+	}
+
+	#[test]
+	fn line_changed_command() {
+		let mut options = TodoFileOptions::new(10, "#");
+
+		options.line_changed_command("command");
+
+		assert_some_eq!(options.line_changed_command, "command");
 	}
 }


### PR DESCRIPTION
This adds an optional feature, where a exec command is injected with the provided script after every modified line.

Closes #61 