### PR TITLE
docs: fix `d` keybinding description

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ Key bindings can be customized, see [configuration](readme/customization.md#key-
 | `e`         | Normal/Diff | Set selected commit(s) to be edited       |
 | `s`         | Normal/Diff | Set selected commit(s) to be squashed     |
 | `f`         | Normal/Diff | Set selected commit(s) to be fixed-up     |
-| `d`         | Normal/Diff | Set selected commit(s) to be dropped      |
+| `d`         | Normal      | Set selected commit(s) to be dropped      |
+| `d`         | Diff        | Show full commit diff                     |
 | `E`         | Normal      | Edit the command of an editable action    |
 | `v`         | Normal/Diff | Enter and exit visual mode (for selection)|
 | `I`         | Normal      | Insert a new line                         |
@@ -206,7 +207,6 @@ Key bindings can be customized, see [configuration](readme/customization.md#key-
 | End         | Diff        | Scroll view to the end                    |
 | PageUp      | Diff        | Scroll view a step up                     |
 | PageDown    | Diff        | Scroll view a step down                   |
-| `d`         | Diff        | Show full commit diff                     |
 
 ## Supported Platforms
 


### PR DESCRIPTION
The first description of the `d` keybindings states it drops commits both in `Normal` and `Diff` modes, and later on it is stated that it shows the full diff for a commit in `Diff` mode, which seems to conflict with the former. This PR fixes that.

Also, I couldn't find a definition of the `Normal` and `Diff` modes. `Normal` is when viewing the commit list, and `Diff` is when viewing the content of a commit with `c`, isn't it? Maybe that should be stated somewhere too.