### PR TITLE
Add ViewLines struct to replace Vec<ViewLine>

### DIFF
--- a/src/components/choice.rs
+++ b/src/components/choice.rs
@@ -7,7 +7,7 @@ use crate::{
 	display::DisplayColor,
 	input::{Event, InputOptions, KeyCode},
 	util::handle_view_data_scroll,
-	view::{LineSegment, ViewData, ViewLine},
+	view::{LineSegment, ViewData, ViewLine, ViewLines},
 };
 
 pub(crate) static INPUT_OPTIONS: LazyLock<InputOptions> =
@@ -44,7 +44,7 @@ where T: Clone
 		}
 	}
 
-	pub(crate) fn set_prompt(&mut self, prompt_lines: Vec<ViewLine>) {
+	pub(crate) fn set_prompt(&mut self, prompt_lines: ViewLines) {
 		self.view_data.update_view_data(|updater| {
 			updater.clear();
 			for line in prompt_lines {

--- a/src/components/choice/tests.rs
+++ b/src/components/choice/tests.rs
@@ -36,7 +36,7 @@ fn render_options_no_prompt() {
 #[test]
 fn render_options_prompt() {
 	let mut module = Choice::new(create_choices());
-	module.set_prompt(vec![ViewLine::from("Prompt")]);
+	module.set_prompt(ViewLines::from([ViewLine::from("Prompt")]));
 	assert_rendered_output!(
 		Style module.get_view_data(),
 		"{TITLE}",

--- a/src/modules/external_editor.rs
+++ b/src/modules/external_editor.rs
@@ -17,7 +17,7 @@ use crate::{
 	module::{ExitStatus, Module, State},
 	process::Results,
 	todo_file::{Line, TodoFile},
-	view::{RenderContext, ViewData, ViewLine},
+	view::{RenderContext, ViewData, ViewLine, ViewLines},
 };
 
 static INPUT_OPTIONS: LazyLock<InputOptions> = LazyLock::new(|| InputOptions::RESIZE);
@@ -181,7 +181,7 @@ impl ExternalEditor {
 				String::from("Undo modifications and edit rebase file"),
 			),
 		]);
-		empty_choice.set_prompt(vec![ViewLine::from("The rebase file is empty.")]);
+		empty_choice.set_prompt(ViewLines::from([ViewLine::from("The rebase file is empty.")]));
 
 		let error_choice = Choice::new(vec![
 			(Action::AbortRebase, '1', String::from("Abort rebase")),

--- a/src/modules/insert.rs
+++ b/src/modules/insert.rs
@@ -19,7 +19,7 @@ use crate::{
 	module::{Module, State},
 	process::Results,
 	todo_file::{Line, TodoFile},
-	view::{LineSegment, RenderContext, ViewData, ViewDataUpdater, ViewLine},
+	view::{LineSegment, RenderContext, ViewData, ViewDataUpdater, ViewLine, ViewLines},
 };
 
 pub(crate) struct Insert {
@@ -122,7 +122,7 @@ impl Insert {
 			(LineType::UpdateRef, 'u', String::from("update-ref <reference>")),
 			(LineType::Cancel, 'q', String::from("Cancel add line")),
 		]);
-		action_choices.set_prompt(vec![ViewLine::from("Select the type of line to insert:")]);
+		action_choices.set_prompt(ViewLines::from([ViewLine::from("Select the type of line to insert:")]));
 
 		Self {
 			action_choices,

--- a/src/test_helpers/assertions/assert_rendered_output/render_view_data.rs
+++ b/src/test_helpers/assertions/assert_rendered_output/render_view_data.rs
@@ -20,30 +20,30 @@ pub(crate) fn render_view_data(view_data: &ViewData, options: AssertRenderOption
 	}
 
 	if !body_only {
-		let leading_lines = view_data.get_leading_lines();
+		let leading_lines = view_data.leading_lines();
 		if !leading_lines.is_empty() {
 			lines.push(String::from("{LEADING}"));
-			for line in leading_lines {
+			for line in leading_lines.iter() {
 				lines.push(render_view_line(line, Some(options)));
 			}
 		}
 	}
 
-	let body_lines = view_data.get_lines();
+	let body_lines = view_data.lines();
 	if !body_lines.is_empty() {
 		if !body_only {
 			lines.push(String::from("{BODY}"));
 		}
-		for line in body_lines {
+		for line in body_lines.iter() {
 			lines.push(render_view_line(line, Some(options)));
 		}
 	}
 
 	if !body_only {
-		let trailing_lines = view_data.get_trailing_lines();
+		let trailing_lines = view_data.trailing_lines();
 		if !trailing_lines.is_empty() {
 			lines.push(String::from("{TRAILING}"));
-			for line in trailing_lines {
+			for line in trailing_lines.iter() {
 				lines.push(render_view_line(line, Some(options)));
 			}
 		}

--- a/src/view.rs
+++ b/src/view.rs
@@ -18,6 +18,7 @@ mod thread;
 mod view_data;
 mod view_data_updater;
 mod view_line;
+mod view_lines;
 
 #[cfg(test)]
 mod tests;
@@ -35,6 +36,7 @@ pub(crate) use self::{
 	view_data::ViewData,
 	view_data_updater::ViewDataUpdater,
 	view_line::ViewLine,
+	view_lines::ViewLines,
 };
 use crate::display::{Display, DisplayColor, Tui};
 
@@ -101,17 +103,17 @@ impl<C: Tui> View<C> {
 			self.display.next_line()?;
 		}
 
-		let lines = render_slice.get_lines();
+		let view_lines = render_slice.view_lines();
 		let leading_line_count = render_slice.get_leading_lines_count();
 		let trailing_line_count = render_slice.get_trailing_lines_count();
-		let lines_count = lines.len() - leading_line_count - trailing_line_count;
+		let lines_count = view_lines.count() as usize - leading_line_count - trailing_line_count;
 		let show_scroll_bar = render_slice.should_show_scroll_bar();
 		let scroll_indicator_index = render_slice.get_scroll_index();
 		let view_height = window_height - leading_line_count - trailing_line_count;
 
-		let leading_lines_iter = lines.iter().take(leading_line_count);
-		let lines_iter = lines.iter().skip(leading_line_count).take(lines_count);
-		let trailing_lines_iter = lines.iter().skip(leading_line_count + lines_count);
+		let leading_lines_iter = view_lines.iter().take(leading_line_count);
+		let lines_iter = view_lines.iter().skip(leading_line_count).take(lines_count);
+		let trailing_lines_iter = view_lines.iter().skip(leading_line_count + lines_count);
 
 		for line in leading_lines_iter {
 			self.display.ensure_at_line_start()?;

--- a/src/view/render_slice/tests.rs
+++ b/src/view/render_slice/tests.rs
@@ -23,17 +23,17 @@ fn assert_rendered(render_slice: &RenderSlice, expected: &[&str]) {
 		}
 	}
 
-	let lines = render_slice.get_lines();
-	if lines.is_empty() {
+	let view_lines = render_slice.view_lines();
+	if view_lines.is_empty() {
 		output.push(String::from("{EMPTY}"));
 	}
 	else {
 		let leading_line_count = render_slice.get_leading_lines_count();
 		let trailing_line_count = render_slice.get_trailing_lines_count();
-		let lines_count = lines.len() - leading_line_count - trailing_line_count;
-		let leading_lines = lines.iter().take(leading_line_count);
-		let body_lines = lines.iter().skip(leading_line_count).take(lines_count);
-		let trailing_lines = lines.iter().skip(leading_line_count + lines_count);
+		let lines_count = view_lines.count() as usize - leading_line_count - trailing_line_count;
+		let leading_lines = view_lines.iter().take(leading_line_count);
+		let body_lines = view_lines.iter().skip(leading_line_count).take(lines_count);
+		let trailing_lines = view_lines.iter().skip(leading_line_count + lines_count);
 
 		if leading_line_count > 0 {
 			output.push(String::from("{LEADING}"));
@@ -1237,40 +1237,40 @@ fn scroll_horizontal_with_segments() {
 
 #[test]
 fn calculate_max_line_length_max_first() {
-	let view_lines = [
+	let view_lines = ViewLines::from([
 		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
 		ViewLine::from("012345"),
-	];
+	]);
 	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 1), 16);
 }
 
 #[test]
 fn calculate_max_line_length_max_last() {
-	let view_lines = [
+	let view_lines = ViewLines::from([
 		ViewLine::from("012345"),
 		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
-	];
+	]);
 	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 2), 16);
 }
 
 #[test]
 fn calculate_max_line_length_with_slice() {
-	let view_lines = [
+	let view_lines = ViewLines::from([
 		ViewLine::from("012345"),
 		ViewLine::from("012345"),
 		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
 		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
-	];
+	]);
 	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 1, 2), 16);
 }
 
 #[test]
 fn calculate_max_line_length_ignore_pinned() {
-	let view_lines = [
+	let view_lines = ViewLines::from([
 		ViewLine::from("012345"),
 		ViewLine::from("012345"),
 		ViewLine::from(vec![LineSegment::new("0123456789"), LineSegment::new("012345")]),
 		ViewLine::new_pinned(vec![LineSegment::new("0123456789"), LineSegment::new("01234567")]),
-	];
+	]);
 	assert_eq!(RenderSlice::calculate_max_line_length(&view_lines, 0, 4), 16);
 }

--- a/src/view/thread/state.rs
+++ b/src/view/thread/state.rs
@@ -276,8 +276,10 @@ mod tests {
 					.state
 					.render_slice()
 					.lock()
-					.get_lines()
-					.first()
+					.view_lines()
+					.iter()
+					.take(1)
+					.next()
 					.unwrap()
 					.get_segments()
 					.first()

--- a/src/view/view_data.rs
+++ b/src/view/view_data.rs
@@ -1,13 +1,13 @@
 use uuid::Uuid;
 
-use crate::view::{ViewDataUpdater, ViewLine};
+use crate::view::{ViewDataUpdater, ViewLine, ViewLines};
 
 /// Represents the content to be rendered to the `View`.
 #[derive(Debug)]
 pub(crate) struct ViewData {
-	lines: Vec<ViewLine>,
-	lines_leading: Vec<ViewLine>,
-	lines_trailing: Vec<ViewLine>,
+	lines: ViewLines,
+	lines_leading: ViewLines,
+	lines_trailing: ViewLines,
 	name: String,
 	retain_scroll_position: bool,
 	scroll_version: u32,
@@ -23,9 +23,9 @@ impl ViewData {
 	pub(crate) fn new<C>(callback: C) -> Self
 	where C: FnOnce(&mut ViewDataUpdater<'_>) {
 		let mut view_data = Self {
-			lines: vec![],
-			lines_leading: vec![],
-			lines_trailing: vec![],
+			lines: ViewLines::new(),
+			lines_leading: ViewLines::new(),
+			lines_trailing: ViewLines::new(),
 			name: Uuid::new_v4().hyphenated().to_string(),
 			retain_scroll_position: true,
 			scroll_version: 0,
@@ -117,15 +117,15 @@ impl ViewData {
 		self.show_help
 	}
 
-	pub(crate) const fn get_leading_lines(&self) -> &Vec<ViewLine> {
+	pub(crate) const fn leading_lines(&self) -> &ViewLines {
 		&self.lines_leading
 	}
 
-	pub(crate) const fn get_lines(&self) -> &Vec<ViewLine> {
+	pub(crate) const fn lines(&self) -> &ViewLines {
 		&self.lines
 	}
 
-	pub(crate) const fn get_trailing_lines(&self) -> &Vec<ViewLine> {
+	pub(crate) const fn trailing_lines(&self) -> &ViewLines {
 		&self.lines_trailing
 	}
 
@@ -193,9 +193,9 @@ mod tests {
 		view_data.push_leading_line(ViewLine::new_empty_line());
 		view_data.push_trailing_line(ViewLine::new_empty_line());
 		view_data.clear();
-		assert!(view_data.get_leading_lines().is_empty());
-		assert!(view_data.get_lines().is_empty());
-		assert!(view_data.get_trailing_lines().is_empty());
+		assert!(view_data.leading_lines().is_empty());
+		assert!(view_data.lines().is_empty());
+		assert!(view_data.trailing_lines().is_empty());
 	}
 
 	#[test]
@@ -205,9 +205,9 @@ mod tests {
 		view_data.push_leading_line(ViewLine::new_empty_line());
 		view_data.push_trailing_line(ViewLine::new_empty_line());
 		view_data.clear_body();
-		assert!(!view_data.get_leading_lines().is_empty());
-		assert!(view_data.get_lines().is_empty());
-		assert!(!view_data.get_trailing_lines().is_empty());
+		assert!(!view_data.leading_lines().is_empty());
+		assert!(view_data.lines().is_empty());
+		assert!(!view_data.trailing_lines().is_empty());
 	}
 
 	#[test]
@@ -251,21 +251,21 @@ mod tests {
 	fn push_leading_line() {
 		let mut view_data = ViewData::new(|_| {});
 		view_data.push_leading_line(ViewLine::new_empty_line());
-		assert_eq!(view_data.get_leading_lines().len(), 1);
+		assert_eq!(view_data.leading_lines().count(), 1);
 	}
 
 	#[test]
 	fn push_line() {
 		let mut view_data = ViewData::new(|_| {});
 		view_data.push_line(ViewLine::new_empty_line());
-		assert_eq!(view_data.get_lines().len(), 1);
+		assert_eq!(view_data.lines().count(), 1);
 	}
 
 	#[test]
 	fn push_trailing_line() {
 		let mut view_data = ViewData::new(|_| {});
 		view_data.push_trailing_line(ViewLine::new_empty_line());
-		assert_eq!(view_data.get_trailing_lines().len(), 1);
+		assert_eq!(view_data.trailing_lines().count(), 1);
 	}
 
 	#[test]

--- a/src/view/view_data_updater.rs
+++ b/src/view/view_data_updater.rs
@@ -118,8 +118,8 @@ mod tests {
 		let mut updater = ViewDataUpdater::new(&mut view_data);
 		updater.clear_body();
 		assert!(updater.is_modified());
-		assert!(view_data.get_lines().is_empty());
-		assert_eq!(view_data.get_leading_lines().len(), 1);
+		assert!(view_data.lines().is_empty());
+		assert_eq!(view_data.leading_lines().count(), 1);
 	}
 
 	#[test]
@@ -164,7 +164,7 @@ mod tests {
 		let mut updater = ViewDataUpdater::new(&mut view_data);
 		updater.push_leading_line(ViewLine::new_empty_line());
 		assert!(updater.is_modified());
-		assert_eq!(view_data.get_leading_lines().len(), 1);
+		assert_eq!(view_data.leading_lines().count(), 1);
 	}
 
 	#[test]
@@ -173,7 +173,7 @@ mod tests {
 		let mut updater = ViewDataUpdater::new(&mut view_data);
 		updater.push_line(ViewLine::new_empty_line());
 		assert!(updater.is_modified());
-		assert_eq!(view_data.get_lines().len(), 1);
+		assert_eq!(view_data.lines().count(), 1);
 	}
 
 	#[test]
@@ -182,7 +182,7 @@ mod tests {
 		let mut updater = ViewDataUpdater::new(&mut view_data);
 		updater.push_trailing_line(ViewLine::new_empty_line());
 		assert!(updater.is_modified());
-		assert_eq!(view_data.get_trailing_lines().len(), 1);
+		assert_eq!(view_data.trailing_lines().count(), 1);
 	}
 
 	#[test]

--- a/src/view/view_lines.rs
+++ b/src/view/view_lines.rs
@@ -1,0 +1,117 @@
+use std::{slice::Iter, vec};
+
+use crate::view::ViewLine;
+
+/// Represents a line in the view.
+#[derive(Debug)]
+pub(crate) struct ViewLines {
+	lines: Vec<ViewLine>,
+}
+
+impl ViewLines {
+	pub(crate) fn new() -> Self {
+		Self { lines: vec![] }
+	}
+
+	#[expect(
+		clippy::cast_possible_truncation,
+		reason = "Number of lines will be below maximum of 16-bit."
+	)]
+	pub(crate) fn count(&self) -> u16 {
+		self.lines.len() as u16
+	}
+
+	pub(crate) fn is_empty(&self) -> bool {
+		self.lines.is_empty()
+	}
+
+	pub(crate) fn iter(&self) -> Iter<'_, ViewLine> {
+		self.lines.iter()
+	}
+
+	pub(crate) fn clear(&mut self) {
+		self.lines.clear();
+	}
+
+	pub(crate) fn push(&mut self, view_line: ViewLine) {
+		self.lines.push(view_line);
+	}
+}
+
+impl<const N: usize> From<[ViewLine; N]> for ViewLines {
+	fn from(values: [ViewLine; N]) -> Self {
+		Self {
+			lines: Vec::from(values),
+		}
+	}
+}
+
+impl IntoIterator for ViewLines {
+	type IntoIter = vec::IntoIter<Self::Item>;
+	type Item = ViewLine;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.lines.into_iter()
+	}
+}
+
+impl FromIterator<ViewLine> for ViewLines {
+	fn from_iter<T: IntoIterator<Item = ViewLine>>(iter: T) -> Self {
+		Self {
+			lines: Vec::from_iter(iter),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn new() {
+		assert!(ViewLines::new().is_empty());
+	}
+
+	#[test]
+	fn push() {
+		let mut view_lines = ViewLines::new();
+		view_lines.push(ViewLine::new_empty_line());
+		assert_eq!(view_lines.count(), 1);
+	}
+
+	#[test]
+	fn clear() {
+		let mut view_lines = ViewLines::new();
+		view_lines.push(ViewLine::new_empty_line());
+		view_lines.clear();
+		assert!(view_lines.is_empty());
+	}
+
+	#[test]
+	fn iter() {
+		let mut view_lines = ViewLines::new();
+		view_lines.push(ViewLine::new_empty_line());
+		view_lines.push(ViewLine::new_empty_line());
+		assert_eq!(view_lines.iter().len(), 2);
+	}
+
+	#[test]
+	fn into_iter() {
+		let mut view_lines = ViewLines::new();
+		view_lines.push(ViewLine::new_empty_line());
+		view_lines.push(ViewLine::new_empty_line());
+		assert_eq!(view_lines.into_iter().len(), 2);
+	}
+
+	#[test]
+	fn from_slice() {
+		let view_lines = ViewLines::from([ViewLine::new_empty_line()]);
+		assert_eq!(view_lines.iter().len(), 1);
+	}
+
+	#[test]
+	fn from_iter() {
+		let view_lines = ViewLines::from_iter([ViewLine::new_empty_line()]);
+		assert_eq!(view_lines.iter().len(), 1);
+	}
+}


### PR DESCRIPTION
This replaces the representation of lines with a ViewLines struct. This provides a standard interface for working with the lines.