### PR TITLE
Allow running tests on unpacked crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ include = [
 	"/LICENSE",
 	"/readme",
 	"/README.md",
-	"/src/interactive-rebase-tool.1"
+	"/src/interactive-rebase-tool.1",
+	"/test"
 ]
 edition = "2021"
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -47,8 +47,23 @@ mod tests {
 	#[test]
 	#[serial_test::serial]
 	fn build_version_with_env() {
+		let maybe_git_hash = option_env!("GIRT_BUILD_GIT_HASH");
+		assert_eq!(
+			std::process::Command::new("git")
+				.args(["rev-parse", "--is-inside-work-tree"])
+				.output()
+				.map(|out| out.status.success())
+				.unwrap_or(false),
+			maybe_git_hash.is_some()
+		);
+
 		let version = build_version();
-		let expected_meta = format!("({} {})", env!("GIRT_BUILD_GIT_HASH"), env!("GIRT_BUILD_DATE"));
+		let expected_meta = if let Some(git_hash) = maybe_git_hash {
+			format!("({} {})", git_hash, env!("GIRT_BUILD_DATE"))
+		}
+		else {
+			format!("({})", env!("GIRT_BUILD_DATE"))
+		};
 		assert!(version.starts_with("interactive-rebase-tool"));
 		assert!(version.ends_with(expected_meta.as_str()));
 	}


### PR DESCRIPTION
Downstream Linux distros may want to run the tests as part of their package build process, but will only have our packaged crate, not a Git checkout.  Include test fixtures in the crate, and fix a test that assumes the availability of a commit hash.