### PR TITLE
Fix flicker caused by action width change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added
-- Post modified line exec command ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/888))
+- Post modified line exec command ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/890))
 
+### Fixed
+- Flicker when action width changes ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/891))
 
 ## [2.3.0] - 2023-07-19
 ### Added

--- a/src/core/src/modules/list/tests/render.rs
+++ b/src/core/src/modules/list/tests/render.rs
@@ -125,7 +125,7 @@ fn noop_list() {
 			Style view_data,
 			"{TITLE}{HELP}",
 			"{BODY}",
-			"{Selected}{Normal} > noop {Pad( )}"
+			"{Selected}{Normal} > noop   {Pad( )}"
 		);
 	});
 }
@@ -170,4 +170,18 @@ fn pinned_segments() {
 			);
 		},
 	);
+}
+
+#[test]
+fn full_with_short_actions() {
+	module_test(&["pick aaaaaaaa comment 1"], &[], |mut test_context| {
+		let mut module = create_list(&Config::new(), test_context.take_todo_file());
+		let view_data = test_context.build_view_data(&mut module);
+		assert_rendered_output!(
+			Style view_data,
+			"{TITLE}{HELP}",
+			"{BODY}",
+			"{Selected}{Normal} > {ActionPick}pick   {Normal}aaaaaaaa comment 1{Pad( )}"
+		);
+	});
 }

--- a/src/core/src/modules/list/utils.rs
+++ b/src/core/src/modules/list/utils.rs
@@ -268,12 +268,14 @@ pub(super) fn get_todo_line_segments(
 		false,
 	));
 
+	let action_padding = cmp::max(maximum_action_width, 6);
+
 	let action_name = if is_full_width {
 		if let Some(opt) = line.option() {
-			format!("{:maximum_action_width$} ", format!("{action} {opt}"))
+			format!("{:action_padding$} ", format!("{action} {opt}"))
 		}
 		else {
-			format!("{:maximum_action_width$} ", action.to_string())
+			format!("{:action_padding$} ", action.to_string())
 		}
 	}
 	else {


### PR DESCRIPTION
When the longest action name changed, it would cause the action column in the list display to resize, causing a flicker. While this was intended behavior, it almost always caused a redraw, which was jarring. This changes the rendering of the action to keep the minimum draw width of the action at 6, to reduce the amount of flicker.

Fixes #882 