### PR TITLE
Properly support multiple visible lines in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [2.4.0] - 2024-06-01
 ### Added
-- Add support for `NO_COLOR` environment
-  variable  ([#896](https://github.com/MitMaro/git-interactive-rebase-tool/pull/896))
+- Add support for `NO_COLOR` environment variable  ([#896](https://github.com/MitMaro/git-interactive-rebase-tool/pull/896))
 - Post modified line exec command ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/890))
 
 ### Changed
@@ -15,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Fixed TTY support on macOS ([#874](https://github.com/MitMaro/git-interactive-rebase-tool/pull/874))
 - Flicker when action width changes ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/891))
+- Selected line was not always visible when multiple lines were selected ([#918](https://github.com/MitMaro/git-interactive-rebase-tool/pull/918))
 
 ## [2.3.0] - 2023-07-19
 ### Added
@@ -183,7 +183,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Initial project release
 
-[Unreleased]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.3.0...HEAD
+[Unreleased]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.4.0...HEAD
+[2.4.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/MitMaro/git-interactive-rebase-tool/compare/2.1.0...2.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ nonstandard_style = { level = "warn", priority = -2 }
 rust_2018_compatibility = { level = "warn", priority = -2 }
 rust_2018_idioms = { level = "warn", priority = -2 }
 rust_2021_compatibility = { level = "warn", priority = -2 }
-rust_2024_compatibility = { level = "warn", priority = -2 }
+# rust_2024_compatibility = { level = "warn", priority = -2 } - requires some significant changes
 unused = { level = "warn", priority = -2 }
 
 unknown_lints = { level = "warn", priority = -1 }

--- a/src/view/render_slice.rs
+++ b/src/view/render_slice.rs
@@ -274,7 +274,7 @@ impl RenderSlice {
 			self.padding_height < self.height && lines_length > (self.height - self.padding_height);
 
 		self.scroll_position.set_lines_length(lines_length);
-		if let Some(row) = view_data.get_visible_row().as_ref() {
+		for row in view_data.visible_rows() {
 			self.scroll_position.ensure_line_visible(*row);
 		}
 

--- a/src/view/tests.rs
+++ b/src/view/tests.rs
@@ -182,3 +182,56 @@ fn render_with_scroll_bar() {
 		],
 	);
 }
+
+#[test]
+fn render_ensure_visible_row_single() {
+	assert_render(
+		30,
+		3,
+		&ViewData::new(|updater| {
+			updater.push_line(ViewLine::from("This is line 1"));
+			updater.push_line(ViewLine::from("This is line 2"));
+			updater.push_line(ViewLine::from("This is line 3"));
+			updater.push_line(ViewLine::from("This is line 4"));
+			updater.push_line(ViewLine::from("This is line 5"));
+			updater.ensure_line_visible(3);
+		}),
+		&["This is line 2 ", "This is line 3 ", "This is line 4█"],
+	);
+}
+
+#[test]
+fn render_ensure_visible_multiple_rows_increasing_order() {
+	assert_render(
+		30,
+		3,
+		&ViewData::new(|updater| {
+			updater.push_line(ViewLine::from("This is line 1"));
+			updater.push_line(ViewLine::from("This is line 2"));
+			updater.push_line(ViewLine::from("This is line 3"));
+			updater.push_line(ViewLine::from("This is line 4"));
+			updater.push_line(ViewLine::from("This is line 5"));
+			updater.ensure_line_visible(3);
+			updater.ensure_line_visible(4);
+		}),
+		&["This is line 3 ", "This is line 4 ", "This is line 5█"],
+	);
+}
+
+#[test]
+fn render_ensure_visible_multiple_rows_decreasing_order() {
+	assert_render(
+		30,
+		3,
+		&ViewData::new(|updater| {
+			updater.push_line(ViewLine::from("This is line 1"));
+			updater.push_line(ViewLine::from("This is line 2"));
+			updater.push_line(ViewLine::from("This is line 3"));
+			updater.push_line(ViewLine::from("This is line 4"));
+			updater.push_line(ViewLine::from("This is line 5"));
+			updater.ensure_line_visible(4);
+			updater.ensure_line_visible(3);
+		}),
+		&["This is line 3 ", "This is line 4 ", "This is line 5█"],
+	);
+}

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -15,7 +15,7 @@ pub(crate) struct ViewData {
 	show_title: bool,
 	version: u32,
 	visible_column: Option<usize>,
-	visible_row: Option<usize>,
+	visible_rows: Vec<usize>,
 }
 
 impl ViewData {
@@ -33,7 +33,7 @@ impl ViewData {
 			show_title: false,
 			version: 0,
 			visible_column: None,
-			visible_row: None,
+			visible_rows: vec![],
 		};
 		let mut view_data_updater = ViewDataUpdater::new(&mut view_data);
 		callback(&mut view_data_updater);
@@ -69,8 +69,12 @@ impl ViewData {
 		self.lines.clear();
 	}
 
+	pub(crate) fn clear_visible_lines(&mut self) {
+		self.visible_rows.clear();
+	}
+
 	pub(crate) fn ensure_line_visible(&mut self, row_index: usize) {
-		self.visible_row = Some(row_index);
+		self.visible_rows.push(row_index);
 	}
 
 	pub(crate) fn ensure_column_visible(&mut self, column_index: usize) {
@@ -129,8 +133,8 @@ impl ViewData {
 		&self.visible_column
 	}
 
-	pub(crate) const fn get_visible_row(&self) -> &Option<usize> {
-		&self.visible_row
+	pub(crate) const fn visible_rows(&self) -> &Vec<usize> {
+		&self.visible_rows
 	}
 
 	pub(crate) fn get_name(&self) -> &str {
@@ -210,7 +214,16 @@ mod tests {
 	fn ensure_line_visible() {
 		let mut view_data = ViewData::new(|_| {});
 		view_data.ensure_line_visible(10);
-		assert_eq!(view_data.get_visible_row().unwrap(), 10);
+		view_data.ensure_line_visible(11);
+		assert_eq!(view_data.visible_rows(), &vec![10, 11]);
+	}
+
+	#[test]
+	fn clear_visible_lines() {
+		let mut view_data = ViewData::new(|_| {});
+		view_data.ensure_line_visible(10);
+		view_data.clear_visible_lines();
+		assert_eq!(view_data.visible_rows().len(), 0);
 	}
 
 	#[test]

--- a/src/view/view_data_updater.rs
+++ b/src/view/view_data_updater.rs
@@ -18,6 +18,7 @@ impl<'view_data> ViewDataUpdater<'view_data> {
 	/// Clear content of the view data.
 	pub(crate) fn clear(&mut self) {
 		self.modified = true;
+		self.view_data.clear_visible_lines();
 		self.view_data.clear();
 	}
 
@@ -127,7 +128,7 @@ mod tests {
 		let mut updater = ViewDataUpdater::new(&mut view_data);
 		updater.ensure_line_visible(10);
 		assert!(updater.is_modified());
-		assert_eq!(view_data.get_visible_row().unwrap(), 10);
+		assert_eq!(view_data.visible_rows(), &vec![10]);
 	}
 
 	#[test]


### PR DESCRIPTION
Previously, only one line could be marked as visible in the view data. This resulted in the multi-select mode not correctly scrolling to the start index in cases where lines are reordered.

This change adds support for multiple visible lines in the view data, resulting in the "ensure visible" algorithm running over each visible line.