### PR TITLE
parse `GIT_CONFIG_PARAMETERS`

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -208,8 +208,6 @@ where ModuleProvider: module::ModuleProvider + Send + 'static
 
 #[cfg(all(unix, test))]
 mod tests {
-	use std::ffi::OsString;
-
 	use claims::assert_ok;
 
 	use super::*;
@@ -227,10 +225,6 @@ mod tests {
 			with_git_directory,
 		},
 	};
-
-	fn args(args: &[&str]) -> Args {
-		Args::try_from(args.iter().map(OsString::from).collect::<Vec<OsString>>()).unwrap()
-	}
 
 	fn create_mocked_crossterm() -> mocks::CrossTerm {
 		let mut crossterm = mocks::CrossTerm::new();
@@ -254,7 +248,7 @@ mod tests {
 	fn load_filepath_from_args_failure() {
 		let event_provider = create_event_reader(|| Ok(None));
 		let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-			Application::new(args(&[]), event_provider, create_mocked_crossterm());
+			Application::new(Args::from_os_strings(Vec::new()).unwrap(), event_provider, create_mocked_crossterm());
 		let exit = application_error!(application);
 		assert_eq!(exit.get_status(), &ExitStatus::StateError);
 		assert!(
@@ -269,7 +263,7 @@ mod tests {
 		with_git_directory("fixtures/not-a-repository", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(args(&["todofile"]), event_provider, create_mocked_crossterm());
+				Application::new(Args::from_strs(["todofile"]).unwrap(), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::StateError);
 			assert!(exit.get_message().unwrap().contains("Unable to load Git repository: "));
@@ -281,7 +275,7 @@ mod tests {
 		with_git_directory("fixtures/invalid-config", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(args(&["rebase-todo"]), event_provider, create_mocked_crossterm());
+				Application::new(Args::from_strs(["rebase-todo"]).unwrap(), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::ConfigError);
 		});
@@ -322,7 +316,7 @@ mod tests {
 		with_git_directory("fixtures/simple", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(args(&["does-not-exist"]), event_provider, create_mocked_crossterm());
+				Application::new(Args::from_strs(["does-not-exist"]).unwrap(), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::FileReadError);
 		});
@@ -334,7 +328,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo-noop");
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			);
@@ -349,7 +343,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo-empty");
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			);
@@ -382,7 +376,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -408,7 +402,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -433,7 +427,7 @@ mod tests {
 				))))
 			});
 			let mut application: Application<Modules> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -449,7 +443,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				args(&[rebase_todo.as_str()]),
+				Args::from_strs([rebase_todo]).unwrap(),
 				event_provider,
 				create_mocked_crossterm(),
 			)

--- a/src/application.rs
+++ b/src/application.rs
@@ -34,7 +34,7 @@ where ModuleProvider: module::ModuleProvider + Send + 'static
 impl<ModuleProvider> Application<ModuleProvider>
 where ModuleProvider: module::ModuleProvider + Send + 'static
 {
-	pub(crate) fn new<EventProvider, Tui>(args: &Args, event_provider: EventProvider, tui: Tui) -> Result<Self, Exit>
+	pub(crate) fn new<EventProvider, Tui>(args: Args, event_provider: EventProvider, tui: Tui) -> Result<Self, Exit>
 	where
 		EventProvider: EventReaderFn,
 		Tui: crate::display::Tui + Send + 'static,
@@ -144,7 +144,7 @@ where ModuleProvider: module::ModuleProvider + Send + 'static
 		Ok(())
 	}
 
-	fn filepath_from_args(args: &Args) -> Result<String, Exit> {
+	fn filepath_from_args(args: Args) -> Result<String, Exit> {
 		args.todo_file_path().map(String::from).ok_or_else(|| {
 			Exit::new(
 				ExitStatus::StateError,
@@ -254,7 +254,7 @@ mod tests {
 	fn load_filepath_from_args_failure() {
 		let event_provider = create_event_reader(|| Ok(None));
 		let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-			Application::new(&args(&[]), event_provider, create_mocked_crossterm());
+			Application::new(args(&[]), event_provider, create_mocked_crossterm());
 		let exit = application_error!(application);
 		assert_eq!(exit.get_status(), &ExitStatus::StateError);
 		assert!(
@@ -269,7 +269,7 @@ mod tests {
 		with_git_directory("fixtures/not-a-repository", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(&args(&["todofile"]), event_provider, create_mocked_crossterm());
+				Application::new(args(&["todofile"]), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::StateError);
 			assert!(exit.get_message().unwrap().contains("Unable to load Git repository: "));
@@ -281,7 +281,7 @@ mod tests {
 		with_git_directory("fixtures/invalid-config", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(&args(&["rebase-todo"]), event_provider, create_mocked_crossterm());
+				Application::new(args(&["rebase-todo"]), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::ConfigError);
 		});
@@ -322,7 +322,7 @@ mod tests {
 		with_git_directory("fixtures/simple", |_| {
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> =
-				Application::new(&args(&["does-not-exist"]), event_provider, create_mocked_crossterm());
+				Application::new(args(&["does-not-exist"]), event_provider, create_mocked_crossterm());
 			let exit = application_error!(application);
 			assert_eq!(exit.get_status(), &ExitStatus::FileReadError);
 		});
@@ -334,7 +334,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo-noop");
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			);
@@ -349,7 +349,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo-empty");
 			let event_provider = create_event_reader(|| Ok(None));
 			let application: Result<Application<TestModuleProvider<DefaultTestModule>>, Exit> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			);
@@ -382,7 +382,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -408,7 +408,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -433,7 +433,7 @@ mod tests {
 				))))
 			});
 			let mut application: Application<Modules> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			)
@@ -449,7 +449,7 @@ mod tests {
 			let rebase_todo = format!("{git_dir}/rebase-todo");
 			let event_provider = create_event_reader(|| Ok(Some(Event::Key(KeyEvent::from(KeyCode::Char('W'))))));
 			let mut application: Application<Modules> = Application::new(
-				&args(&[rebase_todo.as_str()]),
+				args(&[rebase_todo.as_str()]),
 				event_provider,
 				create_mocked_crossterm(),
 			)

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,7 +113,7 @@ mod tests {
 	#[test]
 	fn try_from_config_loader() {
 		with_temp_bare_repository(|repository| {
-			let loader = ConfigLoader::from(repository);
+			let loader = ConfigLoader::new(repository);
 			let config = assert_ok!(loader.load_config());
 			assert_ok!(Config::try_from(&config));
 		});

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -25,21 +25,18 @@ pub(crate) fn run(args: Args) -> Exit {
 
 #[cfg(test)]
 mod tests {
-	use std::{ffi::OsString, path::Path};
+	use std::path::Path;
 
 	use super::*;
 	use crate::test_helpers::with_git_directory;
 
-	fn args(args: &[&str]) -> Args {
-		Args::try_from(args.iter().map(OsString::from).collect::<Vec<OsString>>()).unwrap()
-	}
-
 	#[test]
 	fn successful_run() {
 		with_git_directory("fixtures/simple", |path| {
-			let todo_file = Path::new(path).join("rebase-todo-empty");
+			let todo_file = Path::new(path).join("rebase-todo-empty").into_os_string();
+			let args = Args::from_os_strings(vec![todo_file]).unwrap();
 			assert_eq!(
-				run(args(&[todo_file.to_str().unwrap()])).get_status(),
+				run(args).get_status(),
 				&ExitStatus::Good
 			);
 		});
@@ -48,9 +45,10 @@ mod tests {
 	#[test]
 	fn error_on_application_create() {
 		with_git_directory("fixtures/simple", |path| {
-			let todo_file = Path::new(path).join("does-not-exist");
+			let todo_file = Path::new(path).join("does-not-exist").into_os_string();
+			let args = Args::from_os_strings(vec![todo_file]).unwrap();
 			assert_eq!(
-				run(args(&[todo_file.to_str().unwrap()])).get_status(),
+				run(args).get_status(),
 				&ExitStatus::FileReadError
 			);
 		});

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 #[cfg(not(tarpaulin_include))]
-pub(crate) fn run(args: Args) -> Exit {
-	let mut application: Application<Modules> = match Application::new(args, read_event, CrossTerm::new()) {
+pub(crate) fn run(args: Args, git_config_parameters: Vec<(String, String)>) -> Exit {
+	let mut application: Application<Modules> = match Application::new(args, git_config_parameters, read_event, CrossTerm::new()) {
 		Ok(app) => app,
 		Err(exit) => return exit,
 	};
@@ -35,8 +35,9 @@ mod tests {
 		with_git_directory("fixtures/simple", |path| {
 			let todo_file = Path::new(path).join("rebase-todo-empty").into_os_string();
 			let args = Args::from_os_strings(vec![todo_file]).unwrap();
+			let git_config_parameters = Vec::new();
 			assert_eq!(
-				run(args).get_status(),
+				run(args, git_config_parameters).get_status(),
 				&ExitStatus::Good
 			);
 		});
@@ -47,8 +48,9 @@ mod tests {
 		with_git_directory("fixtures/simple", |path| {
 			let todo_file = Path::new(path).join("does-not-exist").into_os_string();
 			let args = Args::from_os_strings(vec![todo_file]).unwrap();
+			let git_config_parameters = Vec::new();
 			assert_eq!(
-				run(args).get_status(),
+				run(args, git_config_parameters).get_status(),
 				&ExitStatus::FileReadError
 			);
 		});

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[cfg(not(tarpaulin_include))]
-pub(crate) fn run(args: &Args) -> Exit {
+pub(crate) fn run(args: Args) -> Exit {
 	let mut application: Application<Modules> = match Application::new(args, read_event, CrossTerm::new()) {
 		Ok(app) => app,
 		Err(exit) => return exit,
@@ -39,7 +39,7 @@ mod tests {
 		with_git_directory("fixtures/simple", |path| {
 			let todo_file = Path::new(path).join("rebase-todo-empty");
 			assert_eq!(
-				run(&args(&[todo_file.to_str().unwrap()])).get_status(),
+				run(args(&[todo_file.to_str().unwrap()])).get_status(),
 				&ExitStatus::Good
 			);
 		});
@@ -50,7 +50,7 @@ mod tests {
 		with_git_directory("fixtures/simple", |path| {
 			let todo_file = Path::new(path).join("does-not-exist");
 			assert_eq!(
-				run(&args(&[todo_file.to_str().unwrap()])).get_status(),
+				run(args(&[todo_file.to_str().unwrap()])).get_status(),
 				&ExitStatus::FileReadError
 			);
 		});

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ use crate::{
 };
 
 #[must_use]
-fn run(os_args: Vec<OsString>) -> Exit {
+fn run(os_args: Vec<OsString>, git_config_parameters: Vec<(String, String)>) -> Exit {
 	match Args::from_os_strings(os_args) {
 		Err(err) => err,
 		Ok(args) => {
@@ -80,16 +80,57 @@ fn run(os_args: Vec<OsString>) -> Exit {
 				Mode::Help => help::run(),
 				Mode::Version => version::run(),
 				Mode::License => license::run(),
-				Mode::Editor => editor::run(args),
+				Mode::Editor => editor::run(args, git_config_parameters),
 			}
 		},
 	}
+}
+/// returns a pair of name/value pairs passed as overrides to `git`.
+///
+/// input here is expected to come from `git -c`, and is in the form
+/// of `-c <name>=<value>` pairs, for example `-c interactive-rebase-tool.diffTabWidth=4`.
+/// separated by a single whitespace
+///
+/// notes:
+/// 1. the key/value have both gone through git's shell quoting.
+///    from `gix-quote`: "every single-quote `'` is escaped as `'\''`, 
+///    every exclamation mark `!` is escaped as `'\!'`, and the entire string
+///    is enclosed in single quotes."
+/// 2. if input doesn't contain a '=', a `=` is appended between
+///    `key` and `value`. `value`, will be an empty string.
+/// 3. if input does contain a '=' but `value` is empty, `value`
+///    will also be an empty string.
+/// 4. an empty string will later be interpreted as `true`,
+///    but we don't do this here.
+pub(crate) fn parse_git_config_parameters(env_var: OsString) -> Vec<(String, String)> {
+	// we expect valid UTF-8 from the shell/git, so we don't handle errors here. 
+	let Some(env_var) = env_var.to_str() else {
+		return Vec::new();
+	};
+
+	// naive implementation: assumes correctly-escaped strings, efficiency isn't a priority
+	fn unescape(s: &str) -> String {
+		let s = s.trim_matches('\'');
+		let mut s = s.replace("\\'", "\'");
+		s = s.replace("\\!", "!");
+		s
+	}
+
+	env_var
+		.split_ascii_whitespace()
+		.filter_map(|pair| pair.split_once('='))
+		.map(|(name, value)| (unescape(name), unescape(value)))
+		.collect()
 }
 
 #[expect(clippy::print_stderr, reason = "Required to print error message.")]
 #[cfg(not(tarpaulin_include))]
 fn main() -> impl Termination {
-	let exit = run(env::args_os().skip(1).collect());
+	let args = env::args_os().skip(1).collect();
+	let git_config_parameters = env::var_os("GIT_CONFIG_PARAMETERS")
+		.map(parse_git_config_parameters)
+		.unwrap_or_default();
+	let exit = run(args, git_config_parameters);
 	if let Some(message) = exit.get_message() {
 		eprintln!("{message}");
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn run(os_args: Vec<OsString>) -> Exit {
 				Mode::Help => help::run(),
 				Mode::Version => version::run(),
 				Mode::License => license::run(),
-				Mode::Editor => editor::run(&args),
+				Mode::Editor => editor::run(args),
 			}
 		},
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ use crate::{
 
 #[must_use]
 fn run(os_args: Vec<OsString>) -> Exit {
-	match Args::try_from(os_args) {
+	match Args::from_os_strings(os_args) {
 		Err(err) => err,
 		Ok(args) => {
 			match *args.mode() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,14 +3,11 @@ use std::path::Path;
 use super::*;
 use crate::{module::ExitStatus, test_helpers::with_git_directory};
 
-fn args(args: &[&str]) -> Vec<OsString> {
-	args.iter().map(OsString::from).collect::<Vec<OsString>>()
-}
-
 #[test]
 #[serial_test::serial]
 fn successful_run_help() {
-	let exit = run(args(&["--help"]));
+	let args = ["--help"].into_iter().map(OsString::from).collect();
+	let exit = run(args);
 	assert!(exit.get_message().unwrap().contains("USAGE:"));
 	assert_eq!(exit.get_status(), &ExitStatus::Good);
 }
@@ -18,7 +15,8 @@ fn successful_run_help() {
 #[test]
 #[serial_test::serial]
 fn successful_run_version() {
-	let exit = run(args(&["--version"]));
+	let args = ["--version"].into_iter().map(OsString::from).collect();
+	let exit = run(args);
 	assert!(exit.get_message().unwrap().starts_with("interactive-rebase-tool"));
 	assert_eq!(exit.get_status(), &ExitStatus::Good);
 }
@@ -26,7 +24,8 @@ fn successful_run_version() {
 #[test]
 #[serial_test::serial]
 fn successful_run_license() {
-	let exit = run(args(&["--license"]));
+	let args = ["--license"].into_iter().map(OsString::from).collect();
+	let exit = run(args);
 	assert!(
 		exit.get_message()
 			.unwrap()
@@ -38,9 +37,10 @@ fn successful_run_license() {
 #[test]
 fn successful_run_editor() {
 	with_git_directory("fixtures/simple", |path| {
-		let todo_file = Path::new(path).join("rebase-todo-empty");
+		let todo_file = Path::new(path).join("rebase-todo-empty").into_os_string();
+		let args = vec![todo_file];
 		assert_eq!(
-			run(args(&[todo_file.to_str().unwrap()])).get_status(),
+			run(args).get_status(),
 			&ExitStatus::Good
 		);
 	});

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,8 @@ use crate::{module::ExitStatus, test_helpers::with_git_directory};
 #[serial_test::serial]
 fn successful_run_help() {
 	let args = ["--help"].into_iter().map(OsString::from).collect();
-	let exit = run(args);
+	let git_config_parameters = Vec::new();
+	let exit = run(args, git_config_parameters);
 	assert!(exit.get_message().unwrap().contains("USAGE:"));
 	assert_eq!(exit.get_status(), &ExitStatus::Good);
 }
@@ -16,7 +17,8 @@ fn successful_run_help() {
 #[serial_test::serial]
 fn successful_run_version() {
 	let args = ["--version"].into_iter().map(OsString::from).collect();
-	let exit = run(args);
+	let git_config_parameters = Vec::new();
+	let exit = run(args, git_config_parameters);
 	assert!(exit.get_message().unwrap().starts_with("interactive-rebase-tool"));
 	assert_eq!(exit.get_status(), &ExitStatus::Good);
 }
@@ -25,7 +27,8 @@ fn successful_run_version() {
 #[serial_test::serial]
 fn successful_run_license() {
 	let args = ["--license"].into_iter().map(OsString::from).collect();
-	let exit = run(args);
+	let git_config_parameters = Vec::new();
+	let exit = run(args, git_config_parameters);
 	assert!(
 		exit.get_message()
 			.unwrap()
@@ -39,8 +42,9 @@ fn successful_run_editor() {
 	with_git_directory("fixtures/simple", |path| {
 		let todo_file = Path::new(path).join("rebase-todo-empty").into_os_string();
 		let args = vec![todo_file];
+		let git_config_parameters = Vec::new();
 		assert_eq!(
-			run(args).get_status(),
+			run(args, git_config_parameters).get_status(),
 			&ExitStatus::Good
 		);
 	});
@@ -52,5 +56,6 @@ fn successful_run_editor() {
 #[expect(unsafe_code)]
 fn error() {
 	let args = unsafe { vec![OsString::from(String::from_utf8_unchecked(vec![0xC3, 0x28]))] };
-	assert_eq!(run(args).get_status(), &ExitStatus::StateError);
+	let git_config_parameters = Vec::new();
+	assert_eq!(run(args, git_config_parameters).get_status(), &ExitStatus::StateError);
 }


### PR DESCRIPTION
closes #977 .

**also contains a drive by refactor**: a somewhat nicer way to parse `Args` from strings (especially in tests).
once again, if this is unnecessary, unwarranted or should just be split out to a smaller PR, that's no problem.

still a draft because of two potential issues:
1. no unit test. do we have existing tests which actually spawn `git`?
2. we don't parse the `GIT_CONFIG_PARAMETERS` env var (despite the title of this PR), just the value that we expect `git` to leave there after using `git -c`. I suspect that we can't assume that it's properly escaped. that said, do we even care about use cases other than setting it via `git -c`?