### PR TITLE
Fix issue with handling of search input in list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+### Fixed
+- Fix issue with search input handling that blocked setting `Esc` and `Enter` in keybindings ([#935](https://github.com/MitMaro/git-interactive-rebase-tool/pull/935))
+
 ## [2.4.1] - 2024-06-26
 ### Fixed
 - Renamed and copied file order reversed in show commit view ([#926](https://github.com/MitMaro/git-interactive-rebase-tool/pull/926))

--- a/src/input/event_handler.rs
+++ b/src/input/event_handler.rs
@@ -37,6 +37,11 @@ impl EventHandler {
 			}
 		}
 
+		if input_options.contains(InputOptions::SEARCH_START) {
+			if let Some(evt) = Self::handle_search_start(&self.key_bindings, event) {
+				return evt;
+			}
+		}
 		if input_options.contains(InputOptions::SEARCH) {
 			if let Some(evt) = Self::handle_search(&self.key_bindings, event) {
 				return evt;
@@ -113,6 +118,13 @@ impl EventHandler {
 			}) => Event::from(StandardEvent::ScrollBottom),
 			_ => return None,
 		})
+	}
+
+	fn handle_search_start(key_bindings: &KeyBindings, event: Event) -> Option<Event> {
+		key_bindings
+			.search_start
+			.contains(&event)
+			.then(|| Event::from(StandardEvent::SearchStart))
 	}
 
 	fn handle_search(key_bindings: &KeyBindings, event: Event) -> Option<Event> {
@@ -270,6 +282,15 @@ mod tests {
 	fn search_inputs(#[case] event: Event, #[case] expected: Event) {
 		let event_handler = EventHandler::new(create_test_keybindings());
 		let result = event_handler.read_event(event, &InputOptions::SEARCH, |_, _| Event::from(KeyCode::Null));
+		assert_eq!(result, expected);
+	}
+
+	#[rstest]
+	#[case::search_start(Event::from('/'), Event::from(StandardEvent::SearchStart))]
+	#[case::other(Event::from('a'), Event::from(KeyCode::Null))]
+	fn search_start(#[case] event: Event, #[case] expected: Event) {
+		let event_handler = EventHandler::new(create_test_keybindings());
+		let result = event_handler.read_event(event, &InputOptions::SEARCH_START, |_, _| Event::from(KeyCode::Null));
 		assert_eq!(result, expected);
 	}
 

--- a/src/input/input_options.rs
+++ b/src/input/input_options.rs
@@ -10,9 +10,11 @@ bitflags! {
 		const RESIZE = 0b0000_0010;
 		/// Enable undo and redo input handling
 		const UNDO_REDO = 0b0000_0100;
+		/// Search start
+		const SEARCH_START = 0b0000_1000;
 		/// Search handling
-		const SEARCH = 0b0000_1000;
+		const SEARCH = 0b0001_1000;
 		/// Help input handling
-		const HELP = 0b0001_0000;
+		const HELP = 0b0010_0000;
 	}
 }

--- a/src/modules/list.rs
+++ b/src/modules/list.rs
@@ -40,7 +40,7 @@ use crate::{
 const INPUT_OPTIONS: InputOptions = InputOptions::UNDO_REDO
 	.union(InputOptions::RESIZE)
 	.union(InputOptions::HELP)
-	.union(InputOptions::SEARCH);
+	.union(InputOptions::SEARCH_START);
 
 #[derive(Debug, PartialEq, Eq)]
 enum ListState {


### PR DESCRIPTION
The search input handling was incorrectly handling Esc and Enter inputs when the search is not active. This has resulted in those keys being unable to be used in keybindings.

This change updates the input handling, to use a "search start" input option instead of the full search option.

Closes #934 