### PR TITLE
Cleanup from the 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [2.4.0] - 2024-06-01
+## [2.4.0] - 2024-06-13
 ### Added
 - Add support for `NO_COLOR` environment variable  ([#896](https://github.com/MitMaro/git-interactive-rebase-tool/pull/896))
 - Post modified line exec command ([#888](https://github.com/MitMaro/git-interactive-rebase-tool/pull/890))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Native cross-platform full feature terminal based [sequence editor][git-sequence
 
 [![Git Interactive Rebase Tool](/docs/assets/images/girt-demo.gif?raw=true)](https://youtu.be/q3tzb-gQC0w)
 
+**This is the documentation for the development build. For the current stable release, please use the [2.4.x documentation](https://github.com/MitMaro/git-interactive-rebase-tool/tree/2.4.0/README.md).**
+
 ## Table of Contents
 
 * [Features](./README.md#features)


### PR DESCRIPTION
This change consists of adding the dev notice back to the readme and fixing the release date in the CHANGELOG.