### PR TITLE
Only load first parent on commit diff

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -60,11 +60,10 @@ impl Repository {
 			.id();
 		let diff_loader_repository = Arc::clone(&self.repository);
 		let loader = CommitDiffLoader::new(diff_loader_repository, config);
-		// TODO this is ugly because it assumes one parent
-		Ok(loader
+
+		loader
 			.load_from_hash(oid)
-			.map_err(|e| GitError::CommitLoad { cause: e })?
-			.remove(0))
+			.map_err(|e| GitError::CommitLoad { cause: e })
 	}
 }
 


### PR DESCRIPTION
When generating diffs, the first parent should be used to show the changes that were introduced in the change. Diffing against the other parents slows down diff loading and does not provide any useful information.