### PR TITLE
Fix some typos in brand names and use Oxford list for an enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [1.2.1] - 2020-01-26
 
 ### Fixed
-- ANSI color support broken on MacOS ([#219](https://github.com/MitMaro/git-interactive-rebase-tool/issues/219)) 
+- ANSI color support broken on macOS ([#219](https://github.com/MitMaro/git-interactive-rebase-tool/issues/219))
 
 ## [1.2.0] - 2020-01-11
 
@@ -110,7 +110,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [1.0.0] - 2019-04-10
 
 ### Added
-- Support for unicode characters
+- Support for Unicode characters
 - Horizontal and vertical overflow support
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Native cross-platform full feature terminal based [sequence editor][git-sequence
 
 ### Cross-platform
 
-Built and works on Linux, macOS, Windows and many others.
+Built and works on Linux, macOS, Windows, and many others.
 
 ### Set action
 

--- a/readme/customization.md
+++ b/readme/customization.md
@@ -69,7 +69,7 @@ Some values from your Git Config are directly used by this application.
 
 ## Colors
 
-The valid colors are the [eight original 8 ANSI colors][ANSIColors]. They are `black`, `blue`, `cyan`, `green`, `magenta`, `red`, `white` and `yellow`. Dimmed versions of the 8 ANSI colors can be used by prefixing the color  with `dark`, for example `dark red`. Each terminal controls the exact color for these color names. On terminals that support 256 colors, a color triplet with the format `<red>,<green>,<blue>` can be used. Each color has a range of 0 to 255 with `255, 255, 255` resulting in white and `0,0,0` resulting in black. A value of `-1` or `transparent` can be used to use the default terminal color.
+The valid colors are the [eight original 8 ANSI colors][ANSIColors]. They are `black`, `blue`, `cyan`, `green`, `magenta`, `red`, `white` and `yellow`. Dimmed versions of the 8 ANSI colors can be used by prefixing the color with `dark`, for example `dark red`. Each terminal controls the exact color for these color names. On terminals that support 256 colors, a color triplet with the format `<red>,<green>,<blue>` can be used. Each color has a range of 0 to 255 with `255, 255, 255` resulting in white and `0,0,0` resulting in black. A value of `-1` or `transparent` can be used to use the default terminal color.
 
 [ANSIColors]:https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 
@@ -101,7 +101,7 @@ The valid colors are the [eight original 8 ANSI colors][ANSIColors]. They are `b
 
 ## Key Bindings
 
-Most keys can be changed to any printable character or supported special character. It is possible to provide conflicting bindings, which will result in undefined behaviour. The `inputConfirmYes` binding has a special behaviour in that it responds to both the uppercase and lowercase letter of the value set, if the variant exist.
+Most keys can be changed to any printable character or supported special character. It is possible to provide conflicting bindings, which will result in undefined behavior. The `inputConfirmYes` binding has a special behavior in that it responds to both the uppercase and lowercase letter of the value set, if the variant exist.
 
 | Key                         | Default   | Type   | Description                                         |
 |-----------------------------|-----------|--------|-----------------------------------------------------|
@@ -128,7 +128,7 @@ Most keys can be changed to any printable character or supported special charact
 | `inputMoveSelectionDown`    | j         | String | Key for moving the selected line(s) down            |
 | `inputMoveSelectionUp`      | k         | String | Key for moving the selected line(s) up              |
 | `inputMoveStepDown`         | PageDown  | String | Key for moving the cursor down by a large step      |
-| `inputMoveStepUp`           | PageUp    | String | Key for moving the cursor up  by a large step       |
+| `inputMoveStepUp`           | PageUp    | String | Key for moving the cursor up by a large step        |
 | `inputMoveUp`               | Up        | String | Key for moving the cursor up                        |
 | `inputOpenInExternalEditor` | !         | String | Key for opening the external editor                 |
 | `inputRebase`               | w         | String | Key for rebasing with confirmation                  |

--- a/readme/install.md
+++ b/readme/install.md
@@ -70,7 +70,7 @@ The executable will be installed to `/usr/bin`.
 
     guix shell git-interactive-rebase-tool
     
-### In a temporary container (linux namespace)
+### In a temporary container (Linux namespace)
 
     guix shell --container git-interactive-rebase-tool
 


### PR DESCRIPTION
I'm using your tool and I noticed a few "typos"

So I'm suggesting a few changes