### PR TITLE
Add support for additional platforms

### DIFF
--- a/.github/workflows/master-coverage.yml
+++ b/.github/workflows/master-coverage.yml
@@ -20,7 +20,7 @@ jobs:
           crate: cargo-tarpaulin
       - name: Run cargo-tarpaulin
         run: |
-          cargo +nightly tarpaulin --all-features --ignore-tests --line --output-dir coverage --timeout 10 --out Lcov
+          cargo +nightly tarpaulin --ignore-tests --line --output-dir coverage --timeout 10 --out Lcov
       - name: Post to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo doc --all-features
+      - run: cargo doc
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -71,7 +71,7 @@ jobs:
           crate: cargo-tarpaulin
       - name: Run cargo-tarpaulin
         run: |
-          cargo +nightly tarpaulin --all-features --ignore-tests --line --output-dir coverage --timeout 10 --out Lcov
+          cargo +nightly tarpaulin --ignore-tests --line --output-dir coverage --timeout 10 --out Lcov
       - name: Post to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   update-latest-tag:
-    runs-on: ubuntu-latest
     name: Update Latest Tag
+    runs-on: ubuntu-latest
     env:
       TARGET_RELEASE_ID: 18843342
       GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -19,36 +19,54 @@ jobs:
       - name: "Update Tag and Title"
         run: "./.github/scripts/update-tag.bash"
 
-  debian:
-    name: Debian Latest
+  deb:
+    name: "Release Latest - ${{ matrix.platform.name }}"
+    continue-on-error: true
+    strategy:
+      matrix:
+        platform:
+          - name: ubuntu_arm64
+            target: aarch64-unknown-linux-gnu
+            image: ubuntu:24.04
+          - name: ubuntu_amd64
+            target: x86_64-unknown-linux-gnu
+            image: ubuntu:24.04
+
+          - name: debian_arm64
+            target: aarch64-unknown-linux-gnu
+            image: debian:sid-slim
+          - name: debian_amd64
+            target: x86_64-unknown-linux-gnu
+            image: debian:sid-slim
     runs-on: ubuntu-latest
     needs: update-latest-tag
     timeout-minutes: 10
-    container:
-      image: 'docker://debian:sid-slim'
     steps:
-      - uses: actions/checkout@v3
-      - name: "System Setup"
-        run: |
-          apt-get update;
-          apt-get --assume-yes -f install curl build-essential pkg-config;
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          TZ: "America/St_Johns"
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-deb
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          toolchain: nightly
+          args: "--release --features dev"
+
       - name: "Build Deb"
-        run: cargo +nightly deb --output "target/debian/debian_amd64-interactive-rebase-tool.deb" -- --features dev
+        run: cargo +nightly deb --no-strip --no-build --target ${{ matrix.platform.target }} --output "target/git-interactive-rebase-tool-unstable-${{ matrix.platform.name }}.deb"
       - name: Upload
         uses: ncipollo/release-action@v1
         with:
           tag: latest
           allowUpdates: true
-          artifacts: "target/debian/debian_amd64-interactive-rebase-tool.deb"
+          artifacts: "target/git-interactive-rebase-tool-unstable-${{ matrix.platform.name }}.deb"
           artifactErrorsFailBuild: true
           artifactContentType: "application/vnd.debian.binary-package"
           replacesArtifacts: true
@@ -59,62 +77,60 @@ jobs:
           prerelease: true
           updateOnlyUnreleased: true
 
-  ubuntu:
-    name: Ubuntu Latest
-    runs-on: ubuntu-latest
+  linux-other:
+    name: "Release Latest - ${{ matrix.platform.name }}"
+    continue-on-error: true
+    strategy:
+      matrix:
+        platform:
+          # Alpine
+          - name: alpine-arm64
+            target: aarch64-unknown-linux-gnu
+            features: "zlib-ng-compat"
+          - name: alpine-amd64
+            target: x86_64-unknown-linux-gnu
+          # Arch
+          - name: arch-arm64
+            target: aarch64-unknown-linux-gnu
+            features: "zlib-ng-compat"
+          - name: arch-amd64
+            target: x86_64-unknown-linux-gnu
+          # Fedora
+          - name: fedora-arm64
+            target: aarch64-unknown-linux-gnu
+            features: "zlib-ng-compat"
+          - name: fedora-amd64
+            target: x86_64-unknown-linux-gnu
+          # Raspberry PI
+          - name: pi0-1_arm
+            target: arm-unknown-linux-gnueabihf
+          - name: pi2-4_armv7
+            target: armv7-unknown-linux-gnueabihf
+            features: "zlib-ng-compat"
+          - name: pi5_arm64
+            target: aarch64-unknown-linux-gnu
+            features: "zlib-ng-compat"
     needs: update-latest-tag
-    timeout-minutes: 10
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
         with:
+          command: build
+          target: ${{ matrix.platform.target }}
           toolchain: nightly
-      - uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-deb
-      - name: "Build Deb"
-        run: cargo +nightly deb --output "target/debian/ubuntu_amd64-interactive-rebase-tool.deb" -- --features dev
+          args: "--features 'dev ${{ matrix.platform.features }}'"
+      - name: "Copy"
+        run: cp target/${{ matrix.platform.target }}/debug/interactive-rebase-tool target/debug/git-interactive-rebase-tool-unstable-${{ matrix.platform.name }}
       - name: Upload
         uses: ncipollo/release-action@v1
         with:
           tag: latest
           allowUpdates: true
-          artifacts: "target/debian/ubuntu_amd64-interactive-rebase-tool.deb"
-          artifactErrorsFailBuild: true
-          artifactContentType: "application/vnd.debian.binary-package"
-          replacesArtifacts: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          makeLatest: false
-          prerelease: true
-          updateOnlyUnreleased: true
-
-  alpine:
-    name: Alpine Latest
-    runs-on: ubuntu-latest
-    needs: update-latest-tag
-    container:
-      image: 'docker://rust:alpine'
-    steps:
-      - uses: actions/checkout@v3
-      - run: |
-          apk update
-          apk upgrade
-          apk add bash musl-dev zlib-dev zlib-static
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-      - name: "Build"
-        run: |
-          cargo build --features dev
-          cp target/debug/interactive-rebase-tool target/debug/alpine_amd64-interactive-rebase-tool
-      - name: Upload
-        uses: ncipollo/release-action@v1
-        with:
-          tag: latest
-          allowUpdates: true
-          artifacts: "target/debug/alpine_amd64-interactive-rebase-tool"
+          artifacts: target/debug/git-interactive-rebase-tool-unstable-${{ matrix.platform.name }}
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           omitBodyDuringUpdate: true
@@ -124,70 +140,16 @@ jobs:
           prerelease: true
           updateOnlyUnreleased: true
 
-  arch:
-    name: Arch Latest
-    runs-on: ubuntu-latest
-    needs: update-latest-tag
-    container:
-      image: 'docker://archlinux:base-devel'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-      - name: "Build"
-        run: |
-          cargo build --features dev
-          cp target/debug/interactive-rebase-tool target/debug/arch_amd64-interactive-rebase-tool
-      - name: Upload
-        uses: ncipollo/release-action@v1
-        with:
-          tag: latest
-          allowUpdates: true
-          artifacts: "target/debug/arch_amd64-interactive-rebase-tool"
-          artifactErrorsFailBuild: true
-          replacesArtifacts: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          makeLatest: false
-          prerelease: true
-          updateOnlyUnreleased: true
-
-  fedora:
-    name: Fedora Latest
-    runs-on: ubuntu-latest
-    needs: update-latest-tag
-    container:
-      image: 'docker://fedora:latest'
-    steps:
-      - uses: actions/checkout@v3
-      - run: |
-          dnf install curl dnf-plugins-core cmake gcc clang make -y
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-      - name: "Build"
-        run: |
-          cargo build --features dev
-          cp target/debug/interactive-rebase-tool target/debug/fedora_amd64-interactive-rebase-tool
-      - name: Upload
-        uses: ncipollo/release-action@v1
-        with:
-          tag: latest
-          allowUpdates: true
-          artifacts: "target/debug/fedora_amd64-interactive-rebase-tool"
-          artifactErrorsFailBuild: true
-          replacesArtifacts: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          makeLatest: false
-          prerelease: true
-          updateOnlyUnreleased: true
-
-  macos-amd64:
-    name: MacOS amd64 Latest
+  macos:
+    name: "Release Latest - macOS_${{ matrix.platform.name }}"
+    continue-on-error: true
+    strategy:
+      matrix:
+        platform:
+          - name: arm
+            target: aarch64-apple-darwin
+          - name: intel
+            target: x86_64-apple-darwin
     runs-on: macos-latest
     timeout-minutes: 10
     needs: update-latest-tag
@@ -196,46 +158,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
+          targets: ${{ matrix.platform.target }}
       - name: "Build"
         run: |
-          cargo build --features dev 
-          cp target/debug/interactive-rebase-tool target/debug/macos-amd64-interactive-rebase-tool
+          cargo build --features dev --target ${{ matrix.platform.target }}
+          cp target/${{ matrix.platform.target }}/debug/interactive-rebase-tool target/git-interactive-rebase-tool-unstable-macos_${{ matrix.platform.name }}
       - name: Upload
         uses: ncipollo/release-action@v1
         with:
           tag: latest
           allowUpdates: true
-          artifacts: "target/debug/macos-amd64-interactive-rebase-tool"
-          artifactErrorsFailBuild: true
-          replacesArtifacts: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          makeLatest: false
-          prerelease: true
-          updateOnlyUnreleased: true
-
-  macos-arm:
-    name: MacOS ARM Latest
-    runs-on: macos-latest
-    timeout-minutes: 10
-    needs: update-latest-tag
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
-          targets: aarch64-apple-darwin
-      - name: "Build"
-        run: |
-          cargo build --target aarch64-apple-darwin --features dev 
-          cp target/aarch64-apple-darwin/debug/interactive-rebase-tool target/aarch64-apple-darwin/debug/macos-arm-interactive-rebase-tool
-      - name: Upload
-        uses: ncipollo/release-action@v1
-        with:
-          tag: latest
-          allowUpdates: true
-          artifacts: "target/aarch64-apple-darwin/debug/macos-arm-interactive-rebase-tool"
+          artifacts: target/git-interactive-rebase-tool-unstable-macos_${{ matrix.platform.name }}
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           omitBodyDuringUpdate: true
@@ -246,23 +179,34 @@ jobs:
           updateOnlyUnreleased: true
 
   windows:
-    name: Windows Latest
+    name: "Release Latest - Windows_${{ matrix.platform.name }}"
+    continue-on-error: true
+    strategy:
+      matrix:
+        platform:
+          - name: arm64
+            target: aarch64-pc-windows-msvc
+          - name: x64
+            target: x86_64-pc-windows-msvc
     runs-on: windows-latest
     timeout-minutes: 10
     needs: update-latest-tag
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.platform.target }}
       - name: "Build"
         run: |
-          cargo rustc --target x86_64-pc-windows-msvc --release --bin interactive-rebase-tool
-          copy target/x86_64-pc-windows-msvc/release/interactive-rebase-tool.exe target/x86_64-pc-windows-msvc/release/windows_amd64-interactive-rebase-tool.exe
+          cargo rustc --target ${{ matrix.platform.target }} --release --bin interactive-rebase-tool
+          copy target/${{ matrix.platform.target }}/release/interactive-rebase-tool.exe target/git-interactive-rebase-tool-unstable-windows_${{ matrix.platform.name }}.exe
       - name: Upload
         uses: ncipollo/release-action@v1
         with:
           tag: latest
           allowUpdates: true
-          artifacts: "target/x86_64-pc-windows-msvc/release/windows_amd64-interactive-rebase-tool.exe"
+          artifacts: "target/git-interactive-rebase-tool-unstable-windows_${{ matrix.platform.name }}.exe"
           artifactErrorsFailBuild: true
           replacesArtifacts: true
           omitBodyDuringUpdate: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,14 @@ on:
     types: [ published ]
 
 jobs:
-  build-ubuntu-legacy:
-    strategy:
-      matrix:
-        version: [ '14.04', '16.04' ]
+  build_tag:
+    name: "Build Tag Name"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    container:
-      image: 'docker://ubuntu:${{ matrix.version }}'
+    timeout-minutes: 1
+    outputs:
+      release_version: ${{ steps.ref.outputs.version }}
     steps:
-      - name: "Get Tag Name"
+      - name: " Build Tag"
         id: ref
         shell: bash
         run: |
@@ -23,136 +21,265 @@ jobs:
           ref="${ref//refs\/tags\//}";
           ref="${ref//master/dev}";
           echo "$ref";
-          echo "::set-output name=name::$ref"
-      - uses: actions/checkout@v3
-      # manually install and use rustup, since dtolnay/rust-toolchain is not supported on older versions of Ubuntu
-      - name: "System Setup"
-        run: |
-          apt-get update;
-          apt-get --assume-yes -f install curl build-essential pkg-config;
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- --default-toolchain stable -y;
-          $HOME/.cargo/bin/cargo install --force cargo-deb
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          TZ: "America/St_Johns"
-      - name: "Build Deb"
-        run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-ubuntu-${{ matrix.version }}_amd64.deb"
-      - name: "Upload Release"
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target/debian/*.deb
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-ubuntu:
+          echo "version=$ref" >> "$GITHUB_OUTPUT"
+
+
+
+  build-deb:
+    name: "Release ${{ matrix.platform.name }}"
     strategy:
       matrix:
-        version: [ '18.04', '20.04', '22.04', '22.10', '23.04' ]
+        platform:
+          - name: ubuntu-20.04_arm64
+            target: aarch64-unknown-linux-gnu
+            image: ubuntu:20.04
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: ubuntu-20.04_amd64
+            target: x86_64-unknown-linux-gnu
+            image: ubuntu:20.04
+
+          - name: ubuntu-22.04_arm64
+            target: aarch64-unknown-linux-gnu
+            image: ubuntu:22.04
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: ubuntu-22.04_amd64
+            target: x86_64-unknown-linux-gnu
+            image: ubuntu:22.04
+
+          - name: ubuntu-24.04_arm64
+            target: aarch64-unknown-linux-gnu
+            image: ubuntu:24.04
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: ubuntu-24.04_amd64
+            target: x86_64-unknown-linux-gnu
+            image: ubuntu:24.04
+
+          - name: debian-10_arm64
+            target: aarch64-unknown-linux-gnu
+            image: debian:10-slim
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: debian-10_amd64
+            target: x86_64-unknown-linux-gnu
+            image: debian:10-slim
+
+          - name: debian-11_arm64
+            target: aarch64-unknown-linux-gnu
+            image: debian:11-slim
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: debian-11_amd64
+            target: x86_64-unknown-linux-gnu
+            image: debian:11-slim
+
+          - name: debian-12_arm64
+            target: aarch64-unknown-linux-gnu
+            image: debian:12-slim
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: debian-12_amd64
+            target: x86_64-unknown-linux-gnu
+            image: debian:12-slim
+
+          - name: debian-sid_arm64
+            target: aarch64-unknown-linux-gnu
+            image: debian:sid-slim
+            build-args: "--features zlib-ng-compat"
+            pkg-args: --no-strip
+          - name: debian-sid_amd64
+            target: x86_64-unknown-linux-gnu
+            image: debian:sid-slim
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container:
-      image: 'docker://ubuntu:${{ matrix.version }}'
+    needs: [ build_tag ]
     steps:
-      - name: "Get Tag Name"
-        id: ref
-        shell: bash
-        run: |
-          ref="${{ github.ref }}";
-          ref="${ref//refs\/heads\//}";
-          ref="${ref//refs\/tags\//}";
-          ref="${ref//master/dev}";
-          echo "$ref";
-          echo "::set-output name=name::$ref"
       - uses: actions/checkout@v3
-      - name: "System Setup"
-        run: |
-          apt-get update;
-          apt-get --assume-yes -f install curl build-essential pkg-config;
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          TZ: "America/St_Johns"
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-deb
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          toolchain: stable
+          args: "--release ${{ matrix.platform.build-args }}"
       - name: "Build Deb"
-        run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-ubuntu-${{ matrix.version }}_amd64.deb"
+        run: $HOME/.cargo/bin/cargo +stable deb ${{ matrix.platform.pkg-args }} --no-build --target ${{ matrix.platform.target }} --output "target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}.deb"
       - name: "Upload Release"
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/debian/*.deb
+            target/*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-debian:
+  build-rpm:
+    name: "Release ${{ matrix.platform.name }}"
     strategy:
       matrix:
-        version: [ '10', '11', '12', 'sid' ]
+        platform:
+          - name: fedora-39_arm64
+            target: aarch64-unknown-linux-gnu
+            image: fedora:39
+            build-args: "--features zlib-ng-compat"
+          - name: fedora-39_amd64
+            target: x86_64-unknown-linux-gnu
+            image: fedora:39
+          - name: fedora-40_arm64
+            target: aarch64-unknown-linux-gnu
+            image: fedora:40
+            build-args: "--features zlib-ng-compat"
+          - name: fedora-40_amd64
+            target: x86_64-unknown-linux-gnu
+            image: fedora:40
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container:
-      image: 'docker://debian:${{ matrix.version }}-slim'
+    needs: [ build_tag ]
     steps:
-      - name: "Get Tag Name"
-        id: ref
-        shell: bash
-        run: |
-          ref="${{ github.ref }}";
-          ref="${ref//refs\/heads\//}";
-          ref="${ref//refs\/tags\//}";
-          ref="${ref//master/dev}";
-          echo "$ref";
-          echo "::set-output name=name::$ref"
-      - uses: actions/checkout@v3
-      - name: "System Setup"
-        run: |
-          apt-get update;
-          apt-get --assume-yes -f install curl build-essential pkg-config;
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          TZ: "America/St_Johns"
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - uses: baptiste0928/cargo-install@v2
         with:
-          crate: cargo-deb
-      - name: "Build Deb"
-        run: $HOME/.cargo/bin/cargo +stable deb --output "target/debian/git-interactive-rebase-tool-${{ steps.ref.outputs.name }}-debian-${{ matrix.version }}_amd64.deb"
+          crate: cargo-generate-rpm
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          toolchain: stable
+          args: "--release ${{ matrix.platform.build-args }}"
+      - name: "Build RPM"
+        run: $HOME/.cargo/bin/cargo +stable generate-rpm --target ${{ matrix.platform.target }} --output "target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}.rpm"
       - name: "Upload Release"
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/debian/*.deb
+            target/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-macos:
-    runs-on: macos-latest
-    timeout-minutes: 5
+
+  linux-other:
+    name: "Release ${{ matrix.platform.name }}"
+    continue-on-error: true
+    strategy:
+      matrix:
+        platform:
+          # Alpine
+          - name: alpine_arm64
+            target: aarch64-unknown-linux-gnu
+            build-args: "--features zlib-ng-compat"
+          - name: alpine_amd64
+            target: x86_64-unknown-linux-gnu
+          # Arch
+          - name: arch_arm64
+            target: aarch64-unknown-linux-gnu
+            build-args: "--features zlib-ng-compat"
+          - name: arch_amd64
+            target: x86_64-unknown-linux-gnu
+          # Raspberry PI
+          - name: pi0-1_arm
+            target: arm-unknown-linux-gnueabihf
+          - name: pi2-4_armv7
+            target: armv7-unknown-linux-gnueabihf
+            build-args: "--features zlib-ng-compat"
+          - name: pi5_arm64
+            target: aarch64-unknown-linux-gnu
+            build-args: "--features zlib-ng-compat"
+    needs: [ build_tag ]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - name: "Build"
-        run: "cargo +stable build --release"
-      - name: "Rename"
-        run: "cp target/release/interactive-rebase-tool target/release/macos-interactive-rebase-tool"
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          toolchain: stable
+          args: "--release ${{ matrix.platform.build-args }}"
+      - name: "Copy"
+        run: cp target/${{ matrix.platform.target }}/release/interactive-rebase-tool target/release/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}
       - name: "Upload Release"
         uses: softprops/action-gh-release@v1
         with:
-          files: target/release/macos-interactive-rebase-tool
+          files: target/release/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    name: "Release macOS-${{ matrix.platform.macos }}_${{ matrix.platform.name }}"
+    strategy:
+      matrix:
+        platform:
+          - name: macos-12_arm
+            target: aarch64-apple-darwin
+            macos: 12
+          - name: macos-12_intel
+            target: x86_64-apple-darwin
+            macos: 12
+          - name: macos-13_arm
+            target: aarch64-apple-darwin
+            macos: 13
+          - name: macos-13_intel
+            target: x86_64-apple-darwin
+            macos: 13
+          - name: macos-14_arm
+            target: aarch64-apple-darwin
+            macos: 14
+          - name: macos-14_intel
+            target: x86_64-apple-darwin
+            macos: 14
+    runs-on: macos-${{ matrix.platform.macos }}
+    timeout-minutes: 5
+    needs: [ build_tag ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.platform.target }}
+      - name: "Build"
+        run: "cargo +stable build --release --target ${{ matrix.platform.target }}"
+      - name: "Rename"
+        run: "cp target/${{ matrix.platform.target }}/release/interactive-rebase-tool target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}"
+      - name: "Upload Release"
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-${{ matrix.platform.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows:
+    name: "Release Windows_${{ matrix.target }}"
+    strategy:
+      matrix:
+        target: [ 'aarch64', 'x86_64' ]
     runs-on: windows-latest
     timeout-minutes: 10
+    needs: [ build_tag ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: "${{ matrix.target }}-pc-windows-msvc"
       - name: "Build"
-        run: "cargo rustc --target x86_64-pc-windows-msvc --release --bin interactive-rebase-tool"
+        run: "cargo rustc --target ${{ matrix.target }}-pc-windows-msvc --release --bin interactive-rebase-tool"
+      - name: "Rename"
+        run: "copy target/${{ matrix.target }}-pc-windows-msvc/release/interactive-rebase-tool.exe target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-windows-${{ matrix.version }}_${{ matrix.target }}.exe"
       - name: "Upload Release"
         uses: softprops/action-gh-release@v1
         with:
-          files: target/x86_64-pc-windows-msvc/release/interactive-rebase-tool.exe
+          files: target/git-interactive-rebase-tool-${{ needs.build_tag.outputs.release_version }}-windows-${{ matrix.version }}_${{ matrix.target }}.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,8 +460,23 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -462,6 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
+ "cmake",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -531,6 +556,18 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ rustc_version = "0.4.0"
 [features]
 default = []
 dev = []
+# Mostly used for some arm systems
+zlib-ng-compat = ["git2/zlib-ng-compat"]
 
 [profile.release]
 incremental = true
@@ -81,6 +83,15 @@ assets = [
     ["readme/**/*.md", "usr/share/doc/interactive-rebase-tool/readme/", "644"],
     ["CHANGELOG.md", "usr/share/doc/interactive-rebase-tool/", "644"],
     ["src/interactive-rebase-tool.1", "usr/share/man/man1/interactive-rebase-tool.1", "644"]
+]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/interactive-rebase-tool", dest = "/usr/bin/interactive-rebase-tool", mode = "755" },
+    { source = "README.md", dest = "/usr/share/doc/interactive-rebase-tool/", mode = "644" },
+    { source = "readme/*.md", dest = "/usr/share/doc/interactive-rebase-tool/readme/", mode = "644" },
+    { source = "CHANGELOG.md", dest = "/usr/share/doc/interactive-rebase-tool/", mode = "644" },
+    { source = "src/interactive-rebase-tool.1", dest = "/usr/share/man/man1/interactive-rebase-tool.1", mode = "644" },
 ]
 
 [lints.rust]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,12 +7,12 @@ default_to_workspace = false
 
 [tasks.dev]
 dependencies = [
-	"build",
-	"build-nightly",
-	"test",
-	"docs",
-	"lint",
-	"format",
+    "build",
+    "build-nightly",
+    "test",
+    "docs",
+    "lint",
+    "format",
 ]
 
 [tasks.build]
@@ -56,22 +56,21 @@ command = "cargo"
 condition = { platforms = ["linux"] }
 env = { "RUSTFLAGS" = "-C link-dead-code" }
 args = [
-	"tarpaulin",
-	"--all-features",
-	"--ignore-tests",
-	"--line",
-	"--verbose",
-	"--out", "Html",
-	"--out", "Lcov",
-	"--output-dir",
-	"coverage",
-	"${@}"
+    "tarpaulin",
+    "--ignore-tests",
+    "--line",
+    "--verbose",
+    "--out", "Html",
+    "--out", "Lcov",
+    "--output-dir",
+    "coverage",
+    "${@}"
 ]
 
 [tasks.docs]
 dependencies = [
-	"docs-nightly",
-	"docs-stable"
+    "docs-nightly",
+    "docs-stable"
 ]
 
 [tasks.docs-stable]
@@ -79,9 +78,8 @@ dependencies = ["update-rust-stable"]
 toolchain = "stable"
 command = "cargo"
 args = [
-	"doc",
-	"--all-features",
-	"${@}"
+    "doc",
+    "${@}"
 ]
 
 [tasks.docs-nightly]
@@ -90,15 +88,14 @@ toolchain = "nightly${RUST_NIGHTLY_VERSION_PREFIX}"
 ignore_errors = true
 command = "cargo"
 args = [
-	"doc",
-	"--all-features",
-	"${@}"
+    "doc",
+    "${@}"
 ]
 
 [tasks.lint]
 dependencies = [
-	"lint-nightly",
-	"lint-stable"
+    "lint-nightly",
+    "lint-stable"
 ]
 
 [tasks.lint-stable]
@@ -106,10 +103,9 @@ dependencies = ["update-rust-stable"]
 toolchain = "stable"
 command = "cargo"
 args = [
-	"clippy",
-	"--all-targets",
-	"--all-features",
-	"${@}"
+    "clippy",
+    "--all-targets",
+    "${@}"
 ]
 
 [tasks.lint-nightly]
@@ -118,10 +114,9 @@ toolchain = "nightly${RUST_NIGHTLY_VERSION_PREFIX}"
 ignore_errors = true
 command = "cargo"
 args = [
-	"clippy",
-	"--all-targets",
-	"--all-features",
-	"${@}"
+    "clippy",
+    "--all-targets",
+    "${@}"
 ]
 
 [tasks.format]
@@ -129,11 +124,11 @@ dependencies = ["update-rust-nightly"]
 toolchain = "nightly${RUST_NIGHTLY_VERSION_PREFIX}"
 command = "cargo"
 args = [
-	"fmt",
-	"--all",
-	"--",
-	"--check",
-	"${@}"
+    "fmt",
+    "--all",
+    "--",
+    "--check",
+    "${@}"
 ]
 
 [tasks.format-apply]
@@ -141,11 +136,11 @@ dependencies = ["update-rust-nightly"]
 toolchain = "nightly${RUST_NIGHTLY_VERSION_PREFIX}"
 command = "cargo"
 args = [
-	"fmt",
-	"--all",
-	"--",
-	"--emit", "files",
-	"${@}"
+    "fmt",
+    "--all",
+    "--",
+    "--emit", "files",
+    "${@}"
 ]
 
 [tasks.licenses]


### PR DESCRIPTION
This change updates the release process to provide builds for Arm based systems, as well as several different Linux distros, and an RPM release.

Supported operating systems: Alpine, Arch, Debian, Fedora, Pi 0-5, Ubuntu, macOS, Windows

Supported architectures: arm64, amd64, arm (Pi 0-1), armv7 (Pi 2-4)

closes #786 