### PR TITLE
Fix hidden line on non-body line addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Fixed TTY support on macOS ([#874](https://github.com/MitMaro/git-interactive-rebase-tool/pull/874))
 - Flicker when action width changes ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/891))
 - Selected line was not always visible when multiple lines were selected ([#918](https://github.com/MitMaro/git-interactive-rebase-tool/pull/918))
+- Selected line hidden by added trailing, leading or header line when view was not resized ([#919](https://github.com/MitMaro/git-interactive-rebase-tool/pull/919))
 
 ## [2.3.0] - 2023-07-19
 ### Added

--- a/src/view/render_slice.rs
+++ b/src/view/render_slice.rs
@@ -218,6 +218,7 @@ impl RenderSlice {
 
 		if self.padding_height != padding_height {
 			self.padding_height = padding_height;
+			self.update_scroll_position_size();
 		}
 	}
 


### PR DESCRIPTION
When a leading, trailing or header line was added to the view data, the RenderSlice was not correctly updated to take into account which lines should be visible. This resulted in some lines being hidden below the view "window". This fixes the RenderSlice to recalculate the scroll position when a leading, trailing or header line is changed.